### PR TITLE
fix(server): 支持 Windows 8.3 短文件名的工作区根目录，修复路径逃逸误判

### DIFF
--- a/packages/server/src/services/workspace-file-service.ts
+++ b/packages/server/src/services/workspace-file-service.ts
@@ -27,9 +27,17 @@ export interface WorkspaceFilePreview {
 
 export class WorkspaceFileService {
   readonly #workspaceRoot: string
+  #resolvedWorkspaceRoot: Promise<string> | undefined
 
   constructor(workspaceRoot: string) {
     this.#workspaceRoot = workspaceRoot
+  }
+
+  #resolveWorkspaceRoot(): Promise<string> {
+    // realpath 会把 Windows 8.3 短名（如 C:\Users\ADMINI~1\...）展开为完整路径；
+    // target 侧同样经过 realpath，两侧必须基于同一展开结果比较，否则前缀比对会误判"逃逸"。
+    this.#resolvedWorkspaceRoot ??= realpath(this.#workspaceRoot).catch(() => resolve(this.#workspaceRoot))
+    return this.#resolvedWorkspaceRoot
   }
 
   async list(requestedPath: string): Promise<WorkspaceFileList> {
@@ -97,10 +105,11 @@ export class WorkspaceFileService {
       if (isMissingFile(error)) throw new ServiceError('not-found', 'workspace_entry_not_found', 'Workspace entry not found')
       throw error
     }
-    if (!pathIsInside(this.#workspaceRoot, absolutePath)) {
+    const workspaceRoot = await this.#resolveWorkspaceRoot()
+    if (!pathIsInside(workspaceRoot, absolutePath)) {
       throw new ServiceError('forbidden', 'workspace_path_rejected', 'Workspace path escapes the configured root')
     }
-    const relativePath = relative(this.#workspaceRoot, absolutePath).split(sep).join('/')
+    const relativePath = relative(workspaceRoot, absolutePath).split(sep).join('/')
     if (workspaceEntryIsHidden(relativePath)) {
       throw new ServiceError('forbidden', 'workspace_path_rejected', 'Workspace path is not accessible')
     }

--- a/packages/server/tests/application-services.test.ts
+++ b/packages/server/tests/application-services.test.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -50,6 +50,21 @@ describe('WorkspaceFileService', () => {
       kind: 'forbidden',
       code: 'workspace_path_rejected',
     })
+  })
+
+  it('accepts a workspace root expressed as a Windows 8.3 short name', async () => {
+    // 在启用了 8.3 短名的 Windows 上，mkdtemp 返回的临时目录本身就是短名形式
+    // （如 C:\Users\ADMINI~1\...）；realpath 会把它展开为完整路径。根目录与
+    // 目标必须基于同一展开结果比较，否则路径逃逸校验会误报（Windows 专属回归）。
+    const root = await temporaryRoot()
+    const expandedRoot = await realpath(root)
+    if (expandedRoot === root) return // 平台未启用短名时无需断言
+    await mkdir(join(root, 'src'))
+    await writeFile(join(root, 'src', 'main.ts'), 'export {}\n')
+    const files = new WorkspaceFileService(root)
+
+    const listing = await files.list('')
+    expect(listing.items.map((item) => item.name)).toEqual(['src'])
   })
 })
 


### PR DESCRIPTION
### 摘要

在 Windows 上，`fs.realpath()` 会把 8.3 短文件名（例如 `C:\Users\ADMINI~1\...`）
展开为完整路径（`C:\Users\Administrator\...`）。`WorkspaceFileService.#resolveEntry`
在比较时，用「realpath 展开后的目标路径」对比「原始的工作区根目录」；当根目录
本身是短文件名形式时（在启用了 8.3 短文件名的 Windows 上，`mkdtemp` 返回的临时
目录正是这种形式），前缀检查会把所有合法路径误判为「逃逸出工作区根目录」。

本次修复在 `pathIsInside` 比较之前，先用 `realpath()` 展开工作区根目录
（失败时回退到 `resolve()`），让两侧在同一展开基准上比较。

### 改动内容

- `packages/server/src/services/workspace-file-service.ts`
  - 新增带缓存的 `#resolveWorkspaceRoot()` 辅助方法（realpath 展开，失败回退 resolve）。
  - `#resolveEntry` 现在基于展开后的根目录做逃逸检查与相对路径计算。
- `packages/server/tests/application-services.test.ts`
  - 新增回归测试：用 8.3 短文件名根目录构造服务，断言目录列表正常返回
    （在未启用短文件名的平台自动跳过）。

### 验证结果

- [x] `pnpm typecheck` 通过
- [x] `pnpm test` 通过 —— Windows 上 **101/101** 测试全绿（修复前有 1 个失败）
- [x] `pnpm verify` 在 Windows 上通过
- [x] `git status` 无凭据 / 私有会话 / 数据库 / 本地运行目录

### 补充说明

- 在 Windows 11（Node v24.18.0）上复现。该问题只出现在启用了 8.3 短文件名
  生成的 Windows 主机上；Linux / macOS 上的 CI 不受影响。
- 非 Windows 平台无行为变化：当根目录与 realpath 结果一致时，比较逻辑与原先完全相同。