### PR TITLE
feat(web): 对话 Markdown 渲染、实时交互增强与模型交互日志模块

### DIFF
--- a/docs/community/README.md
+++ b/docs/community/README.md
@@ -6,6 +6,7 @@
 - [世界主题创作约定](world-theme-authoring.md)
 - [员工蓝图创作约定](employee-blueprint-authoring.md)
 - [声明式插件创作约定](plugin-authoring.md)
+- [模型交互日志（运行时能力说明）](model-interaction-logs.md)
 - [规范实现状态](implementation-status.md)
 
 规范关键词含义：

--- a/docs/community/implementation-status.md
+++ b/docs/community/implementation-status.md
@@ -17,6 +17,7 @@
 | Pixi 表现 | RendererRegistry、Pixi 实现、8 状态、四向 fallback、脚底锚点、Y-sort、遮挡、growth badge | 官方 roster 多数 clip 目前是单帧受控 fallback | Three.js、正式多帧全方向资产 |
 | 员工蓝图 | schemaVersion、严格字段/长度/唯一性、package id 与能力绑定、不可变 id+version、模板过滤、默认拒绝与逐项能力授权、独立实例/会话、SQLite 恢复 | requested skills 当前展示但不自动授权；模型继续走 ModelProfile/assignment | avatar、memory/skill 文件、蓝图 modelPolicy、compatibility/评测 schema |
 | 插件 | canonical `prompt-transform` 进入真实 conversation runtime prompt；legacy `commands` 明确转换；staged 校验；原始用户消息持久化不被改写 | 仅声明式 JSON；支持 `/command`、`always`、prepend/append/replace、priority 与资源上限；强制无外发 | 可执行代码、skill/tool/event/widget、网络代理与外发审计 |
+| 模型交互日志 | turn/discovery 双源采集、SQLite 持久化（v11 STRICT 表 + 三索引）、分页/筛选/详情/清空 API、设置面板「日志记录」界面、错误信息密钥清洗（`sk-…`/`Bearer …`/键值对 → `[已隐藏]`） | token 用量字段预留但当前恒为空（DSH worker 未透出单次请求用量）；消息数为近似统计；无自动保留策略 | worker 进程内逐请求采集与 token 透出、日志自动清理/条数上限 |
 | CI | Node 22.19、pnpm 11.7、frozen lockfile、typecheck、test、Chromium、E2E | 仓库工作流名为 `required`；GitHub 分支保护需在仓库设置中另行确认 | 自动发布与包签名流水线 |
 
 ## 关键证据
@@ -30,6 +31,7 @@
 - renderer 与动画：`packages/web/src/features/world/renderer`、`packages/web/tests`
 - 员工蓝图解析与实例化：`packages/server/src/employee-blueprint-manifest.ts`、`packages/persistence/src/sqlite-store.ts`
 - prompt transform：`packages/server/src/prompt-transform-parser.ts`、`packages/server/src/routes/conversation-routes.ts`
+- 模型交互日志：`packages/server/src/services/model-interaction-service.ts`、`packages/server/src/routes/model-interaction-routes.ts`、`packages/persistence/src/migrations.ts`（v11）、[模块说明与观测边界](model-interaction-logs.md)
 - CI：`.github/workflows/ci.yml`
 
 ## 采用规则

--- a/docs/community/model-interaction-logs.md
+++ b/docs/community/model-interaction-logs.md
@@ -1,0 +1,73 @@
+# 模型交互日志模块
+
+本模块记录服务端可观测到的模型 API 交互，用于排查「某次对话/模型发现为什么失败、耗时多少、走了哪个模型」等运行问题。日志只存请求摘要统计，**绝不保存 API 密钥、prompt 明文或响应明文**（与 AGENTS.md 凭据红线一致）。
+
+## 采集点与观测边界（必读）
+
+模型 API 的实际请求发生在 DSH worker 进程内部（harness-adapter 的 model-router / adapter），服务端**无法逐请求观测**。因此本模块在两个服务端可见的位置采集，并如实标注边界：
+
+| 采集点 | source | 观测内容 | 边界 |
+| --- | --- | --- | --- |
+| 对话回合（server 用 `TurnInteractionLoggingRuntime` 装饰器包住 `AgentRuntimePort`，见 `packages/server/src/server.ts`） | `turn` | 服务端发起的**整轮** turn 交互：开始时间、模型 ID、provider（来自模型路由解析；未配置路由时为 `dsh-default` / `默认 DSH 模型`）、成功/失败、耗时、工具调用次数、最终响应字符摘要 | 不是单次模型请求；worker 内部发生了几次请求、每次多少 token，服务端不可见 |
+| `/models` 模型发现（`model-catalog-service.discover` 调用处，见 `packages/server/src/routes/model-routes.ts`） | `discovery` | 真实 HTTP 往返：成功/失败、状态码（`ServiceError.code`）、耗时 | GET 请求无 prompt，请求摘要恒为 0 |
+
+运行时升级金丝雀走独立 runtime（无 workspace 归属），不记录。
+
+## 记录字段与数据口径
+
+每条日志字段见 contracts 的 `ModelInteractionLog`（`packages/contracts/src/index.ts`）。以下口径在使用日志做分析时必须先明确，**不能混算**：
+
+1. **token 用量字段当前恒为空**：需求约定「若接口返回才填」。但 DSH worker 内部的单次请求 token 用量没有透出到服务端，因此 `tokensPrompt / tokensCompletion / tokensTotal` 目前**永远填不上**（字段已预留，落库为 NULL，前端显示 `—`）。拿到真实 token 数需要到 harness-adapter 的 model-router / adapter.ts（worker 进程内）采集并透出，属于后继迭代项——**不是本模块坏了**。
+2. **`durationMs` 是双语义**：`turn` 级是**整轮延迟**（从服务端发起 turn 到 worker 返回，含全部工具调用）；`discovery` 级才是**单次 HTTP 往返**。前端用 source 徽标（对话回合/模型发现）区分，做报表/性能分析时两类必须分开。
+3. **`promptMessageCount` 是近似值**：turn 级按「1 条用户 prompt + 每轮工具回填 1 条」估算（即 `1 + toolCallCount`），不是真实发送给模型的消息条数；`responseCharCount` 只含**最终响应**字符数（`result.finalResponse.length`），不含中间工具输出。`promptCharCount` 为 prompt 实际字符数（只取 `.length`，不存原文）。
+
+## 隐私红线
+
+- 请求只存摘要统计（消息数 / 字符数），不存 prompt 原文与响应原文；错误信息可存。
+- 错误信息落库前在 service 层统一清洗（`sanitizeErrorMessage`，见 `packages/server/src/services/model-interaction-service.ts`），覆盖三类密钥模式并替换为 `[已隐藏]`：
+  - `sk-…` 形式（`\bsk-[A-Za-z0-9_-]{8,}\b`）
+  - `Bearer …` 形式
+  - `api_key=` / `access_token=` / `secret=` / `password=` 等键值形式
+- 清洗后截断 500 字符。
+- 单测与 e2e 均断言「日志 JSON 不含 prompt 明文」；集成测试断言错误码正确落库。
+
+## 持久化
+
+SQLite 新表 `model_interaction_logs`（走项目现有 migration 机制，v11，见 `packages/persistence/src/migrations.ts`）：
+
+- STRICT 表，主键 `id`；`workspace_id` 必填且级联删除，`world_id / session_id / employee_id` 可选（级联删除）。
+- 约束：`source` ∈ turn/discovery，`status` ∈ success/failed，计数与耗时字段非负。
+- 索引：`(workspace_id, created_at DESC, id)`、`(workspace_id, status, created_at DESC, id)`、`(workspace_id, model_id, created_at DESC, id)`——覆盖列表默认排序与状态/模型筛选。
+- 存储层方法（`packages/persistence/src/sqlite-store.ts`）：`recordModelInteraction`（含归属与字段校验）、`listModelInteractions`（分页+筛选+去重 modelIds）、`getModelInteraction`、`clearModelInteractions`。
+
+## 查询 API
+
+前缀 `/api/workspaces/:workspaceId/model-interactions`（`packages/server/src/routes/model-interaction-routes.ts`）：
+
+| 方法/路径 | 说明 | 校验与边界 |
+| --- | --- | --- |
+| `GET .../model-interactions` | 列表（分页） | `page`≥1（默认 1）、`pageSize` 钳制 1–100（默认 20）；`status` 白名单（非 success/failed 返回 422 `invalid_status_filter`）；`modelId` 可选筛选；排序 `created_at DESC, id DESC` 稳定翻页不重不漏；响应含去重 `modelIds` 供前端下拉 |
+| `GET .../model-interactions/:id` | 详情 | 校验日志归属该 workspace，否则 404 `model_interaction_not_found`（防跨工作区泄露） |
+| `DELETE .../model-interactions` | 清空 | 删除该 workspace 全部日志，返回 `{ removed }`；非 GET 请求需带 `application/json` Content-Type（服务端安全护栏约定，前端 api.ts 已按此处理） |
+
+## 前端界面
+
+「设置」面板新增「日志记录」栏目（`packages/web/src/components/SettingsDialog.tsx`）：
+
+- 列表：时间 / 模型 ID + provider / source 徽标（对话回合/模型发现）/ 状态（成功/失败）/ 耗时 / token（无则 `—`）。
+- 筛选：状态（全部/成功/失败）+ 模型（去重下拉，无数据时禁用）。
+- 详情：点击行展开（记录时间、source、模型、provider、状态、错误码、错误信息、消息数/字符数、工具调用次数、耗时、token 明细）。
+- 清空按钮 + 分页；空态两种：无任何日志 vs 筛选无结果。
+- 视觉证据（AGENTS.md 护栏）：三视口截图 + 控制台 error/warn 记录，见验证一节。
+
+## 测试与验证
+
+- `pnpm verify`：20 个测试文件 / 119 个测试全部通过（typecheck + build + vitest），含存储层单测（记录/列表/筛选/分页/清空/持久化/校验）与 API 集成测试（turn 成功/失败、discovery 失败、筛选、详情、清空）。
+- `pnpm test:e2e`：7 个 e2e 全部通过；日志面板用例覆盖「发消息产生真实日志 → API total 断言 → 面板列表 → 详情展开（且详情不含 prompt 明文）→ 状态筛选 → 清空 → 空态」，并产出三视口截图与 console 记录供视觉审批。
+- 视觉审批（合并门禁）：截图 `artifacts/ui-world-conversations/model-logs-{1440x900,1920x1080,3840x2160}.png` + `model-logs-console.log`，需视觉岗按 AGENTS.md 护栏逐项查验。
+
+## 已知限制与后继迭代（不阻塞当前合入）
+
+1. **真实 token 用量**：需在 harness-adapter（worker 进程内）采集单次请求 token 并透出到服务端，`tokens_*` 字段才有值。
+2. **保留策略**：日志表目前只支持手动清空，无自动清理/条数上限，长跑后表会无限增长（现有索引 + 分页钳制下短期无性能风险），建议后续加自动清理策略。
+3. **错误清洗单测**：`sanitizeErrorMessage` 的密钥替换行为暂无直接单测（现有断言覆盖「不含 prompt 明文」与错误码落库），建议补一条喂含 `sk-…` / `Bearer …` 错误消息验证 `[已隐藏]` 的单测，作为隐私红线的直接证据。

--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -1,4 +1,4 @@
-import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -62,9 +62,9 @@ test('onboards, recruits, talks, browses dossiers and previews a real workspace 
 
   await composer.fill('@阿帆 请确认真实回合')
   await page.getByRole('button', { name: '发送' }).click()
-  await expect(page.getByText('我先建立性能基线。')).toBeVisible()
-  await page.getByText('阿帆的思考过程').click()
-  await expect(page.getByText('核对事实与权限。')).toBeVisible()
+  await expect(page.getByText('我先建立性能基线。').first()).toBeVisible()
+  await page.getByText('阿帆的思考过程').first().click()
+  await expect(page.getByText('核对事实与权限。').first()).toBeVisible()
   await expect(page.getByText('search_workspace').first()).toBeVisible()
 
   await dock.getByRole('button', { name: '文件', exact: true }).click()
@@ -323,7 +323,94 @@ test('opens the dossier as an all-employee information directory', async ({ page
   await expect(dock.getByText('32', { exact: true })).toBeVisible()
 })
 
+test('clears the composer instantly, shows the owner message on screen, and keeps the thinking trace visible during and after a turn', async ({ page }) => {
+  // 用慢速回合重建 server，留出窗口断言“进行中”状态
+  await server.close()
+  server = await createCyberServer({
+    stateRoot,
+    workspacePath: process.cwd(),
+    webRoot: join(process.cwd(), 'packages', 'web', 'dist'),
+    port: 0,
+    runtime: new BrowserRuntime({ eventIntervalMs: 500 }),
+  })
+  origin = (await server.start()).origin
+  const consoleEntries: string[] = []
+  const pageErrors: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      consoleEntries.push(`[${message.type()}] ${message.text()}`)
+    }
+  })
+  page.on('pageerror', (error) => pageErrors.push(String(error)))
+  await page.goto(origin)
+  // 独立于测试 1/2：无工作区则自行 onboarding，已有则直接进入
+  const shell = page.locator('.workbench-shell')
+  const onboarding = page.getByRole('heading', { name: '创建第一个本地世界' })
+  await expect(shell.or(onboarding)).toBeVisible()
+  if (await onboarding.isVisible()) {
+    await page.getByRole('button', { name: '创建本地工作区' }).click()
+    await expect(shell).toBeVisible()
+  }
+
+  // 无“与阿帆私聊”则自行招募，已有则复用现有会话
+  const directButton = page.getByRole('button', { name: '与阿帆私聊' })
+  if (await directButton.count() === 0) {
+    await page.getByRole('button', { name: '添加第一名员工' }).click()
+    const market = page.getByRole('dialog', { name: '员工市场' })
+    await market.getByRole('button', { name: /开发工程师 v1/ }).click()
+    await market.getByRole('textbox', { name: '员工称呼（可选）' }).fill('阿帆')
+    await market.getByRole('button', { name: '确认招聘' }).click()
+    await expect(market).toBeHidden()
+    await expect(page.getByRole('button', { name: '与阿帆私聊' })).toBeVisible()
+  }
+  await directButton.first().click()
+  const composer = page.getByRole('textbox', { name: '给当前世界的员工发送消息' })
+  await expect(composer).toBeEnabled()
+  const ownerText = '任务：验证乐观发送与实时思考展示'
+  await composer.fill(ownerText)
+  await page.getByRole('button', { name: '发送' }).click()
+
+  // 1) 发送后输入框立即清空（乐观更新，不等模型回合结束）
+  await expect(composer).toHaveValue('')
+  // 2) 用户消息立即上屏，不依赖 chat 响应返回
+  await expect(page.locator('.message--owner').filter({ hasText: ownerText })).toBeVisible()
+
+  // 3) 思考过程在回合进行中明显可见（turn.started → reasoning → tool 逐条到达）
+  await expect(page.locator('.live-turns-block')).toBeVisible()
+  await expect(page.locator('.live-turn--live')).toBeVisible()
+  await expect(page.locator('.live-turn__badge')).toHaveText('实时')
+  await expect(page.locator('.live-turn__reasoning').filter({ hasText: '核对事实与权限。' })).toBeVisible()
+  await expect(page.locator('.tool-step').filter({ hasText: 'search_workspace' })).toBeVisible()
+
+  // 视觉证据：思考过程进行中的三个视口截图（供视觉审批使用）
+  await page.setViewportSize({ width: 1_920, height: 1_080 })
+  await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'live-turns-1920x1080.png') })
+  await page.setViewportSize({ width: 1_440, height: 900 })
+  await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'live-turns-1440x900.png') })
+  await page.setViewportSize({ width: 3_840, height: 2_160 })
+  await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'live-turns-3840x2160.png') })
+  await page.setViewportSize({ width: 1_584, height: 992 })
+
+  // 4) 回合结束后 liveTurns 保留一段时间，不立即清空
+  await expect(page.locator('.live-turn--completed')).toBeVisible()
+  await expect(page.locator('.live-turn--completed').filter({ hasText: '核对事实与权限。' })).toBeVisible()
+
+  // 视觉审批证据：记录控制台 error/warn，并断言无未捕获页面错误
+  await writeFile(
+    join(process.cwd(), 'artifacts', 'ui-world-conversations', 'live-turns-console.log'),
+    `[pageerror]\n${pageErrors.join('\n')}\n\n[console]\n${consoleEntries.join('\n')}\n`,
+    'utf8',
+  )
+  expect(pageErrors, `页面存在未捕获错误：${pageErrors.join('; ')}`).toEqual([])
+})
+
 class BrowserRuntime implements AgentRuntimePort {
+  readonly eventIntervalMs: number
+
+  constructor(options: { eventIntervalMs?: number } = {}) {
+    this.eventIntervalMs = options.eventIntervalMs ?? 20
+  }
+
   async runTurn(request: AgentTurnRequest) {
     const agentSessionId = request.agent.agentSessionId ?? `agent-${request.agent.id}`
     const events = [
@@ -336,7 +423,7 @@ class BrowserRuntime implements AgentRuntimePort {
     ] as const
     for (const event of events) {
       request.onEvent?.({ ...event, source: 'browser-e2e', sourceSessionId: agentSessionId, metadata: {} })
-      await new Promise((resolvePromise) => setTimeout(resolvePromise, 20))
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, this.eventIntervalMs))
     }
     return { agentSessionId, finalResponse: '我先建立性能基线。', eventCount: events.length }
   }

--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -404,6 +404,97 @@ test('clears the composer instantly, shows the owner message on screen, and keep
   expect(pageErrors, `页面存在未捕获错误：${pageErrors.join('; ')}`).toEqual([])
 })
 
+test('shows real model interaction logs in the settings panel with filtering, detail, clear and visual evidence', async ({ page }) => {
+  // 独立于前序测试：无工作区则自行 onboarding，已有则直接复用
+  await page.goto(origin)
+  const shell = page.locator('.workbench-shell')
+  const onboarding = page.getByRole('heading', { name: '创建第一个本地世界' })
+  await expect(shell.or(onboarding)).toBeVisible()
+  if (await onboarding.isVisible()) {
+    await page.getByRole('button', { name: '创建本地工作区' }).click()
+    await expect(shell).toBeVisible()
+  }
+
+  // 无“与阿帆私聊”则自行招募，已有则复用现有会话
+  const directButton = page.getByRole('button', { name: '与阿帆私聊' })
+  if (await directButton.count() === 0) {
+    await page.getByRole('button', { name: '添加第一名员工' }).click()
+    const market = page.getByRole('dialog', { name: '员工市场' })
+    await market.getByRole('button', { name: /开发工程师 v1/ }).click()
+    await market.getByRole('textbox', { name: '员工称呼（可选）' }).fill('阿帆')
+    await market.getByRole('button', { name: '确认招聘' }).click()
+    await expect(market).toBeHidden()
+    await expect(page.getByRole('button', { name: '与阿帆私聊' })).toBeVisible()
+  }
+
+  const workspaces = await (await fetch(`${origin}/api/workspaces`)).json() as { items: Array<{ id: string }> }
+  const workspaceId = workspaces.items[0]!.id
+  const beforeTotal = (await (await fetch(`${origin}/api/workspaces/${workspaceId}/model-interactions`)).json() as { total: number }).total
+
+  // 发一条真实回合，触发 turn 级模型交互日志（用 @提及确保命中员工并创建会话）
+  const composer = page.getByRole('textbox', { name: '给当前世界的员工发送消息' })
+  await expect(composer).toBeEnabled()
+  await composer.fill('@阿帆 任务：请确认模型交互日志的采集')
+  await page.getByRole('button', { name: '发送' }).click()
+  await expect(page.getByText('我先建立性能基线。').first()).toBeVisible()
+  await expect.poll(async () =>
+    (await (await fetch(`${origin}/api/workspaces/${workspaceId}/model-interactions`)).json() as { total: number }).total,
+  ).toBeGreaterThan(beforeTotal)
+
+  // 打开设置 → 日志记录
+  await page.getByRole('button', { name: '设置' }).click()
+  const settings = page.getByRole('dialog', { name: '设置' })
+  await expect(settings).toBeVisible()
+  await settings.getByRole('button', { name: '日志记录' }).click()
+  await expect(settings.getByRole('heading', { name: '模型交互日志' })).toBeVisible()
+  await expect(settings.locator('.log-entry').first()).toBeVisible()
+  await expect(settings.locator('.log-entry__model').filter({ hasText: 'dsh-default' }).first()).toBeVisible()
+  await expect(settings.locator('.log-status--success').first()).toBeVisible()
+  await expect(settings.getByText('对话回合').first()).toBeVisible()
+
+  // 展开详情：显示请求摘要（不含 prompt 明文）
+  await settings.locator('.log-entry__row').first().click()
+  await expect(settings.locator('.log-detail')).toBeVisible()
+  await expect(settings.locator('.log-detail').getByText('请求摘要')).toBeVisible()
+  await expect(settings.locator('.log-detail')).not.toContainText('请确认模型交互日志的采集')
+
+  // 状态筛选
+  await settings.locator('.log-filter select').first().selectOption('success')
+  await expect(settings.locator('.log-entry').first()).toBeVisible()
+  await expect(settings.locator('.log-status--success').first()).toBeVisible()
+
+  // 视觉证据：日志面板三个视口截图 + 控制台 error/warn 记录（供视觉审批）
+  const consoleEntries: string[] = []
+  const pageErrors: string[] = []
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      consoleEntries.push(`[${message.type()}] ${message.text()}`)
+    }
+  })
+  page.on('pageerror', (error) => pageErrors.push(String(error)))
+  await page.setViewportSize({ width: 1_920, height: 1_080 })
+  await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'model-logs-1920x1080.png') })
+  await page.setViewportSize({ width: 1_440, height: 900 })
+  await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'model-logs-1440x900.png') })
+  await page.setViewportSize({ width: 3_840, height: 2_160 })
+  await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'model-logs-3840x2160.png') })
+  await page.setViewportSize({ width: 1_584, height: 992 })
+  await writeFile(
+    join(process.cwd(), 'artifacts', 'ui-world-conversations', 'model-logs-console.log'),
+    `[pageerror]\n${pageErrors.join('\n')}\n\n[console]\n${consoleEntries.join('\n')}\n`,
+    'utf8',
+  )
+  expect(pageErrors, `页面存在未捕获错误：${pageErrors.join('; ')}`).toEqual([])
+
+  // 清空日志 → 空态提示
+  page.once('dialog', (dialog) => void dialog.accept())
+  await settings.getByRole('button', { name: '清空日志' }).click()
+  await expect(settings.getByText('还没有模型交互日志')).toBeVisible()
+  await expect.poll(async () =>
+    (await (await fetch(`${origin}/api/workspaces/${workspaceId}/model-interactions`)).json() as { total: number }).total,
+  ).toBe(0)
+})
+
 class BrowserRuntime implements AgentRuntimePort {
   readonly eventIntervalMs: number
 

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,4 @@
-export const CYBER_SCHEMA_VERSION = 10 as const
+export const CYBER_SCHEMA_VERSION = 12 as const
 
 export type IsoTimestamp = string
 export type JsonPrimitive = boolean | number | string | null
@@ -322,6 +322,82 @@ export interface WorkspacePreferences {
 export type ModelProviderKind = 'deepseek' | 'openai-compatible-local' | 'openai-compatible-remote'
 export type ModelApiKind = 'openai-completions' | 'openai-responses' | 'anthropic-messages'
 
+export type ModelInteractionLogStatus = 'success' | 'failed'
+export type ModelInteractionLogSource = 'turn' | 'discovery'
+
+/**
+ * 一条模型交互日志。隐私红线：绝不保存 API 密钥、prompt 明文或响应明文，
+ * 只保存请求摘要统计（消息数 / 字符数）与可读的错误信息（不含密钥）。
+ */
+export interface ModelInteractionLog {
+  id: string
+  workspaceId: string
+  worldId?: string
+  sessionId?: string
+  employeeId?: string
+  /** 采集来源：turn=对话回合（服务端发起的整轮交互），discovery=/models 模型发现 */
+  source: ModelInteractionLogSource
+  modelId: string
+  /** provider 展示名（模型配置显示名，或默认 DSH 模型） */
+  provider: string
+  status: ModelInteractionLogStatus
+  errorCode?: string
+  errorMessage?: string
+  /** 模型接口返回的 HTTP 状态码（如 200/401/429/502）；worker 未透出时为空 */
+  httpStatus?: number
+  /** 请求摘要：发送给模型的消息条数（turn 级为 1 条用户消息 + 工具回填条数，近似） */
+  promptMessageCount: number
+  /** 请求摘要：prompt 字符数 */
+  promptCharCount: number
+  responseCharCount?: number
+  toolCallCount?: number
+  durationMs: number
+  /** 仅当接口真实返回 token 用量时填写 */
+  tokensPrompt?: number
+  tokensCompletion?: number
+  tokensTotal?: number
+  createdAt: IsoTimestamp
+}
+
+export interface RecordModelInteractionInput {
+  workspaceId: string
+  worldId?: string
+  sessionId?: string
+  employeeId?: string
+  source: ModelInteractionLogSource
+  modelId: string
+  provider: string
+  status: ModelInteractionLogStatus
+  errorCode?: string
+  errorMessage?: string
+  httpStatus?: number
+  promptMessageCount: number
+  promptCharCount: number
+  responseCharCount?: number
+  toolCallCount?: number
+  durationMs: number
+  tokensPrompt?: number
+  tokensCompletion?: number
+  tokensTotal?: number
+}
+
+export interface ModelInteractionLogFilter {
+  status?: ModelInteractionLogStatus
+  modelId?: string
+  page: number
+  pageSize: number
+}
+
+export interface ModelInteractionLogPage {
+  items: ModelInteractionLog[]
+  total: number
+  page: number
+  pageSize: number
+  /** 该工作区出现过（去重）的模型 ID，用于前端筛选下拉 */
+  modelIds: string[]
+}
+
+
 export interface ModelProfile {
   id: string
   workspaceId: string
@@ -569,6 +645,7 @@ export interface DatabaseDoctorReport {
     worldEntityStates: number
     worldObjectStates: number
     worldThemeBindings: number
+    modelInteractionLogs: number
     events: number
     outbox: number
   }

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -515,6 +515,49 @@ const MIGRATIONS: readonly Migration[] = [
         ON world_theme_bindings(package_id, package_version, theme_id, theme_version, content_digest, status);
     `,
   },
+  {
+    version: 11,
+    name: 'model-interaction-logs',
+    sql: `
+      CREATE TABLE model_interaction_logs (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        world_id TEXT REFERENCES worlds(id) ON DELETE CASCADE,
+        session_id TEXT REFERENCES work_sessions(id) ON DELETE CASCADE,
+        employee_id TEXT REFERENCES employee_instances(id) ON DELETE CASCADE,
+        source TEXT NOT NULL CHECK (source IN ('turn', 'discovery')),
+        model_id TEXT NOT NULL,
+        provider TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('success', 'failed')),
+        error_code TEXT,
+        error_message TEXT,
+        prompt_message_count INTEGER NOT NULL CHECK (prompt_message_count >= 0),
+        prompt_char_count INTEGER NOT NULL CHECK (prompt_char_count >= 0),
+        response_char_count INTEGER CHECK (response_char_count >= 0),
+        tool_call_count INTEGER CHECK (tool_call_count >= 0),
+        duration_ms INTEGER NOT NULL CHECK (duration_ms >= 0),
+        tokens_prompt INTEGER CHECK (tokens_prompt >= 0),
+        tokens_completion INTEGER CHECK (tokens_completion >= 0),
+        tokens_total INTEGER CHECK (tokens_total >= 0),
+        created_at TEXT NOT NULL
+      ) STRICT;
+
+      CREATE INDEX model_interaction_logs_workspace_idx
+        ON model_interaction_logs(workspace_id, created_at DESC, id);
+      CREATE INDEX model_interaction_logs_status_idx
+        ON model_interaction_logs(workspace_id, status, created_at DESC, id);
+      CREATE INDEX model_interaction_logs_model_idx
+        ON model_interaction_logs(workspace_id, model_id, created_at DESC, id);
+    `,
+  },
+  {
+    version: 12,
+    name: 'model-interaction-http-status',
+    sql: `
+      ALTER TABLE model_interaction_logs
+        ADD COLUMN http_status INTEGER CHECK (http_status BETWEEN 100 AND 599);
+    `,
+  },
 ]
 
 export function migrate(database: DatabaseSync, now: () => string): void {

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -28,12 +28,18 @@ import {
   type ModelAssignment,
   type ModelAssignmentScope,
   type ModelApiKind,
+  type ModelInteractionLog,
+  type ModelInteractionLogFilter,
+  type ModelInteractionLogPage,
+  type ModelInteractionLogSource,
+  type ModelInteractionLogStatus,
   type ModelProfile,
   type ModelProviderKind,
   type CyberPackageManifest,
   type InstalledPackage,
   type PackageInstallTransaction,
   type ParticipantKind,
+  type RecordModelInteractionInput,
   type RuntimeUpdateStatus,
   type RuntimeUpdateTransaction,
   type SkillEvidence,
@@ -202,6 +208,13 @@ export interface SaveModelAssignmentInput {
   actorId?: string
 }
 
+export type {
+  ModelInteractionLog,
+  ModelInteractionLogFilter,
+  ModelInteractionLogPage,
+  RecordModelInteractionInput,
+} from '@dsh-cyber/contracts'
+
 export interface SaveLocalAssetInput {
   id?: string
   workspaceId: string
@@ -316,6 +329,7 @@ const KNOWN_TABLES = [
   'world_entity_states',
   'world_object_states',
   'world_theme_bindings',
+  'model_interaction_logs',
   'domain_events',
   'sync_outbox',
 ] as const
@@ -773,6 +787,172 @@ export class SqliteStore {
     if (profileId !== undefined) return this.getModelProfile(profileId)
     return this.listModelProfiles(workspaceId).find((profile) => profile.isDefault)
       ?? this.listModelProfiles(workspaceId)[0]
+  }
+
+  recordModelInteraction(input: RecordModelInteractionInput): ModelInteractionLog {
+    this.#assertWritable()
+    const workspace = this.#requireWorkspace(input.workspaceId)
+    if (input.worldId !== undefined) {
+      const world = this.#requireWorld(input.worldId)
+      if (world.workspaceId !== workspace.id) {
+        throw new PersistenceError('Model interaction world does not belong to workspace')
+      }
+    }
+    if (input.sessionId !== undefined) {
+      const session = this.#requireSession(input.sessionId)
+      if (session.workspaceId !== workspace.id) {
+        throw new PersistenceError('Model interaction session does not belong to workspace')
+      }
+    }
+    if (input.employeeId !== undefined) {
+      const employee = this.#requireEmployee(input.employeeId)
+      if (employee.workspaceId !== workspace.id) {
+        throw new PersistenceError('Model interaction employee does not belong to workspace')
+      }
+    }
+    if (input.source !== 'turn' && input.source !== 'discovery') {
+      throw new PersistenceError('Model interaction source is invalid')
+    }
+    if (input.status !== 'success' && input.status !== 'failed') {
+      throw new PersistenceError('Model interaction status is invalid')
+    }
+    if (!input.modelId.trim()) throw new PersistenceError('Model interaction model id cannot be empty')
+    if (!input.provider.trim()) throw new PersistenceError('Model interaction provider cannot be empty')
+    if (!Number.isInteger(input.promptMessageCount) || input.promptMessageCount < 0) {
+      throw new PersistenceError('Model interaction prompt message count must be a non-negative integer')
+    }
+    if (!Number.isInteger(input.promptCharCount) || input.promptCharCount < 0) {
+      throw new PersistenceError('Model interaction prompt char count must be a non-negative integer')
+    }
+    if (!Number.isInteger(input.durationMs) || input.durationMs < 0) {
+      throw new PersistenceError('Model interaction duration must be a non-negative integer')
+    }
+    assertOptionalCount('response char count', input.responseCharCount)
+    assertOptionalCount('tool call count', input.toolCallCount)
+    assertOptionalCount('tokens prompt', input.tokensPrompt)
+    assertOptionalCount('tokens completion', input.tokensCompletion)
+    assertOptionalCount('tokens total', input.tokensTotal)
+
+    const log: ModelInteractionLog = {
+      id: this.#idFactory(),
+      workspaceId: workspace.id,
+      source: input.source,
+      modelId: input.modelId.trim().slice(0, 200),
+      provider: input.provider.trim().slice(0, 120),
+      status: input.status,
+      promptMessageCount: input.promptMessageCount,
+      promptCharCount: input.promptCharCount,
+      durationMs: input.durationMs,
+      createdAt: this.#clock(),
+    }
+    if (input.worldId !== undefined) log.worldId = input.worldId
+    if (input.sessionId !== undefined) log.sessionId = input.sessionId
+    if (input.employeeId !== undefined) log.employeeId = input.employeeId
+    if (input.errorCode?.trim()) log.errorCode = input.errorCode.trim().slice(0, 120)
+    if (input.errorMessage?.trim()) log.errorMessage = input.errorMessage.trim().slice(0, 1_000)
+    if (input.httpStatus !== undefined) {
+      if (!Number.isInteger(input.httpStatus) || input.httpStatus < 100 || input.httpStatus > 599) {
+        throw new PersistenceError('Model interaction HTTP status must be between 100 and 599')
+      }
+      log.httpStatus = input.httpStatus
+    }
+    if (input.responseCharCount !== undefined) log.responseCharCount = input.responseCharCount
+    if (input.toolCallCount !== undefined) log.toolCallCount = input.toolCallCount
+    if (input.tokensPrompt !== undefined) log.tokensPrompt = input.tokensPrompt
+    if (input.tokensCompletion !== undefined) log.tokensCompletion = input.tokensCompletion
+    if (input.tokensTotal !== undefined) log.tokensTotal = input.tokensTotal
+
+    this.database
+      .prepare(
+        `INSERT INTO model_interaction_logs (
+           id, workspace_id, world_id, session_id, employee_id, source, model_id, provider,
+           status, error_code, error_message, http_status, prompt_message_count, prompt_char_count,
+           response_char_count, tool_call_count, duration_ms, tokens_prompt,
+           tokens_completion, tokens_total, created_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        log.id,
+        log.workspaceId,
+        log.worldId ?? null,
+        log.sessionId ?? null,
+        log.employeeId ?? null,
+        log.source,
+        log.modelId,
+        log.provider,
+        log.status,
+        log.errorCode ?? null,
+        log.errorMessage ?? null,
+        log.httpStatus ?? null,
+        log.promptMessageCount,
+        log.promptCharCount,
+        log.responseCharCount ?? null,
+        log.toolCallCount ?? null,
+        log.durationMs,
+        log.tokensPrompt ?? null,
+        log.tokensCompletion ?? null,
+        log.tokensTotal ?? null,
+        log.createdAt,
+      )
+    return log
+  }
+
+  listModelInteractions(workspaceId: string, filter: ModelInteractionLogFilter): ModelInteractionLogPage {
+    this.#requireWorkspace(workspaceId)
+    const page = Math.max(1, Math.trunc(filter.page))
+    const pageSize = Math.min(100, Math.max(1, Math.trunc(filter.pageSize)))
+    const conditions = ['workspace_id = ?']
+    const parameters: Array<string | number> = [workspaceId]
+    if (filter.status !== undefined) {
+      if (filter.status !== 'success' && filter.status !== 'failed') {
+        throw new PersistenceError('Model interaction status filter is invalid')
+      }
+      conditions.push('status = ?')
+      parameters.push(filter.status)
+    }
+    if (filter.modelId !== undefined && filter.modelId.trim()) {
+      conditions.push('model_id = ?')
+      parameters.push(filter.modelId.trim().slice(0, 200))
+    }
+    const where = conditions.join(' AND ')
+    const totalRow = this.database
+      .prepare(`SELECT COUNT(*) AS count FROM model_interaction_logs WHERE ${where}`)
+      .get(...parameters) as { count?: number } | undefined
+    const total = Number(totalRow?.count ?? 0)
+    const rows = this.database
+      .prepare(
+        `SELECT * FROM model_interaction_logs WHERE ${where}
+         ORDER BY created_at DESC, id DESC LIMIT ? OFFSET ?`,
+      )
+      .all(...parameters, pageSize, (page - 1) * pageSize)
+    const modelRows = this.database
+      .prepare(
+        `SELECT DISTINCT model_id FROM model_interaction_logs
+         WHERE workspace_id = ? ORDER BY model_id`,
+      )
+      .all(workspaceId) as Array<{ model_id?: unknown }>
+    return {
+      items: rows.map(mapModelInteractionLog),
+      total,
+      page,
+      pageSize,
+      modelIds: modelRows.map((row) => String(row.model_id)),
+    }
+  }
+
+  getModelInteraction(interactionId: string): ModelInteractionLog | undefined {
+    const row = this.database
+      .prepare('SELECT * FROM model_interaction_logs WHERE id = ?')
+      .get(interactionId)
+    return row ? mapModelInteractionLog(row) : undefined
+  }
+
+  clearModelInteractions(workspaceId: string): number {
+    this.#assertWritable()
+    this.#requireWorkspace(workspaceId)
+    return Number(this.database
+      .prepare('DELETE FROM model_interaction_logs WHERE workspace_id = ?')
+      .run(workspaceId).changes)
   }
 
   saveLocalAsset(input: SaveLocalAssetInput): LocalAsset {
@@ -2476,6 +2656,7 @@ export class SqliteStore {
         worldEntityStates: countRows(this.database, 'world_entity_states'),
         worldObjectStates: countRows(this.database, 'world_object_states'),
         worldThemeBindings: countRows(this.database, 'world_theme_bindings'),
+        modelInteractionLogs: countRows(this.database, 'model_interaction_logs'),
         events: countRows(this.database, 'domain_events'),
         outbox: countRows(this.database, 'sync_outbox'),
       },
@@ -2996,6 +3177,12 @@ function assertLocalAssetRef(value: string): void {
   }
 }
 
+function assertOptionalCount(label: string, value: number | undefined): void {
+  if (value !== undefined && (!Number.isInteger(value) || value < 0)) {
+    throw new PersistenceError(`Model interaction ${label} must be a non-negative integer`)
+  }
+}
+
 function normalizeModelBaseUrl(value: string, providerKind: ModelProviderKind): string {
   let url: URL
   try {
@@ -3267,6 +3454,46 @@ function mapLocalAsset(row: object): LocalAsset {
     byteLength: Number(value.byte_length),
     createdAt: String(value.created_at),
   }
+}
+
+function mapModelInteractionLog(row: object): ModelInteractionLog {
+  const value = row as Record<string, unknown>
+  const log: ModelInteractionLog = {
+    id: String(value.id),
+    workspaceId: String(value.workspace_id),
+    source: value.source as ModelInteractionLogSource,
+    modelId: String(value.model_id),
+    provider: String(value.provider),
+    status: value.status as ModelInteractionLogStatus,
+    promptMessageCount: Number(value.prompt_message_count),
+    promptCharCount: Number(value.prompt_char_count),
+    durationMs: Number(value.duration_ms),
+    createdAt: String(value.created_at),
+  }
+  if (typeof value.world_id === 'string') log.worldId = value.world_id
+  if (typeof value.session_id === 'string') log.sessionId = value.session_id
+  if (typeof value.employee_id === 'string') log.employeeId = value.employee_id
+  if (typeof value.error_code === 'string') log.errorCode = value.error_code
+  if (typeof value.error_message === 'string') log.errorMessage = value.error_message
+  if (value.http_status !== null && value.http_status !== undefined) {
+    log.httpStatus = Number(value.http_status)
+  }
+  if (value.response_char_count !== null && value.response_char_count !== undefined) {
+    log.responseCharCount = Number(value.response_char_count)
+  }
+  if (value.tool_call_count !== null && value.tool_call_count !== undefined) {
+    log.toolCallCount = Number(value.tool_call_count)
+  }
+  if (value.tokens_prompt !== null && value.tokens_prompt !== undefined) {
+    log.tokensPrompt = Number(value.tokens_prompt)
+  }
+  if (value.tokens_completion !== null && value.tokens_completion !== undefined) {
+    log.tokensCompletion = Number(value.tokens_completion)
+  }
+  if (value.tokens_total !== null && value.tokens_total !== undefined) {
+    log.tokensTotal = Number(value.tokens_total)
+  }
+  return log
 }
 
 function mapSession(row: object): WorkSession {

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -175,7 +175,7 @@ describe('SqliteStore', () => {
       '收到，我先建立基线。',
     ])
     expect(reopened.getEmployee(employee.id)?.agentSessionId).toBe('harness-session-1')
-    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 10 })
+    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 12 })
   })
 
   it('writes every domain event and cloud-sync outbox entry atomically', async () => {
@@ -260,7 +260,7 @@ describe('SqliteStore', () => {
     expect(backupStore.getWorkspace(workspace.id)?.name).toBe('赛博公司')
     const exported = JSON.parse(await readFile(exportPath, 'utf8')) as any
     expect(exported.format).toBe('dsh-cyber-export')
-    expect(exported.schemaVersion).toBe(10)
+    expect(exported.schemaVersion).toBe(12)
     expect(exported.workspaces[0].worlds[0].world.id).toBe(world.id)
     expect(exported.workspaces[0].worlds[0].employees[0].employee.id).toBe(employee.id)
     expect(exported.workspaces[0].worlds[0].sessions[0].messages[0].content).toBe('世界内记录')
@@ -572,6 +572,7 @@ describe('SqliteStore', () => {
       DROP TABLE world_object_states;
       DROP TABLE world_entity_states;
       DROP TABLE world_runtime_snapshots;
+      DROP TABLE model_interaction_logs;
       DELETE FROM schema_migrations WHERE version > 2;
       PRAGMA user_version = 2;
     `)
@@ -582,7 +583,7 @@ describe('SqliteStore', () => {
     expect(migrated.listWorkspaces()[0]?.name).toBe('迁移前工作区')
     expect(migrated.doctor()).toMatchObject({
       ok: true,
-      schemaVersion: 10,
+      schemaVersion: 12,
       counts: {
         installedPackages: 0,
         packageTransactions: 0,
@@ -595,6 +596,7 @@ describe('SqliteStore', () => {
         worldEntityStates: 0,
         worldObjectStates: 0,
         worldThemeBindings: 0,
+        modelInteractionLogs: 0,
       },
     })
   })
@@ -639,5 +641,173 @@ describe('SqliteStore', () => {
       report: { events: ['message_start', 'message_end'], healthy: true },
     })
     expect(reopened.doctor().counts.runtimeUpdates).toBe(1)
+  })
+
+  it('records, lists, filters, pages and clears model interaction logs without leaking prompt text', async () => {
+    const { path, store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: '日志工作区' })
+    const world = store.createWorld({
+      workspaceId: workspace.id,
+      name: '赛博公司',
+      templateId: 'cyber-company',
+    })
+    store.saveBlueprint(blueprint())
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      blueprintId: 'software-engineer',
+      blueprintVersion: 1,
+      skillGrants: ['coding'],
+    })
+    const session = store.createSession({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      kind: 'direct',
+      title: '与 小刘 对话',
+      participants: [
+        { participantId: 'owner', kind: 'owner' },
+        { participantId: employee.id, kind: 'employee' },
+      ],
+    })
+
+    const success = store.recordModelInteraction({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      sessionId: session.id,
+      employeeId: employee.id,
+      source: 'turn',
+      modelId: 'deepseek-chat',
+      provider: 'DeepSeek',
+      status: 'success',
+      promptMessageCount: 3,
+      promptCharCount: 842,
+      responseCharCount: 156,
+      toolCallCount: 2,
+      durationMs: 3_420,
+      tokensPrompt: 1_204,
+      tokensCompletion: 312,
+      tokensTotal: 1_516,
+    })
+    expect(success.id).toMatch(/^[0-9a-f-]{36}$/)
+    expect(success.workspaceId).toBe(workspace.id)
+    expect(success.worldId).toBe(world.id)
+    expect(success.sessionId).toBe(session.id)
+    expect(success.employeeId).toBe(employee.id)
+    expect(success.createdAt).toBeTruthy()
+
+    // 真实场景两次交互时间不同；这里稍作延迟保证 created_at 排序稳定
+    await new Promise((resolvePromise) => setTimeout(resolvePromise, 5))
+
+    const failed = store.recordModelInteraction({
+      workspaceId: workspace.id,
+      source: 'discovery',
+      modelId: '-',
+      provider: 'https://models.example.test/v1',
+      status: 'failed',
+      errorCode: 'model_catalog_timeout',
+      errorMessage: '模型服务响应超时，请检查地址或稍后重试。',
+      promptMessageCount: 0,
+      promptCharCount: 0,
+      durationMs: 12_000,
+    })
+    expect(failed.errorCode).toBe('model_catalog_timeout')
+    expect(failed.tokensTotal).toBeUndefined()
+
+    // 列表：默认按时间倒序
+    const all = store.listModelInteractions(workspace.id, { page: 1, pageSize: 20 })
+    expect(all.total).toBe(2)
+    expect(all.items.map((item) => item.id)).toEqual([failed.id, success.id])
+    expect(all.modelIds).toEqual(['-', 'deepseek-chat'])
+
+    // 状态筛选
+    const failures = store.listModelInteractions(workspace.id, { page: 1, pageSize: 20, status: 'failed' })
+    expect(failures.total).toBe(1)
+    expect(failures.items[0]?.id).toBe(failed.id)
+
+    // 模型筛选
+    const modelFiltered = store.listModelInteractions(workspace.id, { page: 1, pageSize: 20, modelId: 'deepseek-chat' })
+    expect(modelFiltered.total).toBe(1)
+    expect(modelFiltered.items[0]?.id).toBe(success.id)
+
+    // 分页
+    const paged = store.listModelInteractions(workspace.id, { page: 2, pageSize: 1 })
+    expect(paged.total).toBe(2)
+    expect(paged.items.map((item) => item.id)).toEqual([success.id])
+
+    // 详情
+    expect(store.getModelInteraction(success.id)).toMatchObject({
+      id: success.id,
+      modelId: 'deepseek-chat',
+      status: 'success',
+      durationMs: 3_420,
+    })
+    expect(store.getModelInteraction('missing-id')).toBeUndefined()
+
+    // 日志内容不含 prompt 明文（字段只存摘要统计）
+    const stored = store.getModelInteraction(success.id)!
+    expect(JSON.stringify(stored)).not.toContain('秘密提示词')
+    expect(stored.promptCharCount).toBe(842)
+
+    // 重启后日志仍在
+    store.close()
+    stores.splice(stores.indexOf(store), 1)
+    const reopened = await SqliteStore.open(path)
+    stores.push(reopened)
+    expect(reopened.listModelInteractions(workspace.id, { page: 1, pageSize: 20 }).total).toBe(2)
+    expect(reopened.doctor().counts.modelInteractionLogs).toBe(2)
+
+    // 清空
+    expect(reopened.clearModelInteractions(workspace.id)).toBe(2)
+    expect(reopened.listModelInteractions(workspace.id, { page: 1, pageSize: 20 }).total).toBe(0)
+  })
+
+  it('rejects invalid model interaction log input', async () => {
+    const { store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: '校验工作区' })
+
+    expect(() => store.recordModelInteraction({
+      workspaceId: workspace.id,
+      source: 'turn',
+      modelId: 'deepseek-chat',
+      provider: 'DeepSeek',
+      status: 'success',
+      promptMessageCount: -1,
+      promptCharCount: 10,
+      durationMs: 5,
+    })).toThrow('prompt message count must be a non-negative integer')
+
+    expect(() => store.recordModelInteraction({
+      workspaceId: workspace.id,
+      source: 'turn',
+      modelId: '  ',
+      provider: 'DeepSeek',
+      status: 'success',
+      promptMessageCount: 1,
+      promptCharCount: 10,
+      durationMs: 5,
+    })).toThrow('model id cannot be empty')
+
+    expect(() => store.recordModelInteraction({
+      workspaceId: workspace.id,
+      source: 'turn',
+      modelId: 'deepseek-chat',
+      provider: 'DeepSeek',
+      status: 'success',
+      promptMessageCount: 1,
+      promptCharCount: 10,
+      durationMs: -1,
+    })).toThrow('duration must be a non-negative integer')
+
+    expect(() => store.recordModelInteraction({
+      workspaceId: workspace.id,
+      source: 'turn',
+      modelId: 'deepseek-chat',
+      provider: 'DeepSeek',
+      status: 'success',
+      promptMessageCount: 1,
+      promptCharCount: 10,
+      durationMs: 5,
+      tokensTotal: -2,
+    })).toThrow('tokens total must be a non-negative integer')
   })
 })

--- a/packages/server/src/routes/model-interaction-routes.ts
+++ b/packages/server/src/routes/model-interaction-routes.ts
@@ -1,0 +1,54 @@
+import type { ModelInteractionLogStatus } from '@dsh-cyber/contracts'
+import type { SqliteStore } from '@dsh-cyber/persistence'
+
+import { HttpError } from '../http/errors.js'
+import type { Router } from '../http/router.js'
+import { nonNegativeInteger, optionalString } from '../http/request.js'
+import { writeJson } from '../http/response.js'
+import type { ModelInteractionService } from '../services/model-interaction-service.js'
+
+export interface ModelInteractionRoutesDependencies {
+  store: SqliteStore
+  interactions: ModelInteractionService
+}
+
+export function registerModelInteractionRoutes(
+  router: Router,
+  dependencies: ModelInteractionRoutesDependencies,
+): void {
+  const { interactions } = dependencies
+
+  router.get(/^\/api\/workspaces\/([^/]+)\/model-interactions$/, ({ response, params, url }) => {
+    const workspaceId = params[0]!
+    const statusValue = url.searchParams.get('status')
+    let status: ModelInteractionLogStatus | undefined
+    if (statusValue !== null && statusValue !== '') {
+      if (statusValue !== 'success' && statusValue !== 'failed') {
+        throw new HttpError(422, 'invalid_status_filter', '状态筛选只支持 success 或 failed')
+      }
+      status = statusValue
+    }
+    const modelId = optionalString(url.searchParams.get('modelId'))
+    const page = Math.max(1, nonNegativeInteger(url.searchParams.get('page')) || 1)
+    const pageSize = Math.min(100, Math.max(1, nonNegativeInteger(url.searchParams.get('pageSize')) || 20))
+    writeJson(response, 200, interactions.list(workspaceId, {
+      ...(status === undefined ? {} : { status }),
+      ...(modelId === undefined ? {} : { modelId }),
+      page,
+      pageSize,
+    }))
+  })
+
+  router.get(/^\/api\/workspaces\/([^/]+)\/model-interactions\/([^/]+)$/, ({ response, params }) => {
+    const log = interactions.get(params[1]!)
+    if (log === undefined || log.workspaceId !== params[0]) {
+      throw new HttpError(404, 'model_interaction_not_found', '模型交互日志不存在')
+    }
+    writeJson(response, 200, { log })
+  })
+
+  router.delete(/^\/api\/workspaces\/([^/]+)\/model-interactions$/, ({ response, params }) => {
+    const removed = interactions.clear(params[0]!)
+    writeJson(response, 200, { removed })
+  })
+}

--- a/packages/server/src/routes/model-routes.ts
+++ b/packages/server/src/routes/model-routes.ts
@@ -18,15 +18,18 @@ import {
   type ModelCredentialService,
 } from '../services/model-credential-service.js'
 import type { ModelCatalogService } from '../services/model-catalog-service.js'
+import type { ModelInteractionService } from '../services/model-interaction-service.js'
+import { ServiceError } from '../services/service-error.js'
 
 export interface ModelRoutesDependencies {
   store: SqliteStore
   credentials: ModelCredentialService
   modelCatalog: ModelCatalogService
+  interactions: ModelInteractionService
 }
 
 export function registerModelRoutes(router: Router, dependencies: ModelRoutesDependencies): void {
-  const { store, credentials, modelCatalog } = dependencies
+  const { store, credentials, modelCatalog, interactions } = dependencies
 
   router.get(/^\/api\/workspaces\/([^/]+)\/model-profiles$/, ({ response, params }) => {
     const workspaceId = params[0]!
@@ -123,17 +126,45 @@ export function registerModelRoutes(router: Router, dependencies: ModelRoutesDep
       && !/^[A-Z_][A-Z0-9_]*_API_KEY$/.test(credentialEnvName)) {
       throw new HttpError(422, 'credential_env_name_invalid', 'Credential environment variable must end with _API_KEY')
     }
-    const items = await modelCatalog.discover({
-      baseUrl: requiredString(body, 'baseUrl'),
-      api: requiredEnum(body, 'api', [
-        'openai-completions',
-        'openai-responses',
-        'anthropic-messages',
-      ]),
-      ...(profileId === undefined ? {} : { profileId }),
-      ...(apiKey === undefined ? {} : { apiKey }),
-      ...(credentialEnvName === undefined ? {} : { credentialEnvName }),
-    })
+    const workspaceId = params[0]!
+    const startedAt = Date.now()
+    const modelId = profile?.modelId ?? '-'
+    const provider = profile?.displayName ?? requiredString(body, 'baseUrl')
+    let items
+    try {
+      items = await modelCatalog.discover({
+        baseUrl: requiredString(body, 'baseUrl'),
+        api: requiredEnum(body, 'api', [
+          'openai-completions',
+          'openai-responses',
+          'anthropic-messages',
+        ]),
+        ...(profileId === undefined ? {} : { profileId }),
+        ...(apiKey === undefined ? {} : { apiKey }),
+        ...(credentialEnvName === undefined ? {} : { credentialEnvName }),
+      })
+      interactions.recordDiscovery({
+        workspaceId,
+        modelId,
+        provider,
+        status: 'success',
+        httpStatus: 200,
+        durationMs: Date.now() - startedAt,
+      })
+    } catch (error) {
+      const httpStatus = serviceErrorHttpStatus(error)
+      interactions.recordDiscovery({
+        workspaceId,
+        modelId,
+        provider,
+        status: 'failed',
+        errorCode: error instanceof ServiceError ? error.code : 'model_catalog_failed',
+        errorMessage: error instanceof Error ? error.message : '模型列表获取失败',
+        ...(httpStatus === undefined ? {} : { httpStatus }),
+        durationMs: Date.now() - startedAt,
+      })
+      throw error
+    }
     writeJson(response, 200, { items })
   })
 
@@ -208,4 +239,20 @@ function isPrivateModelHostname(value: string): boolean {
       || (first === 100 && second !== undefined && second >= 64 && second <= 127)
   }
   return hostname.includes(':') && (hostname.startsWith('fc') || hostname.startsWith('fd') || hostname.startsWith('fe80:'))
+}
+
+const SERVICE_ERROR_HTTP_STATUS: Record<ServiceError['kind'], number> = {
+  conflict: 409,
+  forbidden: 403,
+  invalid: 422,
+  'not-found': 404,
+  'rate-limited': 429,
+  'too-large': 413,
+  unavailable: 502,
+  unsupported: 415,
+}
+
+function serviceErrorHttpStatus(error: unknown): number | undefined {
+  if (!(error instanceof ServiceError)) return undefined
+  return error.httpStatus ?? SERVICE_ERROR_HTTP_STATUS[error.kind]
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -4,7 +4,7 @@ import { join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { BUILTIN_BLUEPRINTS } from '@dsh-cyber/catalog'
-import type { AgentRuntimePort, ModelProfile } from '@dsh-cyber/contracts'
+import type { AgentRuntimePort, AgentTurnRequest, ModelProfile } from '@dsh-cyber/contracts'
 import {
   HarnessModelRouter,
   inspectHarnessCandidate,
@@ -31,6 +31,7 @@ import { registerAssetRoutes } from './routes/asset-routes.js'
 import { registerCatalogRoutes } from './routes/catalog-routes.js'
 import { registerConversationRoutes } from './routes/conversation-routes.js'
 import { registerEmployeeRoutes } from './routes/employee-routes.js'
+import { registerModelInteractionRoutes } from './routes/model-interaction-routes.js'
 import { registerModelRoutes } from './routes/model-routes.js'
 import { registerPackageRoutes } from './routes/package-routes.js'
 import { registerSystemRoutes } from './routes/system-routes.js'
@@ -41,6 +42,10 @@ import { registerWorldRoutes } from './routes/world-routes.js'
 import { AssetService } from './services/asset-service.js'
 import { ModelCredentialService } from './services/model-credential-service.js'
 import { ModelCatalogService } from './services/model-catalog-service.js'
+import {
+  ModelInteractionService,
+  TurnInteractionLoggingRuntime,
+} from './services/model-interaction-service.js'
 import { RuntimeUpdateService } from './services/runtime-update-service.js'
 import { WorkspaceFileService } from './services/workspace-file-service.js'
 import { RuntimeStreamHub } from './streams/runtime-stream-hub.js'
@@ -100,18 +105,21 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
   const modelCatalog = new ModelCatalogService(credentials)
 
   const activeDshBinPath = await resolveActiveRuntime(store, runtimeStateRoot, stateRoot)
-  const runtime = options.runtime ?? new HarnessModelRouter({
+  const interactions = new ModelInteractionService(store)
+  const baseRuntime = options.runtime ?? new HarnessModelRouter({
     stateRoot: runtimeStateRoot,
     ...(activeDshBinPath === undefined ? {} : { dshBinPath: activeDshBinPath }),
     resolveRoute(request) {
-      const selectedProfileId = request.revision.modelPolicy.modelProfileId
-      const selectedProfile = typeof selectedProfileId === 'string'
-        ? store.getModelProfile(selectedProfileId)
-        : undefined
-      const profile = selectedProfile?.workspaceId === request.agent.workspaceId
-        ? selectedProfile
-        : store.resolveModelProfile(request.agent.workspaceId, request.agent.worldId, request.agent.id)
-      return profile === undefined ? undefined : harnessModelRoute(profile)
+      return resolveHarnessRoute(store, request)
+    },
+  })
+  // 无论内置路由还是外部注入的 runtime，统一包一层回合级日志采集；
+  // 观测边界：模型 API 请求在 DSH worker 内部，服务端记录整轮交互的成功/失败与耗时。
+  const runtime = new TurnInteractionLoggingRuntime({
+    inner: baseRuntime,
+    service: interactions,
+    resolveRoute(request) {
+      return resolveHarnessRoute(store, request)
     },
   })
   const orchestrator = new ConversationOrchestrator({ store, runtime, workspacePath: workspaceRoot })
@@ -135,11 +143,12 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
   registerWorkspaceFileRoutes(router, { workspaceFiles })
   registerCatalogRoutes(router, { store, packageCatalog })
   registerWorkspaceRoutes(router, { store })
-  registerModelRoutes(router, { store, credentials, modelCatalog })
+  registerModelRoutes(router, { store, credentials, modelCatalog, interactions })
   registerAssetRoutes(router, { store, assets })
   registerWorldRoutes(router, { store })
   registerPackageRoutes(router, { store, packageManager, packageCatalog })
   registerWorldRuntimeRoutes(router, { store, worldRuntime, worldStreamHub })
+  registerModelInteractionRoutes(router, { store, interactions })
   registerConversationRoutes(router, { store, orchestrator, runtimeStreamHub, worldRuntime })
   registerEmployeeRoutes(router, { store })
 
@@ -208,6 +217,17 @@ async function resolveActiveRuntime(
     )
   }
   return resolveCandidateDshBin(activeRuntime.candidateRoot)
+}
+
+function resolveHarnessRoute(store: SqliteStore, request: AgentTurnRequest): HarnessModelRoute | undefined {
+  const selectedProfileId = request.revision.modelPolicy.modelProfileId
+  const selectedProfile = typeof selectedProfileId === 'string'
+    ? store.getModelProfile(selectedProfileId)
+    : undefined
+  const profile = selectedProfile?.workspaceId === request.agent.workspaceId
+    ? selectedProfile
+    : store.resolveModelProfile(request.agent.workspaceId, request.agent.worldId, request.agent.id)
+  return profile === undefined ? undefined : harnessModelRoute(profile)
 }
 
 function harnessModelRoute(profile: ModelProfile): HarnessModelRoute {

--- a/packages/server/src/services/model-catalog-service.ts
+++ b/packages/server/src/services/model-catalog-service.ts
@@ -78,11 +78,11 @@ function modelCatalogEndpoint(baseUrl: string): URL {
 }
 
 function upstreamCatalogError(status: number): ServiceError {
-  if (status === 401 || status === 403) return new ServiceError('forbidden', 'model_credential_rejected', 'API 密钥无效或没有访问权限，请检查后重试。')
-  if (status === 404) return new ServiceError('not-found', 'model_catalog_not_found', '该接口没有提供模型列表，请确认接口地址以 /v1 结尾，或手动填写模型 ID。')
-  if (status === 429) return new ServiceError('rate-limited', 'model_catalog_rate_limited', '模型服务请求过于频繁，请稍后重试。')
-  if (status >= 500) return new ServiceError('unavailable', 'model_catalog_upstream_error', '模型服务暂时不可用，请稍后重试。')
-  return new ServiceError('invalid', 'model_catalog_rejected', `模型服务拒绝了模型列表请求（状态码 ${status}）。`)
+  if (status === 401 || status === 403) return new ServiceError('forbidden', 'model_credential_rejected', 'API 密钥无效或没有访问权限，请检查后重试。', status)
+  if (status === 404) return new ServiceError('not-found', 'model_catalog_not_found', '该接口没有提供模型列表，请确认接口地址以 /v1 结尾，或手动填写模型 ID。', status)
+  if (status === 429) return new ServiceError('rate-limited', 'model_catalog_rate_limited', '模型服务请求过于频繁，请稍后重试。', status)
+  if (status >= 500) return new ServiceError('unavailable', 'model_catalog_upstream_error', '模型服务暂时不可用，请稍后重试。', status)
+  return new ServiceError('invalid', 'model_catalog_rejected', `模型服务拒绝了模型列表请求（状态码 ${status}）。`, status)
 }
 
 async function readCatalogJson(response: Response): Promise<unknown> {

--- a/packages/server/src/services/model-interaction-service.ts
+++ b/packages/server/src/services/model-interaction-service.ts
@@ -1,0 +1,301 @@
+import type {
+  AgentRuntimeEvent,
+  AgentRuntimePort,
+  AgentTurnRequest,
+  AgentTurnResult,
+  ModelInteractionLog,
+  ModelInteractionLogFilter,
+  ModelInteractionLogPage,
+  ModelInteractionLogStatus,
+} from '@dsh-cyber/contracts'
+import type { HarnessModelRoute } from '@dsh-cyber/harness-adapter'
+import type { SqliteStore } from '@dsh-cyber/persistence'
+
+/**
+ * 模型交互日志服务。
+ *
+ * 隐私红线（与 AGENTS.md 一致）：本服务只持久化请求摘要统计（消息数 / 字符数）、
+ * 可读错误信息与 token 用量（仅接口返回时）。绝不写入 API 密钥、prompt 明文或
+ * 响应明文。错误信息在落库前统一经过敏感内容清洗。
+ */
+export class ModelInteractionService {
+  readonly #store: SqliteStore
+
+  constructor(store: SqliteStore) {
+    this.#store = store
+  }
+
+  /**
+   * 记录一次对话回合级交互（source='turn'）。
+   * 观测边界：模型 API 请求发生在 DSH worker 内部，服务端只能观测整轮交互
+   * （开始时间、worker 返回的成功/失败、耗时、工具调用次数、最终响应摘要）。
+   * 消息数按「1 条用户 prompt + 每轮工具回填 1 条」近似；worker 内部单次请求的
+   * token 用量接口未透出，字段保持为空。
+   */
+  recordTurn(input: RecordTurnInteractionInput): ModelInteractionLog {
+    return this.#store.recordModelInteraction({
+      workspaceId: input.workspaceId,
+      ...(input.worldId === undefined ? {} : { worldId: input.worldId }),
+      ...(input.employeeId === undefined ? {} : { employeeId: input.employeeId }),
+      source: 'turn',
+      modelId: input.modelId,
+      provider: input.provider,
+      status: input.status,
+      ...(input.errorCode === undefined ? {} : { errorCode: input.errorCode }),
+      ...(input.errorMessage === undefined ? {} : { errorMessage: sanitizeErrorMessage(input.errorMessage) }),
+      ...(input.httpStatus === undefined ? {} : { httpStatus: input.httpStatus }),
+      promptMessageCount: 1 + (input.toolCallCount ?? 0),
+      promptCharCount: input.prompt.length,
+      ...(input.responseCharCount === undefined ? {} : { responseCharCount: input.responseCharCount }),
+      ...(input.toolCallCount === undefined ? {} : { toolCallCount: input.toolCallCount }),
+      durationMs: input.durationMs,
+    })
+  }
+
+  /**
+   * 记录一次 /models 模型发现交互（source='discovery'）。GET 请求无 prompt，
+   * 请求摘要保持为 0，耗时与状态反映真实 HTTP 往返。
+   */
+  recordDiscovery(input: RecordDiscoveryInteractionInput): ModelInteractionLog {
+    return this.#store.recordModelInteraction({
+      workspaceId: input.workspaceId,
+      source: 'discovery',
+      modelId: input.modelId,
+      provider: input.provider,
+      status: input.status,
+      ...(input.errorCode === undefined ? {} : { errorCode: input.errorCode }),
+      ...(input.errorMessage === undefined ? {} : { errorMessage: sanitizeErrorMessage(input.errorMessage) }),
+      ...(input.httpStatus === undefined ? {} : { httpStatus: input.httpStatus }),
+      promptMessageCount: 0,
+      promptCharCount: 0,
+      durationMs: input.durationMs,
+    })
+  }
+
+  list(workspaceId: string, filter: ModelInteractionLogFilter): ModelInteractionLogPage {
+    return this.#store.listModelInteractions(workspaceId, filter)
+  }
+
+  get(interactionId: string): ModelInteractionLog | undefined {
+    return this.#store.getModelInteraction(interactionId)
+  }
+
+  clear(workspaceId: string): number {
+    return this.#store.clearModelInteractions(workspaceId)
+  }
+}
+
+export interface RecordTurnInteractionInput {
+  workspaceId: string
+  worldId?: string
+  employeeId?: string
+  modelId: string
+  provider: string
+  status: ModelInteractionLogStatus
+  errorCode?: string
+  errorMessage?: string
+  httpStatus?: number
+  prompt: string
+  responseCharCount?: number
+  toolCallCount?: number
+  durationMs: number
+}
+
+export interface RecordDiscoveryInteractionInput {
+  workspaceId: string
+  modelId: string
+  provider: string
+  status: ModelInteractionLogStatus
+  errorCode?: string
+  errorMessage?: string
+  httpStatus?: number
+  durationMs: number
+}
+
+/**
+ * 包一层 AgentRuntimePort：在真实回合前后记录模型交互日志，不改动业务语义。
+ * 未配置模型路由时（route 为 undefined，走默认 DSH 模型）同样记录，便于排查。
+ */
+export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
+  readonly #inner: AgentRuntimePort
+  readonly #service: ModelInteractionService
+  readonly #resolveRoute: (request: AgentTurnRequest) => HarnessModelRoute | undefined
+
+  constructor(options: {
+    inner: AgentRuntimePort
+    service: ModelInteractionService
+    resolveRoute: (request: AgentTurnRequest) => HarnessModelRoute | undefined
+  }) {
+    this.#inner = options.inner
+    this.#service = options.service
+    this.#resolveRoute = options.resolveRoute
+  }
+
+  async runTurn(request: AgentTurnRequest): Promise<AgentTurnResult> {
+    const startedAt = Date.now()
+    const route = this.#resolveRoute(request)
+    const modelId = route?.modelId ?? 'dsh-default'
+    const provider = route?.displayName ?? '默认 DSH 模型'
+    let toolCallCount = 0
+    let turnFailedCode: string | undefined
+    let turnFailedMessage: string | undefined
+    let turnFailedHttpStatus: number | undefined
+    const wrapped: AgentTurnRequest = {
+      ...request,
+      onEvent: (event: AgentRuntimeEvent) => {
+        if (event.kind === 'tool.started') toolCallCount += 1
+        if (event.kind === 'turn.failed') {
+          const code = event.metadata.errorCode
+          if (typeof code === 'string' && code.trim()) turnFailedCode = code.trim()
+          const message = event.metadata.error
+          if (typeof message === 'string' && message.trim()) turnFailedMessage = message.trim()
+          const status = event.metadata.status ?? event.metadata.httpStatus
+          if (typeof status === 'number') turnFailedHttpStatus = status
+          else if (typeof status === 'string') {
+            const parsed = Number.parseInt(status, 10)
+            if (Number.isInteger(parsed)) turnFailedHttpStatus = parsed
+          }
+        }
+        request.onEvent?.(event)
+      },
+    }
+    try {
+      const result = await this.#inner.runTurn(wrapped)
+      // worker 返回 turn.failed 事件但 runTurn 未抛异常时（如空回复），
+      // 按失败记录，否则 502 类错误在日志里会漏掉。
+      if (turnFailedCode !== undefined || turnFailedMessage !== undefined || turnFailedHttpStatus !== undefined) {
+        this.#service.recordTurn({
+          workspaceId: request.agent.workspaceId,
+          worldId: request.agent.worldId,
+          employeeId: request.agent.id,
+          modelId,
+          provider,
+          status: 'failed',
+          errorCode: turnFailedCode ?? classifyTurnFailure(turnFailedMessage ?? ''),
+          ...(turnFailedMessage === undefined ? {} : { errorMessage: turnFailedMessage }),
+          ...(turnFailedHttpStatus === undefined ? {} : { httpStatus: turnFailedHttpStatus }),
+          prompt: request.prompt,
+          responseCharCount: result.finalResponse.length,
+          toolCallCount,
+          durationMs: Date.now() - startedAt,
+        })
+        return result
+      }
+      this.#service.recordTurn({
+        workspaceId: request.agent.workspaceId,
+        worldId: request.agent.worldId,
+        employeeId: request.agent.id,
+        modelId,
+        provider,
+        status: 'success',
+        prompt: request.prompt,
+        responseCharCount: result.finalResponse.length,
+        toolCallCount,
+        durationMs: Date.now() - startedAt,
+      })
+      return result
+    } catch (error) {
+      const errorMessage = turnFailedMessage ?? errorMessageText(error)
+      const httpStatus = turnFailedHttpStatus ?? extractHttpStatus(error)
+      this.#service.recordTurn({
+        workspaceId: request.agent.workspaceId,
+        worldId: request.agent.worldId,
+        employeeId: request.agent.id,
+        modelId,
+        provider,
+        status: 'failed',
+        errorCode: turnFailedCode ?? classifyTurnFailure(error),
+        ...(errorMessage === '' ? {} : { errorMessage }),
+        ...(httpStatus === undefined ? {} : { httpStatus }),
+        prompt: request.prompt,
+        toolCallCount,
+        durationMs: Date.now() - startedAt,
+      })
+      throw error
+    }
+  }
+
+  closeAgent(agentId: string): Promise<void> {
+    return this.#inner.closeAgent?.(agentId) ?? Promise.resolve()
+  }
+
+  async close(): Promise<void> {
+    await this.#inner.close()
+  }
+
+  [Symbol.asyncDispose](): Promise<void> {
+    return this.close()
+  }
+}
+
+const SECRET_PATTERNS: readonly RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(?:api[_-]?key|access[_-]?token|secret|password)\b\s*[=:]\s*["']?[A-Za-z0-9._-]{8,}/gi,
+]
+
+function sanitizeErrorMessage(value: unknown): string {
+  let text = errorMessageText(value)
+  for (const pattern of SECRET_PATTERNS) text = text.replace(pattern, '[已隐藏]')
+  return text.slice(0, 500)
+}
+
+function errorMessageText(value: unknown): string {
+  const raw = value instanceof Error
+    ? value.message
+    : value === null || value === undefined
+      ? ''
+      : String(value)
+  return raw.trim().slice(0, 500)
+}
+
+export function classifyTurnFailure(value: unknown): string {
+  const signal = value instanceof Error
+    ? `${value.name} ${value.message}`
+    : value !== null && typeof value === 'object'
+      ? Object.values(value).filter((item) => typeof item === 'string' || typeof item === 'number').join(' ')
+      : String(value ?? '')
+  const normalized = signal.toLowerCase()
+  if (/401|403|unauthori[sz]ed|forbidden|authentication|invalid[_ -]?api[_ -]?key|credential/.test(normalized)) return 'authentication'
+  if (/404|model[_ -]?not[_ -]?found|unknown[_ -]?model|invalid[_ -]?model/.test(normalized)) return 'model-not-found'
+  if (/429|rate[_ -]?limit|too many requests|quota/.test(normalized)) return 'rate-limited'
+  if (/timeout|timed out|abort/.test(normalized)) return 'timeout'
+  if (/econn|enotfound|network|fetch failed|connection|socket|dns/.test(normalized)) return 'unreachable'
+  return 'unknown'
+}
+
+/**
+ * 从错误对象或错误文本里尽力提取 HTTP 状态码。
+ * 支持：Error 上的 status/statusCode/code（数字或"502"字符串）、
+ * 错误文本里的 "status: 502" / "HTTP 502" / "(502)" 等常见形态。
+ */
+export function extractHttpStatus(value: unknown): number | undefined {
+  if (value !== null && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    for (const key of ['status', 'statusCode', 'httpStatus', 'code']) {
+      const candidate = record[key]
+      if (typeof candidate === 'number' && Number.isInteger(candidate) && candidate >= 100 && candidate <= 599) {
+        return candidate
+      }
+      if (typeof candidate === 'string') {
+        const parsed = Number.parseInt(candidate, 10)
+        if (Number.isInteger(parsed) && parsed >= 100 && parsed <= 599) return parsed
+      }
+    }
+  }
+  const text = errorMessageText(value)
+  const patterns = [
+    /\b(?:status|http)[^\d]{0,12}(\d{3})\b/i,
+    /\bHTTP(?:\/[\d.]+)?\s+(\d{3})\b/i,
+    /\((\d{3})\)/,
+    /\b(\d{3})\b(?=\s|$)/,
+  ]
+  for (const pattern of patterns) {
+    const match = pattern.exec(text)
+    if (match !== null) {
+      const status = Number.parseInt(match[1]!, 10)
+      if (status >= 100 && status <= 599) return status
+    }
+  }
+  return undefined
+}

--- a/packages/server/src/services/service-error.ts
+++ b/packages/server/src/services/service-error.ts
@@ -11,10 +11,13 @@ export type ServiceErrorKind =
 export class ServiceError extends Error {
   readonly kind: ServiceErrorKind
   readonly code: string
+  /** 上游服务返回的真实 HTTP 状态码（模型接口等外部服务），无则 undefined */
+  readonly httpStatus?: number
 
-  constructor(kind: ServiceErrorKind, code: string, message: string) {
+  constructor(kind: ServiceErrorKind, code: string, message: string, httpStatus?: number) {
     super(message)
     this.kind = kind
     this.code = code
+    if (httpStatus !== undefined) this.httpStatus = httpStatus
   }
 }

--- a/packages/server/tests/model-interaction-routes.test.ts
+++ b/packages/server/tests/model-interaction-routes.test.ts
@@ -1,0 +1,326 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { AgentRuntimePort, AgentTurnRequest, AgentTurnResult } from '@dsh-cyber/contracts'
+
+import { createCyberServer, type CyberServer } from '../src/index.js'
+import { extractHttpStatus } from '../src/services/model-interaction-service.js'
+
+const servers: CyberServer[] = []
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) await server.close()
+})
+
+class FakeRuntime implements AgentRuntimePort {
+  fail = false
+  /** 模拟 worker 空回复：发 turn.failed 事件但不抛异常（502 类错误的典型形态） */
+  silentFail = false
+
+  async runTurn(request: AgentTurnRequest): Promise<AgentTurnResult> {
+    const agentSessionId = request.agent.agentSessionId ?? `agent-${request.agent.id}`
+    if (this.silentFail) {
+      request.onEvent?.({
+        kind: 'turn.started',
+        source: 'test-runtime',
+        sourceSessionId: agentSessionId,
+        metadata: {},
+      })
+      request.onEvent?.({
+        kind: 'turn.failed',
+        source: 'test-runtime',
+        sourceSessionId: agentSessionId,
+        failed: true,
+        metadata: { errorCode: 'empty-response', error: 'model returned no content', httpStatus: 502 },
+      })
+      return { agentSessionId, finalResponse: '', eventCount: 2 }
+    }
+    if (this.fail) {
+      request.onEvent?.({
+        kind: 'turn.started',
+        source: 'test-runtime',
+        sourceSessionId: agentSessionId,
+        metadata: {},
+      })
+      request.onEvent?.({
+        kind: 'turn.failed',
+        source: 'test-runtime',
+        sourceSessionId: agentSessionId,
+        failed: true,
+        metadata: { errorCode: 'upstream-500' },
+      })
+      throw new Error('upstream model error')
+    }
+    request.onEvent?.({
+      kind: 'turn.started',
+      source: 'test-runtime',
+      sourceSessionId: agentSessionId,
+      metadata: {},
+    })
+    request.onEvent?.({
+      kind: 'tool.started',
+      source: 'test-runtime',
+      sourceSessionId: agentSessionId,
+      toolName: 'search_workspace',
+      callId: `call-${request.agent.id}`,
+      metadata: {},
+    })
+    request.onEvent?.({
+      kind: 'tool.completed',
+      source: 'test-runtime',
+      sourceSessionId: agentSessionId,
+      callId: `call-${request.agent.id}`,
+      failed: false,
+      metadata: {},
+    })
+    request.onEvent?.({
+      kind: 'assistant.message',
+      source: 'test-runtime',
+      sourceSessionId: agentSessionId,
+      content: '我先建立性能基线。',
+      metadata: {},
+    })
+    request.onEvent?.({
+      kind: 'turn.completed',
+      source: 'test-runtime',
+      sourceSessionId: agentSessionId,
+      metadata: {},
+    })
+    return { agentSessionId, finalResponse: '我先建立性能基线。', eventCount: 5 }
+  }
+
+  async close(): Promise<void> {}
+}
+
+async function start(stateRoot: string, runtime = new FakeRuntime()) {
+  const server = await createCyberServer({
+    stateRoot,
+    workspacePath: stateRoot,
+    port: 0,
+    runtime,
+  })
+  servers.push(server)
+  const address = await server.start()
+  return { server, runtime, origin: address.origin }
+}
+
+async function json(
+  origin: string,
+  pathname: string,
+  init?: RequestInit,
+): Promise<{ response: Response; body: any }> {
+  const response = await fetch(`${origin}${pathname}`, init)
+  return { response, body: await response.json() }
+}
+
+async function createWorld(origin: string) {
+  const workspaceResult = await json(origin, '/api/workspaces', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: '日志工作区' }),
+  })
+  const workspace = workspaceResult.body.workspace as { id: string }
+  const worldResult = await json(origin, `/api/workspaces/${workspace.id}/worlds`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name: '赛博公司', templateId: 'cyber-company' }),
+  })
+  return { workspace, world: worldResult.body.world as { id: string } }
+}
+
+async function recruit(origin: string, worldId: string, blueprintId: string) {
+  const result = await json(origin, `/api/worlds/${worldId}/recruit`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ blueprintId, blueprintVersion: 1 }),
+  })
+  return result.body.employee as { id: string; displayName: string }
+}
+
+async function chat(origin: string, worldId: string, prompt: string) {
+  return json(origin, `/api/worlds/${worldId}/chat`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ prompt }),
+  })
+}
+
+describe('Model interaction log APIs', () => {
+  it('records successful turn interactions and exposes list, filter, detail and clear APIs', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-interactions-'))
+    const { origin } = await start(stateRoot)
+    const { workspace, world } = await createWorld(origin)
+
+    const engineer = await recruit(origin, world.id, 'cyber-company.software-engineer')
+
+    // 配置模型档案并分配给员工，验证日志记录到真实 modelId / provider
+    const profileResult = await json(origin, `/api/workspaces/${workspace.id}/model-profiles`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: 'profile-deepseek',
+        displayName: '公司 DeepSeek',
+        providerKind: 'deepseek',
+        baseUrl: 'https://api.deepseek.com/v1',
+        modelId: 'deepseek-chat',
+        api: 'openai-completions',
+      }),
+    })
+    expect(profileResult.response.status).toBe(201)
+    await json(origin, `/api/workspaces/${workspace.id}/model-assignments/employee/${engineer.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ modelProfileId: 'profile-deepseek' }),
+    })
+
+    const reply = await chat(origin, world.id, '@开发工程师 请建立性能基线')
+    expect(reply.response.status).toBe(200)
+    expect(reply.body.replies[0].content).toBe('我先建立性能基线。')
+
+    const list = await json(origin, `/api/workspaces/${workspace.id}/model-interactions`)
+    expect(list.response.status).toBe(200)
+    expect(list.body.total).toBe(1)
+    expect(list.body.modelIds).toEqual(['deepseek-chat'])
+    const log = list.body.items[0]
+    expect(log).toMatchObject({
+      source: 'turn',
+      modelId: 'deepseek-chat',
+      provider: '公司 DeepSeek',
+      status: 'success',
+      toolCallCount: 1,
+      promptMessageCount: 2,
+    })
+    expect(log.promptCharCount).toBeGreaterThan(0)
+    expect(log.responseCharCount).toBe('我先建立性能基线。'.length)
+    expect(log.durationMs).toBeGreaterThanOrEqual(0)
+    // 隐私：日志不包含 prompt 明文与密钥
+    expect(JSON.stringify(log)).not.toContain('请建立性能基线')
+
+    // 详情
+    const detail = await json(origin, `/api/workspaces/${workspace.id}/model-interactions/${log.id}`)
+    expect(detail.response.status).toBe(200)
+    expect(detail.body.log.id).toBe(log.id)
+
+    // 状态筛选
+    const failedFilter = await json(origin, `/api/workspaces/${workspace.id}/model-interactions?status=failed`)
+    expect(failedFilter.body.total).toBe(0)
+    const successFilter = await json(origin, `/api/workspaces/${workspace.id}/model-interactions?status=success`)
+    expect(successFilter.body.total).toBe(1)
+
+    // 模型筛选
+    const modelFilter = await json(origin, `/api/workspaces/${workspace.id}/model-interactions?modelId=${encodeURIComponent('deepseek-chat')}`)
+    expect(modelFilter.body.total).toBe(1)
+    const wrongModel = await json(origin, `/api/workspaces/${workspace.id}/model-interactions?modelId=${encodeURIComponent('other-model')}`)
+    expect(wrongModel.body.total).toBe(0)
+
+    // 非法状态筛选
+    const badStatus = await json(origin, `/api/workspaces/${workspace.id}/model-interactions?status=bogus`)
+    expect(badStatus.response.status).toBe(422)
+
+    // 清空（服务端护栏要求非 GET 请求带 application/json）
+    const cleared = await json(origin, `/api/workspaces/${workspace.id}/model-interactions`, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    })
+    expect(cleared.response.status).toBe(200)
+    expect(cleared.body.removed).toBe(1)
+    const afterClear = await json(origin, `/api/workspaces/${workspace.id}/model-interactions`)
+    expect(afterClear.body.total).toBe(0)
+  })
+
+  it('records failed turn interactions with error codes', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-interactions-'))
+    const runtime = new FakeRuntime()
+    const { origin } = await start(stateRoot, runtime)
+    const { workspace, world } = await createWorld(origin)
+    await recruit(origin, world.id, 'cyber-company.software-engineer')
+
+    runtime.fail = true
+    await chat(origin, world.id, '@开发工程师 触发失败')
+
+    const list = await json(origin, `/api/workspaces/${workspace.id}/model-interactions`)
+    expect(list.body.total).toBe(1)
+    expect(list.body.items[0]).toMatchObject({
+      source: 'turn',
+      modelId: 'dsh-default',
+      provider: '默认 DSH 模型',
+      status: 'failed',
+      errorCode: 'upstream-500',
+    })
+    expect(typeof list.body.items[0].errorMessage).toBe('string')
+  })
+
+  it('records failed turns with http status when worker emits turn.failed without throwing', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-interactions-'))
+    const runtime = new FakeRuntime()
+    const { origin } = await start(stateRoot, runtime)
+    const { workspace, world } = await createWorld(origin)
+    await recruit(origin, world.id, 'cyber-company.software-engineer')
+
+    runtime.silentFail = true
+    const reply = await chat(origin, world.id, '@开发工程师 触发空回复')
+    // worker 未抛异常，但 turn.failed 事件 → orchestrator 判定失败，返回 502
+    expect(reply.response.status).toBe(502)
+
+    const list = await json(origin, `/api/workspaces/${workspace.id}/model-interactions`)
+    expect(list.body.total).toBe(1)
+    const log = list.body.items[0]
+    expect(log).toMatchObject({
+      source: 'turn',
+      status: 'failed',
+      errorCode: 'empty-response',
+      httpStatus: 502,
+    })
+    expect(log.errorMessage).toContain('model returned no content')
+  })
+
+  it('records failed /models discovery interactions', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-interactions-'))
+    const { origin } = await start(stateRoot)
+    const { workspace } = await createWorld(origin)
+
+    // 指向无人监听的回环端口，必然连接失败 → 记录 discovery 失败日志
+    const discovery = await json(origin, `/api/workspaces/${workspace.id}/model-profiles/discover`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ baseUrl: 'http://127.0.0.1:9/v1', api: 'openai-completions' }),
+    })
+    expect(discovery.response.status).toBeGreaterThanOrEqual(400)
+
+    const list = await json(origin, `/api/workspaces/${workspace.id}/model-interactions`)
+    expect(list.body.total).toBe(1)
+    const log = list.body.items[0]
+    expect(log).toMatchObject({
+      source: 'discovery',
+      modelId: '-',
+      provider: 'http://127.0.0.1:9/v1',
+      status: 'failed',
+      errorCode: 'model_catalog_unreachable',
+      promptMessageCount: 0,
+      promptCharCount: 0,
+    })
+  })
+})
+
+describe('extractHttpStatus', () => {
+  it('extracts numeric status fields from error objects', () => {
+    expect(extractHttpStatus({ status: 429 })).toBe(429)
+    expect(extractHttpStatus({ statusCode: 503 })).toBe(503)
+    expect(extractHttpStatus({ status: '502' })).toBe(502)
+  })
+
+  it('extracts status codes embedded in error text', () => {
+    expect(extractHttpStatus(new Error('HTTP 500 Internal Server Error'))).toBe(500)
+    expect(extractHttpStatus(new Error('upstream returned status: 401'))).toBe(401)
+    expect(extractHttpStatus(new Error('request failed (429)'))).toBe(429)
+  })
+
+  it('returns undefined when no status code is present', () => {
+    expect(extractHttpStatus(new Error('network unreachable'))).toBeUndefined()
+    expect(extractHttpStatus(undefined)).toBeUndefined()
+    expect(extractHttpStatus('some plain message')).toBeUndefined()
+  })
+})

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -14,12 +14,18 @@
     "@phosphor-icons/react": "^2.1.10",
     "pixi.js": "8.19.0",
     "react": "^19.2.8",
-    "react-dom": "^19.2.8"
+    "react-dom": "^19.2.8",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1",
+    "unist-util-visit": "^5.1.0"
   },
   "devDependencies": {
+    "@types/mdast": "^4.0.4",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^6.0.5",
+    "remark-parse": "^11.0.0",
+    "unified": "^9.2.2",
     "vite": "^8.2.1"
   }
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -98,6 +98,7 @@ export default function App() {
   const [dockCollapsed, setDockCollapsed] = useState(false)
   const [draft, setDraft] = useState('')
   const [sending, setSending] = useState(false)
+  const liveTurnClearTimerRef = useRef<number | undefined>(undefined)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsSection, setSettingsSection] = useState<SettingsSection>('appearance')
   const [savingSettings, setSavingSettings] = useState(false)
@@ -131,6 +132,18 @@ export default function App() {
   const managingRevision = managingDossier?.revisions.find((revision) => revision.revision === managingEmployee?.currentRevision)
   const supportsWorldRuntime = worldRuntimeV2Enabled && worldRuntimeAvailable
 
+  const clearLiveTurns = useCallback(() => {
+    if (liveTurnClearTimerRef.current !== undefined) {
+      window.clearTimeout(liveTurnClearTimerRef.current)
+      liveTurnClearTimerRef.current = undefined
+    }
+    setLiveTurns([])
+  }, [])
+
+  useEffect(() => () => {
+    if (liveTurnClearTimerRef.current !== undefined) window.clearTimeout(liveTurnClearTimerRef.current)
+  }, [])
+
   const loadWorld = useCallback(async (world: World) => {
     setError(undefined)
     setActiveWorld(world)
@@ -138,7 +151,7 @@ export default function App() {
     setSessionParticipants({})
     setConversationIntent(undefined)
     setMessages([])
-    setLiveTurns([])
+    clearLiveTurns()
     setDraft('')
     setSelectedEmployeeId(undefined)
     setDockTab('world')
@@ -188,7 +201,7 @@ export default function App() {
     setEmployees(snapshot.employees.map((employee, index) => toCyberEmployee(employee, index, nextDossiers[employee.id])))
     setSessions(snapshot.openSessions)
     setSessionParticipants(Object.fromEntries(participantResults))
-  }, [])
+  }, [clearLiveTurns])
 
   const bindWorldTheme = useCallback(async (packageId: string) => {
     if (activeWorld === undefined) throw new Error('世界尚未就绪')
@@ -313,9 +326,10 @@ export default function App() {
       title: `与 ${employee.displayName} 对话`,
     } : undefined)
     if (existing === undefined) setMessages([])
+    clearLiveTurns()
     setDraft('')
     setSelectedEmployeeId(employee.id)
-  }, [sessionParticipants, sessions])
+  }, [clearLiveTurns, sessionParticipants, sessions])
 
   const createGroupIntent = useCallback((input: { title: string; employeeIds: string[] }) => {
     const selected = employees.filter((employee) => input.employeeIds.includes(employee.id))
@@ -323,7 +337,7 @@ export default function App() {
     setGroupDialogOpen(false)
     setActiveSessionId(undefined)
     setMessages([])
-    setLiveTurns([])
+    clearLiveTurns()
     setDraft('')
     setConversationIntent({
       kind: 'group',
@@ -331,7 +345,7 @@ export default function App() {
       title: input.title.trim() || selected.map((employee) => employee.displayName).join('、'),
     })
     setSelectedEmployeeId(selected[0]?.id)
-  }, [employees])
+  }, [clearLiveTurns, employees])
 
   const openRecruitment = useCallback(async () => {
     if (activeWorld === undefined) return
@@ -653,6 +667,7 @@ export default function App() {
   const selectSession = useCallback((sessionId: string) => {
     setConversationIntent(undefined)
     setActiveSessionId(sessionId)
+    clearLiveTurns()
     setDraft('')
     setSelectedEmployeeId(sessionParticipants[sessionId]?.[0])
     if (demoMode) {
@@ -660,13 +675,16 @@ export default function App() {
         ? demoData.messages
         : sessionId === demoTavernSessions[0]?.id ? demoTavernMessages : [])
     }
-  }, [sessionParticipants])
+  }, [clearLiveTurns, sessionParticipants])
 
   const send = useCallback(async (prompt: string, attachments: ChatAttachment[]) => {
     if (activeWorld === undefined) return
     setSending(true)
-    setLiveTurns([])
+    clearLiveTurns()
+    // 乐观更新：点击发送瞬间立即清空输入框，不等模型回合结束
+    setDraft('')
     setError(undefined)
+    let optimisticOwnerMessage: WorkMessage | undefined
     try {
       const explicitEmployeeIds = conversationIntent?.employeeIds
         ?? (activeSessionId === undefined ? [] : sessionParticipants[activeSessionId] ?? [])
@@ -699,7 +717,6 @@ export default function App() {
         setSessionParticipants((current) => ({ ...current, [session.id]: targets.map((employee) => employee.id) }))
         setConversationIntent(undefined)
         setMessages((current) => [...current, ownerMessage])
-        setDraft('')
         await delay(650)
         const replies = targets.map((employee, index) => makeDemoMessage(
           session.id,
@@ -714,6 +731,24 @@ export default function App() {
         setMessages((current) => [...current, ...replies])
         return
       }
+      // 乐观更新：用户消息立即上屏，不依赖 chat 响应返回
+      const ownerMessage: WorkMessage = {
+        id: `local-owner-${Date.now()}`,
+        sessionId: activeSessionId ?? `pending-${Date.now()}`,
+        sequence: messages.length + 1,
+        senderId: 'owner',
+        senderKind: 'owner',
+        kind: 'user',
+        content: prompt,
+        metadata: {
+          displayTime: new Date().toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit' }),
+          participantIds: targetIds,
+          ...(attachments.length === 0 ? {} : { attachments: serializableAttachments(attachments) }),
+        },
+        createdAt: new Date().toISOString(),
+      }
+      optimisticOwnerMessage = ownerMessage
+      setMessages((current) => [...current, ownerMessage])
       const result = await api<ChatResult>(`/api/worlds/${activeWorld.id}/chat`, {
         method: 'POST',
         body: JSON.stringify({
@@ -724,7 +759,6 @@ export default function App() {
           ...(activeSessionId === undefined ? {} : { sessionId: activeSessionId }),
         }),
       })
-      setDraft('')
       setActiveSessionId(result.session.id)
       setSessionParticipants((current) => ({ ...current, [result.session.id]: targetIds }))
       setConversationIntent(undefined)
@@ -732,12 +766,19 @@ export default function App() {
       const transcript = await api<{ items: WorkMessage[] }>(`/api/sessions/${result.session.id}/messages`)
       setMessages(transcript.items)
     } catch (cause) {
+      // 回合失败时收回乐观消息，避免 UI 上残留未持久化的用户消息
+      const failedOwnerId = optimisticOwnerMessage?.id
+      if (failedOwnerId !== undefined) {
+        setMessages((current) => current.filter((message) => message.id !== failedOwnerId))
+      }
       setError(cause instanceof Error ? cause.message : '消息发送失败')
     } finally {
       setSending(false)
-      setLiveTurns([])
+      // 回合结束后保留 liveTurns 一段时间，让思考/运行过程不会一闪而过
+      if (liveTurnClearTimerRef.current !== undefined) window.clearTimeout(liveTurnClearTimerRef.current)
+      liveTurnClearTimerRef.current = window.setTimeout(() => setLiveTurns([]), 8_000)
     }
-  }, [activeSession, activeSessionId, activeWorld, conversationIntent, employees, messages.length, sessionParticipants])
+  }, [activeSession, activeSessionId, activeWorld, clearLiveTurns, conversationIntent, employees, messages.length, sessionParticipants])
 
   const uploadChatAttachment = useCallback(async (file: File): Promise<ChatAttachment> => {
     if (workspace === undefined) throw new Error('请先创建工作区')

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -24,6 +24,9 @@ import type {
   JsonObject,
   LocalAssetMimeType,
   ModelAssignment,
+  ModelInteractionLog,
+  ModelInteractionLogFilter,
+  ModelInteractionLogPage,
   ModelProfile,
   PackageInstallTransaction,
   PackagePermissionPreview,
@@ -952,6 +955,78 @@ export default function App() {
     return api<SystemActionResult>(`/api/system/update/${transactionId}/rollback`, { method: 'POST', body: JSON.stringify({ approved: input?.approved === true }) })
   }, [])
 
+  const loadModelLogs = useCallback(async (filter: ModelInteractionLogFilter): Promise<ModelInteractionLogPage> => {
+    if (workspace === undefined) throw new Error('请先创建工作区')
+    if (demoMode) {
+      await delay(200)
+      const status = filter.status
+      const modelId = filter.modelId
+      const items: ModelInteractionLog[] = (demoData.modelProfiles[0] ? [
+        {
+          id: 'demo-log-1',
+          workspaceId: workspace.id,
+          source: 'turn' as const,
+          modelId: demoData.modelProfiles[0].modelId,
+          provider: demoData.modelProfiles[0].displayName,
+          status: 'success' as const,
+          promptMessageCount: 3,
+          promptCharCount: 842,
+          responseCharCount: 156,
+          toolCallCount: 2,
+          durationMs: 3_420,
+          tokensPrompt: 1_204,
+          tokensCompletion: 312,
+          tokensTotal: 1_516,
+          createdAt: new Date(Date.now() - 4 * 60_000).toISOString(),
+        },
+        {
+          id: 'demo-log-2',
+          workspaceId: workspace.id,
+          source: 'discovery' as const,
+          modelId: '-',
+          provider: demoData.modelProfiles[0].displayName,
+          status: 'failed' as const,
+          errorCode: 'model_catalog_timeout',
+          errorMessage: '模型服务响应超时，请检查地址或稍后重试。',
+          promptMessageCount: 0,
+          promptCharCount: 0,
+          durationMs: 12_000,
+          createdAt: new Date(Date.now() - 32 * 60_000).toISOString(),
+        },
+      ] : [])
+        .filter((log) =>
+          (status === undefined || log.status === status) &&
+          (modelId === undefined || modelId === '' || log.modelId === modelId),
+        )
+      const pageSize = filter.pageSize
+      const page = Math.max(1, filter.page)
+      const total = items.length
+      return {
+        items: items.slice((page - 1) * pageSize, page * pageSize),
+        total,
+        page,
+        pageSize,
+        modelIds: [...new Set(items.map((log) => log.modelId))],
+      }
+    }
+    const query = new URLSearchParams()
+    query.set('page', String(filter.page))
+    query.set('pageSize', String(filter.pageSize))
+    if (filter.status !== undefined) query.set('status', filter.status)
+    if (filter.modelId !== undefined && filter.modelId) query.set('modelId', filter.modelId)
+    return api<ModelInteractionLogPage>(`/api/workspaces/${workspace.id}/model-interactions?${query.toString()}`)
+  }, [demoMode, workspace])
+
+  const clearModelLogs = useCallback(async (): Promise<number> => {
+    if (workspace === undefined) throw new Error('请先创建工作区')
+    if (demoMode) {
+      await delay(200)
+      return 0
+    }
+    const result = await api<{ removed: number }>(`/api/workspaces/${workspace.id}/model-interactions`, { method: 'DELETE' })
+    return result.removed
+  }, [demoMode, workspace])
+
   const resize = useCallback((leftPaneWidth: number, rightPaneWidth: number) => {
     setPreferences((current) => current === undefined ? current : { ...current, leftPaneWidth, rightPaneWidth })
   }, [])
@@ -1093,6 +1168,8 @@ export default function App() {
           onDeleteModel={deleteModel}
           onAssignModel={assignModel}
           onSystemAction={runSystemAction}
+          onLoadModelLogs={loadModelLogs}
+          onClearModelLogs={clearModelLogs}
         />
       ) : null}
       {recruitmentOpen ? (

--- a/packages/web/src/components/ChatWorkbench.tsx
+++ b/packages/web/src/components/ChatWorkbench.tsx
@@ -11,7 +11,11 @@ import {
   X,
 } from '@phosphor-icons/react'
 import { useMemo, useRef, useState } from 'react'
+import ReactMarkdown from 'react-markdown'
+import remarkGfm from 'remark-gfm'
 import type { ChatAttachment, JsonObject, WorkMessage, WorkSession, World } from '@dsh-cyber/contracts'
+
+import { mentionPlugin } from './mention-plugin.js'
 
 import type { ConversationIntent, CyberEmployee, LiveAgentTurn, ToolStep } from '../types.js'
 import { worldExperience } from '../world-experience.js'
@@ -343,15 +347,11 @@ function ToolEventMessage({ message, employee }: { message: WorkMessage; employe
 }
 
 function RichText({ value }: { value: string }) {
-  return value.split('\n').map((line, lineIndex) => (
-    <p key={`${lineIndex}-${line}`}>
-      {line.split(/(@[^\s，。；：]+)/g).map((part, partIndex) =>
-        part.startsWith('@')
-          ? <mark key={`${partIndex}-${part}`}>{part}</mark>
-          : <span key={`${partIndex}-${part}`}>{part}</span>,
-      )}
-    </p>
-  ))
+  return (
+    <div className="markdown-body">
+      <ReactMarkdown remarkPlugins={[remarkGfm, mentionPlugin]}>{value}</ReactMarkdown>
+    </div>
+  )
 }
 
 function ArtifactAttachment({ onOpen }: { onOpen(): void }) {

--- a/packages/web/src/components/ChatWorkbench.tsx
+++ b/packages/web/src/components/ChatWorkbench.tsx
@@ -87,6 +87,27 @@ export function ChatWorkbench({
     }
   }, [messages, liveTurns, sending])
 
+  // 切换会话时强制滚动到底部：进入新会话是明确意图，无论会话长短都直接
+  // 看最新消息。会话消息异步加载、分批到达，用定时重试持续滚动直到稳定
+  // 在底部或超时；组件复用不重挂载，用 ref 记录上次会话避免重复触发。
+  const lastSessionIdRef = useRef<string | undefined>(undefined)
+  useEffect(() => {
+    if (session?.id === undefined || lastSessionIdRef.current === session.id) return
+    lastSessionIdRef.current = session.id
+    const container = scrollRef.current
+    if (container === null) return
+    let attempts = 0
+    const timer = window.setInterval(() => {
+      container.scrollTop = container.scrollHeight
+      attempts += 1
+      const settled = container.scrollHeight - container.scrollTop - container.clientHeight <= 2
+      if (settled || attempts >= 20) {
+        window.clearInterval(timer)
+      }
+    }, 100)
+    return () => window.clearInterval(timer)
+  }, [session?.id])
+
   const submit = async () => {
     const prompt = draft.trim()
     if ((!prompt && attachments.length === 0) || sending || uploading) return

--- a/packages/web/src/components/ChatWorkbench.tsx
+++ b/packages/web/src/components/ChatWorkbench.tsx
@@ -10,7 +10,7 @@ import {
   WarningCircle,
   X,
 } from '@phosphor-icons/react'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import type { ChatAttachment, JsonObject, WorkMessage, WorkSession, World } from '@dsh-cyber/contracts'
@@ -60,6 +60,7 @@ export function ChatWorkbench({
 }: ChatWorkbenchProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
+  const scrollRef = useRef<HTMLDivElement>(null)
   const [attachments, setAttachments] = useState<ChatAttachment[]>([])
   const [uploading, setUploading] = useState(false)
   const [attachmentError, setAttachmentError] = useState<string>()
@@ -74,6 +75,17 @@ export function ChatWorkbench({
     .filter((employee): employee is CyberEmployee => employee !== undefined)
   const conversationTitle = session?.title ?? intent?.title ?? '选择员工开始对话'
   const conversationKind = session?.kind ?? intent?.kind
+
+  // 自动滚动到底部：新消息、实时输出或发送状态变化时跟随。若用户主动上翻
+  // 查看历史（距底部超过阈值）则不打扰，直到再次接近底部。
+  useEffect(() => {
+    const container = scrollRef.current
+    if (container === null) return
+    const nearBottom = container.scrollHeight - container.scrollTop - container.clientHeight < 160
+    if (nearBottom || sending) {
+      container.scrollTop = container.scrollHeight
+    }
+  }, [messages, liveTurns, sending])
 
   const submit = async () => {
     const prompt = draft.trim()
@@ -136,7 +148,7 @@ export function ChatWorkbench({
         <div className="chat-header__count">{messages.length}<span>条消息</span></div>
       </header>
 
-      <div className="message-scroll" aria-live="polite" aria-busy={sending}>
+      <div className="message-scroll" ref={scrollRef} aria-live="polite" aria-busy={sending}>
         {messages.length === 0 ? (
           <div className="conversation-empty">
             <TerminalWindow size={34} />
@@ -184,7 +196,12 @@ export function ChatWorkbench({
             </article>
           )
         })}
-        {liveTurns.map((turn) => <LiveTurn key={`${turn.sessionId}:${turn.agentId}`} turn={turn} employee={employees.find((item) => item.id === turn.agentId)} />)}
+        {liveTurns.length > 0 ? (
+          <div className="live-turns-block" aria-label="实时执行过程">
+            <header className="live-turns-block__header"><TerminalWindow size={14} /><span>实时执行过程</span></header>
+            {liveTurns.map((turn) => <LiveTurn key={`${turn.sessionId}:${turn.agentId}`} turn={turn} employee={employees.find((item) => item.id === turn.agentId)} />)}
+          </div>
+        ) : null}
         {sending && liveTurns.length === 0 ? <div className="stream-state"><CircleNotch size={16} className="spin" /><span>正在连接{experience.personLabel}的独立 Agent…</span><span className="stream-caret" /></div> : null}
       </div>
 
@@ -300,11 +317,13 @@ function formatBytes(value: number): string {
 
 function LiveTurn({ turn, employee }: { turn: LiveAgentTurn; employee: CyberEmployee | undefined }) {
   const [reasoningOpen, setReasoningOpen] = useState(true)
+  const live = turn.status === 'thinking' || turn.status === 'working'
   return (
-    <article className={`live-turn live-turn--${turn.status}`}>
+    <article className={`live-turn live-turn--${turn.status}${live ? ' live-turn--live' : ''}`}>
       <header>
-        <span>{turn.status === 'failed' ? <WarningCircle size={16} /> : <CircleNotch size={16} className={turn.status === 'completed' ? '' : 'spin'} />}</span>
+        <span>{turn.status === 'failed' ? <WarningCircle size={16} /> : <CircleNotch size={16} className={live ? 'spin' : ''} />}</span>
         <div><strong>{employee?.displayName ?? '员工'}</strong><small>{liveStatusLabel(turn.status)}</small></div>
+        {live ? <em className="live-turn__badge">实时</em> : null}
       </header>
       {turn.reasoning ? (
         <div className="trace-stack">

--- a/packages/web/src/components/SettingsDialog.tsx
+++ b/packages/web/src/components/SettingsDialog.tsx
@@ -1,5 +1,7 @@
 import {
   ArrowsClockwise,
+  CaretDown,
+  CaretUp,
   CheckCircle,
   Cpu,
   Database,
@@ -7,6 +9,7 @@ import {
   Eye,
   EyeSlash,
   ImageSquare,
+  ListMagnifyingGlass,
   Moon,
   Palette,
   PencilSimple,
@@ -16,11 +19,14 @@ import {
   Trash,
   X,
 } from '@phosphor-icons/react'
-import { useMemo, useState, type ReactNode } from 'react'
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
 import type {
   EmployeeInstance,
   ModelApiKind,
   ModelAssignment,
+  ModelInteractionLog,
+  ModelInteractionLogFilter,
+  ModelInteractionLogPage,
   ModelProfile,
   ModelProviderKind,
   RuntimeUpdateTransaction,
@@ -29,7 +35,7 @@ import type {
   World,
 } from '@dsh-cyber/contracts'
 
-export type SettingsSection = 'appearance' | 'models' | 'runtime' | 'data' | 'updates'
+export type SettingsSection = 'appearance' | 'models' | 'runtime' | 'data' | 'updates' | 'logs'
 export type SystemAction = 'status' | 'doctor' | 'backup' | 'export' | 'list-updates' | 'verify-update' | 'contract-update' | 'canary-update' | 'activate-update' | 'rollback-update'
 
 export interface SystemActionInput {
@@ -76,6 +82,8 @@ interface SettingsDialogProps {
   onDeleteModel(modelProfileId: string): Promise<void>
   onAssignModel(input: { scope: ModelAssignment['scope']; scopeId: string; modelProfileId?: string }): Promise<void>
   onSystemAction(action: SystemAction, input?: SystemActionInput): Promise<SystemActionResult>
+  onLoadModelLogs(filter: ModelInteractionLogFilter): Promise<ModelInteractionLogPage>
+  onClearModelLogs(): Promise<number>
 }
 
 export type ModelProfileSaveDraft = Omit<ModelProfile, 'id' | 'workspaceId' | 'createdAt' | 'updatedAt'> & {
@@ -100,6 +108,7 @@ export interface DiscoveredModel {
 const sections = [
   ['appearance', '外观与个性化', Palette],
   ['models', '模型', Cpu],
+  ['logs', '日志记录', ListMagnifyingGlass],
   ['runtime', '运行时', ShieldCheck],
   ['data', '本地数据', Database],
   ['updates', '更新', ArrowsClockwise],
@@ -218,6 +227,8 @@ export function SettingsDialog({
   onDeleteModel,
   onAssignModel,
   onSystemAction,
+  onLoadModelLogs,
+  onClearModelLogs,
 }: SettingsDialogProps) {
   const [section, setSection] = useState<SettingsSection>(initialSection)
   const [draft, setDraft] = useState(preferences)
@@ -282,6 +293,12 @@ export function SettingsDialog({
                 onSave={onSaveModel}
                 onDiscover={onDiscoverModels}
                 onDelete={onDeleteModel}
+              />
+            ) : null}
+            {section === 'logs' ? (
+              <ModelInteractionLogSettings
+                onLoad={onLoadModelLogs}
+                onClear={onClearModelLogs}
               />
             ) : null}
             {section === 'runtime' ? <RuntimeSettings pending={pendingAction} result={actionResult} error={actionError} onRun={runSystemAction} /> : null}
@@ -551,6 +568,165 @@ function ModelSettings({
       </fieldset>
     </div>
   )
+}
+
+function ModelInteractionLogSettings({
+  onLoad,
+  onClear,
+}: {
+  onLoad(filter: ModelInteractionLogFilter): Promise<ModelInteractionLogPage>
+  onClear(): Promise<number>
+}) {
+  const [status, setStatus] = useState<'' | ModelInteractionLog['status']>('')
+  const [modelId, setModelId] = useState('')
+  const [page, setPage] = useState(1)
+  const pageSize = 20
+  const [result, setResult] = useState<ModelInteractionLogPage>()
+  const [loading, setLoading] = useState(false)
+  const [clearing, setClearing] = useState(false)
+  const [error, setError] = useState<string>()
+  const [expandedId, setExpandedId] = useState<string>()
+  const totalPages = result === undefined ? 0 : Math.max(1, Math.ceil(result.total / result.pageSize))
+
+  const load = async (overrides?: { page?: number; status?: '' | ModelInteractionLog['status']; modelId?: string }) => {
+    setLoading(true)
+    setError(undefined)
+    try {
+      const nextStatus = overrides?.status === undefined ? status : overrides.status
+      const nextModelId = overrides?.modelId === undefined ? modelId : overrides.modelId
+      const nextPage = overrides?.page ?? page
+      const data = await onLoad({
+        page: nextPage,
+        pageSize,
+        ...(nextStatus === '' ? {} : { status: nextStatus }),
+        ...(nextModelId === '' ? {} : { modelId: nextModelId }),
+      })
+      setResult(data)
+      setPage(data.page)
+      setStatus(nextStatus)
+      setModelId(nextModelId)
+      setExpandedId(undefined)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '日志加载失败')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    void load()
+    // 仅在挂载时加载一次；后续筛选/翻页通过显式调用 load 触发
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  const clearLogs = async () => {
+    if (!window.confirm('确定清空全部模型交互日志吗？此操作不可恢复。')) return
+    setClearing(true)
+    setError(undefined)
+    try {
+      const removed = await onClear()
+      setResult(undefined)
+      setExpandedId(undefined)
+      if (removed > 0) await load({ page: 1 })
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '清空日志失败')
+    } finally {
+      setClearing(false)
+    }
+  }
+
+  return (
+    <div className="settings-section">
+      <div className="settings-section__heading">
+        <h3>模型交互日志</h3>
+        <p>记录每次模型 API 交互的摘要统计：时间、模型、provider、请求摘要（消息数 / 字符数）、响应状态、耗时与 token 用量。为保护隐私，日志不保存 API 密钥、prompt 明文或响应明文。</p>
+      </div>
+      <div className="log-toolbar">
+        <label className="log-filter"><span>状态</span><select value={status} onChange={(event) => void load({ status: event.target.value as '' | ModelInteractionLog['status'], page: 1 })}><option value="">全部</option><option value="success">成功</option><option value="failed">失败</option></select></label>
+        <label className="log-filter"><span>模型</span><select value={modelId} disabled={(result?.modelIds ?? []).length === 0} onChange={(event) => void load({ modelId: event.target.value, page: 1 })}><option value="">全部模型</option>{(result?.modelIds ?? []).map((id) => <option key={id} value={id}>{id}</option>)}</select></label>
+        <div className="log-toolbar__actions">
+          <button className="secondary-button" type="button" disabled={loading} onClick={() => void load()}><ArrowsClockwise size={16} />{loading ? '刷新中…' : '刷新'}</button>
+          <button className="secondary-button is-danger" type="button" disabled={loading || clearing || (result?.total ?? 0) === 0} onClick={() => void clearLogs()}><Trash size={16} />{clearing ? '清空中…' : '清空日志'}</button>
+        </div>
+      </div>
+      {error !== undefined ? <p className="model-form-message model-form-message--error" role="alert">{error}</p> : null}
+      {result === undefined ? (
+        loading ? <div className="log-empty">正在加载日志…</div> : (
+          <div className="log-empty"><ListMagnifyingGlass size={24} /><strong>还没有模型交互日志</strong><span>发起一次对话，或在模型设置中获取可用模型列表后，这里会显示真实交互记录。</span></div>
+        )
+      ) : result.items.length === 0 ? (
+        <div className="log-empty"><ListMagnifyingGlass size={24} /><strong>{result.total === 0 ? '还没有模型交互日志' : '没有符合条件的日志'}</strong><span>{result.total === 0 ? '发起一次对话，或在模型设置中获取可用模型列表后，这里会显示真实交互记录。' : '请调整状态或模型筛选条件。'}</span></div>
+      ) : (
+        <>
+          <div className="log-list" aria-label="模型交互日志列表">
+            {result.items.map((log) => {
+              const expanded = expandedId === log.id
+              return (
+                <article key={log.id} className={`log-entry${expanded ? ' is-expanded' : ''}`}>
+                  <button className="log-entry__row" type="button" aria-expanded={expanded} onClick={() => setExpandedId(expanded ? undefined : log.id)}>
+                    <span className="log-entry__time">{formatLogTime(log.createdAt)}</span>
+                    <span className="log-entry__model"><strong>{log.modelId}</strong><small>{log.provider}</small></span>
+                    <span className="log-entry__source">{log.source === 'turn' ? '对话回合' : '模型发现'}</span>
+                    <span className={log.status === 'success' ? 'log-status log-status--success' : 'log-status log-status--failed'}>{log.status === 'success' ? '成功' : '失败'}</span>
+                    <span className="log-entry__http">{log.httpStatus === undefined ? '' : `HTTP ${log.httpStatus}`}</span>
+                    <span className="log-entry__duration">{formatDuration(log.durationMs)}</span>
+                    <span className="log-entry__tokens">{tokensSummary(log)}</span>
+                    <i className="log-entry__toggle">{expanded ? <CaretUp size={14} /> : <CaretDown size={14} />}</i>
+                  </button>
+                  {expanded ? <LogDetail log={log} /> : null}
+                </article>
+              )
+            })}
+          </div>
+          <footer className="log-pagination">
+            <span>共 {result.total} 条 · 第 {result.page} / {totalPages} 页</span>
+            <div>
+              <button className="text-button" type="button" disabled={loading || result.page <= 1} onClick={() => void load({ page: result.page - 1 })}>上一页</button>
+              <button className="text-button" type="button" disabled={loading || result.page >= totalPages} onClick={() => void load({ page: result.page + 1 })}>下一页</button>
+            </div>
+          </footer>
+        </>
+      )}
+    </div>
+  )
+}
+
+function LogDetail({ log }: { log: ModelInteractionLog }) {
+  return (
+    <div className="log-detail">
+      <dl>
+        <div><dt>模型</dt><dd>{log.modelId}</dd></div>
+        <div><dt>提供商</dt><dd>{log.provider}</dd></div>
+        <div><dt>交互类型</dt><dd>{log.source === 'turn' ? '对话回合（服务端整轮交互）' : '/models 模型发现'}</dd></div>
+        <div><dt>状态</dt><dd>{log.status === 'success' ? '成功' : '失败'}{log.errorCode === undefined ? '' : ` · ${log.errorCode}`}</dd></div>
+        <div><dt>HTTP 状态码</dt><dd>{log.httpStatus === undefined ? '—' : log.httpStatus}</dd></div>
+        <div><dt>耗时</dt><dd>{log.durationMs} ms</dd></div>
+        <div><dt>请求摘要</dt><dd>{log.promptMessageCount} 条消息 · {log.promptCharCount} 字符（不含原文）</dd></div>
+        <div><dt>工具调用</dt><dd>{log.toolCallCount ?? 0} 次</dd></div>
+        <div><dt>响应摘要</dt><dd>{log.responseCharCount === undefined ? '—' : `${log.responseCharCount} 字符（不含原文）`}</dd></div>
+        <div><dt>Token 用量</dt><dd>{log.tokensPrompt === undefined ? '接口未返回' : `输入 ${log.tokensPrompt} · 输出 ${log.tokensCompletion ?? 0} · 合计 ${log.tokensTotal ?? 0}`}</dd></div>
+        <div><dt>记录时间</dt><dd>{formatLogTime(log.createdAt, true)}</dd></div>
+      </dl>
+      {log.errorMessage !== undefined && log.errorMessage !== '' ? <p className="log-detail__error"><strong>错误信息</strong>{log.errorMessage}</p> : null}
+    </div>
+  )
+}
+
+function formatLogTime(value: string, full = false): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  if (full) return date.toLocaleString('zh-CN', { hour12: false })
+  return date.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+}
+
+function formatDuration(value: number): string {
+  if (value < 1_000) return `${value} ms`
+  return `${(value / 1_000).toFixed(1)} s`
+}
+
+function tokensSummary(log: ModelInteractionLog): string {
+  if (log.tokensTotal === undefined) return '—'
+  return `Token ${log.tokensTotal.toLocaleString('zh-CN')}`
 }
 
 function validateModelDraft(draft: ModelDraft): string | undefined {

--- a/packages/web/src/components/mention-plugin.ts
+++ b/packages/web/src/components/mention-plugin.ts
@@ -1,0 +1,37 @@
+import type { PhrasingContent, Root } from 'mdast'
+import { visit } from 'unist-util-visit'
+
+declare module 'mdast' {
+  interface EmphasisData {
+    hName?: string
+  }
+}
+
+export const MENTION_PATTERN = /(?<![A-Za-z0-9])(@[^\s，。；：、!?！？]+)/g
+
+/**
+ * remark 插件：把消息正文里的 @提及 转成带 hName 标记的 emphasis 节点。
+ * mdast-util-to-hast 依据 data.hName 直接生成 <mark> 元素，因此提及在
+ * 段落、列表、标题等任意位置都能正确高亮，且不影响普通 *斜体* 语义。
+ */
+export function mentionPlugin() {
+  return (tree: Root) => {
+    visit(tree, 'text', (node, index, parent) => {
+      if (index === undefined || parent === undefined || !node.value.includes('@')) return
+      const parts = node.value.split(MENTION_PATTERN).filter((part): part is string => part.length > 0)
+      if (parts.length === 1) return
+      parent.children.splice(index, 1, ...parts.map((part: string) => {
+        if (part.startsWith('@')) {
+          const mention: PhrasingContent = {
+            type: 'emphasis',
+            data: { hName: 'mark' },
+            children: [{ type: 'text', value: part }],
+          }
+          return mention
+        }
+        const text: PhrasingContent = { type: 'text', value: part }
+        return text
+      }))
+    })
+  }
+}

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -298,14 +298,18 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .tool-step strong { font-size: 9px; font-weight: 500; }
 .tool-step code, .tool-step time { overflow: hidden; text-overflow: ellipsis; color: var(--text-muted); font: 8px var(--font-mono); }
 .stream-state { display: flex; align-items: center; gap: 7px; margin: 10px 0; color: var(--text-muted); font-size: 11px; }
+.live-turns-block { display: grid; gap: 7px; margin: 12px 0 10px; }
+.live-turns-block__header { display: flex; align-items: center; gap: 6px; color: var(--accent); font-size: 10px; font-weight: 600; letter-spacing: .08em; }
 .live-turn { display: grid; gap: 7px; margin: 10px 0; padding: 10px; border: 1px solid var(--border); border-left: 2px solid var(--accent); background: var(--surface-1); }
 .live-turn--completed { border-left-color: var(--success); }
 .live-turn--failed { border-left-color: var(--danger); }
+.live-turn--live { border-left-width: 3px; background: var(--surface-2); box-shadow: 0 0 0 1px var(--accent-soft), 0 0 18px var(--accent-soft); }
 .live-turn > header { display: flex; align-items: center; gap: 8px; }
 .live-turn > header > span { color: var(--accent); }
 .live-turn > header > div { display: flex; align-items: baseline; gap: 7px; }
 .live-turn > header strong { font-size: 11px; }
 .live-turn > header small { color: var(--text-muted); font-size: 9px; }
+.live-turn__badge { flex: 0 0 auto; margin-left: auto; font-style: normal; font-size: 9px; line-height: 1; padding: 4px 7px; border-radius: 999px; color: var(--surface-0); background: var(--accent); }
 .live-turn .trace-stack { margin-top: 0; }
 .live-turn__reasoning, .live-turn__text { margin: 0; padding: 9px; color: var(--text-soft); font-size: 10px; line-height: 1.7; white-space: pre-wrap; }
 .live-turn__reasoning { border-top: 1px solid var(--border); color: var(--text-muted); }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -250,6 +250,26 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .message__content p { margin: 0 0 7px; }
 .message__content p:last-child { margin-bottom: 0; }
 .message__content mark { color: var(--accent-strong); background: transparent; }
+.message__content .markdown-body > :first-child { margin-top: 0; }
+.message__content .markdown-body > :last-child { margin-bottom: 0; }
+.message__content .markdown-body h1, .message__content .markdown-body h2, .message__content .markdown-body h3, .message__content .markdown-body h4 { margin: 10px 0 6px; font-weight: 600; line-height: 1.35; color: var(--text-strong); }
+.message__content .markdown-body h1 { font-size: 17px; }
+.message__content .markdown-body h2 { font-size: 15px; }
+.message__content .markdown-body h3 { font-size: 14px; }
+.message__content .markdown-body h4 { font-size: 13px; }
+.message__content .markdown-body ul, .message__content .markdown-body ol { margin: 4px 0 7px; padding-left: 20px; }
+.message__content .markdown-body li { margin: 2px 0; }
+.message__content .markdown-body li > p { margin: 0; }
+.message__content .markdown-body blockquote { margin: 5px 0 8px; padding: 2px 10px; border-left: 3px solid var(--accent); background: var(--surface-2); color: var(--text-soft); }
+.message__content .markdown-body blockquote > :last-child { margin-bottom: 0; }
+.message__content .markdown-body code { padding: 1px 5px; border-radius: 4px; background: var(--surface-3); font: 12px var(--font-mono); }
+.message__content .markdown-body pre { margin: 6px 0 8px; padding: 9px 11px; overflow-x: auto; border-radius: 6px; background: var(--surface-3); }
+.message__content .markdown-body pre code { padding: 0; background: transparent; font-size: 12px; }
+.message__content .markdown-body table { width: 100%; margin: 6px 0 8px; border-collapse: collapse; font-size: 12px; }
+.message__content .markdown-body th, .message__content .markdown-body td { padding: 5px 8px; border: 1px solid var(--border); text-align: left; }
+.message__content .markdown-body th { background: var(--surface-2); font-weight: 600; }
+.message__content .markdown-body hr { margin: 8px 0; border: 0; border-top: 1px solid var(--border); }
+.message__content .markdown-body a { color: var(--accent-strong); text-decoration: underline; }
 .artifact-attachment { width: min(100%, 520px); display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; align-items: center; gap: 9px; margin-top: 8px; padding: 8px 10px; border: 1px solid var(--border); background: var(--surface-1); text-align: left; }
 .artifact-attachment:hover { border-color: var(--accent); }
 .artifact-attachment__icon { width: 34px; height: 34px; display: grid; place-items: center; background: var(--surface-3); color: var(--accent); }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -848,6 +848,48 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .settings-action-list button span:last-child { color: var(--accent); }
 .settings-action-list button:disabled { opacity: .55; cursor: wait; }
 .update-candidate-field { margin-bottom: 10px; }
+
+.log-toolbar { display: flex; align-items: end; gap: 12px; padding: 14px 15px; border: 1px solid var(--border); background: var(--surface-1); }
+.log-filter { display: grid; gap: 5px; color: var(--text-soft); font-size: 13px; }
+.log-filter select { min-width: 148px; height: 38px; padding: 0 9px; border: 1px solid var(--border); background: var(--surface-0); color: var(--text); font-size: 14px; }
+.log-toolbar__actions { margin-left: auto; display: flex; gap: 7px; }
+.log-toolbar .secondary-button { min-height: 38px; display: inline-flex; align-items: center; gap: 6px; padding: 0 13px; border: 1px solid var(--border); color: var(--text-soft); background: var(--surface-0); font-size: 13px; }
+.log-toolbar .secondary-button:hover:not(:disabled) { border-color: var(--accent); color: var(--text); }
+.log-toolbar .secondary-button.is-danger:hover:not(:disabled) { border-color: var(--danger); color: var(--danger); }
+.log-toolbar .secondary-button:disabled { opacity: .55; cursor: wait; }
+.log-list { display: grid; border: 1px solid var(--border); }
+.log-entry { border-bottom: 1px solid var(--border); background: var(--surface-0); }
+.log-entry:last-child { border-bottom: 0; }
+.log-entry.is-expanded { background: var(--surface-1); }
+.log-entry__row { width: 100%; min-height: 52px; display: grid; grid-template-columns: 132px minmax(150px, 1.5fr) 82px 52px 64px 96px 22px; align-items: center; gap: 9px; padding: 7px 13px; border: 0; background: transparent; color: var(--text); font-size: 13px; text-align: left; cursor: pointer; }
+.log-entry__row:hover { background: var(--surface-2); }
+.log-entry__time { color: var(--text-soft); font-family: var(--font-mono); font-size: 12px; white-space: nowrap; }
+.log-entry__model { min-width: 0; display: grid; gap: 2px; }
+.log-entry__model strong, .log-entry__model small { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
+.log-entry__model strong { font-size: 14px; }
+.log-entry__model small { color: var(--text-muted); font-size: 12px; }
+.log-entry__source { color: var(--text-soft); font-size: 12px; }
+.log-entry__http { color: var(--text-muted); font-family: var(--font-mono); font-size: 12px; text-align: right; }
+.log-entry__duration { color: var(--text-soft); font-family: var(--font-mono); font-size: 12px; text-align: right; }
+.log-entry__tokens { color: var(--text-muted); font-size: 12px; text-align: right; }
+.log-entry__toggle { display: grid; place-items: center; color: var(--text-muted); }
+.log-status { justify-self: start; display: inline-flex; align-items: center; gap: 4px; padding: 2px 8px; border-radius: 999px; font-size: 12px; font-weight: 600; }
+.log-status--success { color: var(--success); background: color-mix(in srgb, var(--success) 14%, var(--surface-0)); }
+.log-status--failed { color: var(--danger); background: color-mix(in srgb, var(--danger) 12%, var(--surface-0)); }
+.log-detail { padding: 13px 15px 15px; border-top: 1px solid var(--border); }
+.log-detail dl { margin: 0; display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 9px 26px; }
+.log-detail dl > div { min-width: 0; display: grid; gap: 2px; }
+.log-detail dt { color: var(--text-muted); font-size: 12px; }
+.log-detail dd { margin: 0; color: var(--text-soft); font-size: 13px; overflow-wrap: anywhere; }
+.log-detail__error { margin: 12px 0 0; padding: 9px 11px; border: 1px solid color-mix(in srgb, var(--danger) 55%, var(--border)); background: color-mix(in srgb, var(--danger) 7%, var(--surface-0)); font-size: 13px; line-height: 1.6; color: var(--text); }
+.log-detail__error strong { display: block; margin-bottom: 3px; color: var(--danger); font-size: 12px; }
+.log-empty { min-height: 190px; display: grid; place-content: center; justify-items: center; gap: 6px; padding: 24px; border: 1px dashed var(--border); color: var(--text-muted); text-align: center; }
+.log-empty svg { color: var(--text-muted); }
+.log-empty strong { color: var(--text-soft); font-size: 14px; }
+.log-empty span { font-size: 12px; line-height: 1.55; }
+.log-pagination { display: flex; align-items: center; justify-content: space-between; gap: 12px; padding: 10px 2px 0; color: var(--text-muted); font-size: 12px; }
+.log-pagination > div { display: flex; gap: 6px; }
+
 .system-result { display: grid; gap: 5px; padding: 12px; border: 1px solid var(--border); border-left: 3px solid var(--success); background: var(--surface-1); }
 .system-result--error { border-left-color: var(--danger); }
 .system-result strong { font-size: 11px; }

--- a/packages/web/tests/mention-plugin.test.ts
+++ b/packages/web/tests/mention-plugin.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import type { Root } from 'mdast'
+
+import { mentionPlugin, MENTION_PATTERN } from '../src/components/mention-plugin.js'
+
+function apply(text: string): unknown[] {
+  const tree: Root = {
+    type: 'root',
+    children: [{ type: 'paragraph', children: [{ type: 'text', value: text }] }],
+  }
+  mentionPlugin()(tree)
+  const paragraph = tree.children[0]
+  return paragraph.type === 'paragraph' ? paragraph.children : []
+}
+
+describe('mention remark plugin', () => {
+  it('wraps inline mentions in emphasis nodes with hName mark', () => {
+    const nodes = apply('项目二：@阿帆 修复问题')
+    expect(nodes).toHaveLength(3)
+    expect(nodes[0]).toMatchObject({ type: 'text', value: '项目二：' })
+    expect(nodes[1]).toMatchObject({ type: 'emphasis', data: { hName: 'mark' }, children: [{ type: 'text', value: '@阿帆' }] })
+    expect(nodes[2]).toMatchObject({ type: 'text', value: ' 修复问题' })
+  })
+
+  it('wraps mentions at the start of a paragraph', () => {
+    const nodes = apply('@小周 请确认。')
+    expect(nodes[0]).toMatchObject({ type: 'emphasis', data: { hName: 'mark' }, children: [{ type: 'text', value: '@小周' }] })
+  })
+
+  it('does not split plain text without mentions', () => {
+    const nodes = apply('没有提及的普通文本')
+    expect(nodes).toHaveLength(1)
+    expect(nodes[0]).toMatchObject({ type: 'text', value: '没有提及的普通文本' })
+  })
+
+  it('handles multiple mentions in one text node', () => {
+    const nodes = apply('@阿帆 和 @小周 都确认')
+    expect(nodes).toHaveLength(4)
+    expect(nodes.filter((node) => node.type === 'emphasis')).toHaveLength(2)
+  })
+
+  it('matches mention tokens and ignores email addresses', () => {
+    expect('@阿帆'.match(MENTION_PATTERN)).toEqual(['@阿帆'])
+    expect('@小周 请确认'.match(MENTION_PATTERN)).toEqual(['@小周'])
+    expect('email@example.com'.match(MENTION_PATTERN)).toBeNull()
+    expect('word@前后'.match(MENTION_PATTERN)).toBeNull()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,7 +180,19 @@ importers:
       react-dom:
         specifier: ^19.2.8
         version: 19.2.8(react@19.2.8)
+      react-markdown:
+        specifier: ^10.1.0
+        version: 10.1.0(@types/react@19.2.18)(react@19.2.8)
+      remark-gfm:
+        specifier: ^4.0.1
+        version: 4.0.1
+      unist-util-visit:
+        specifier: ^5.1.0
+        version: 5.1.0
     devDependencies:
+      '@types/mdast':
+        specifier: ^4.0.4
+        version: 4.0.4
       '@types/react':
         specifier: ^19.2.18
         version: 19.2.18
@@ -190,6 +202,12 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.0.5(vite@8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0))
+      remark-parse:
+        specifier: ^11.0.0
+        version: 11.0.0
+      unified:
+        specifier: ^9.2.2
+        version: 9.2.2
       vite:
         specifier: ^8.2.1
         version: 8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0)
@@ -3084,6 +3102,9 @@ packages:
   '@types/earcut@3.0.0':
     resolution: {integrity: sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==}
 
+  '@types/estree-jsx@1.0.5':
+    resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
+
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
 
@@ -3112,6 +3133,9 @@ packages:
 
   '@types/retry@0.12.0':
     resolution: {integrity: sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==}
+
+  '@types/unist@2.0.11':
+    resolution: {integrity: sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==}
 
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
@@ -3264,6 +3288,12 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  bail@1.0.5:
+    resolution: {integrity: sha512-xFbRxM1tahm08yHBP16MMjVUAvDaBMD38zsM9EMAUN61omwLmKlOpB/Zku5QkjZ8TZ4vn53pj+t518cH0S03RQ==}
+
+  bail@2.0.2:
+    resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -3307,6 +3337,9 @@ packages:
 
   character-entities@2.0.2:
     resolution: {integrity: sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==}
+
+  character-reference-invalid@2.0.1:
+    resolution: {integrity: sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -3444,6 +3477,9 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  estree-util-is-identifier-name@3.0.0:
+    resolution: {integrity: sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
@@ -3576,12 +3612,18 @@ packages:
   hast-util-to-html@9.0.5:
     resolution: {integrity: sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==}
 
+  hast-util-to-jsx-runtime@2.3.6:
+    resolution: {integrity: sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==}
+
   hast-util-whitespace@3.0.0:
     resolution: {integrity: sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==}
 
   hono@4.13.3:
     resolution: {integrity: sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==}
     engines: {node: '>=16.9.0'}
+
+  html-url-attributes@3.0.1:
+    resolution: {integrity: sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==}
 
   html-void-elements@3.0.0:
     resolution: {integrity: sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==}
@@ -3616,6 +3658,9 @@ packages:
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
 
+  inline-style-parser@0.1.1:
+    resolution: {integrity: sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==}
+
   ip-address@10.5.0:
     resolution: {integrity: sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==}
     engines: {node: '>= 12'}
@@ -3623,6 +3668,30 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
+
+  is-alphabetical@2.0.1:
+    resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
+
+  is-alphanumerical@2.0.1:
+    resolution: {integrity: sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
+  is-decimal@2.0.1:
+    resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
+
+  is-hexadecimal@2.0.1:
+    resolution: {integrity: sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==}
+
+  is-plain-obj@2.1.0:
+    resolution: {integrity: sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==}
+    engines: {node: '>=8'}
+
+  is-plain-obj@4.1.0:
+    resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
+    engines: {node: '>=12'}
 
   is-promise@4.0.0:
     resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
@@ -3795,6 +3864,15 @@ packages:
 
   mdast-util-math@3.0.0:
     resolution: {integrity: sha512-Tl9GBNeG/AhJnQM221bJR2HPvLOSnLE/T9cJI9tlc6zwQk2nPk/4f0cHkOdEixQPC/j8UtKDdITswvLAy1OZ1w==}
+
+  mdast-util-mdx-expression@2.0.1:
+    resolution: {integrity: sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==}
+
+  mdast-util-mdx-jsx@3.2.0:
+    resolution: {integrity: sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==}
+
+  mdast-util-mdxjs-esm@2.0.1:
+    resolution: {integrity: sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==}
 
   mdast-util-phrasing@4.1.0:
     resolution: {integrity: sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==}
@@ -4035,6 +4113,9 @@ packages:
     resolution: {integrity: sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==}
     engines: {node: '>=8'}
 
+  parse-entities@4.0.2:
+    resolution: {integrity: sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==}
+
   parse-svg-path@0.2.0:
     resolution: {integrity: sha512-Tf7FFIrguPKQwzD4pWnYkR2VOv3raoHeKED80Bm+BYHI3KxC8KsgsGC5+fSMzAGDA6UEk4bHvmi+RsjmL3khpg==}
 
@@ -4120,6 +4201,12 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
+  react-markdown@10.1.0:
+    resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
+    peerDependencies:
+      '@types/react': '>=18'
+      react: '>=18'
+
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -4144,6 +4231,18 @@ packages:
 
   regex@6.1.0:
     resolution: {integrity: sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==}
+
+  remark-gfm@4.0.1:
+    resolution: {integrity: sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==}
+
+  remark-parse@11.0.0:
+    resolution: {integrity: sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==}
+
+  remark-rehype@11.1.2:
+    resolution: {integrity: sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==}
+
+  remark-stringify@11.0.0:
+    resolution: {integrity: sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==}
 
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
@@ -4254,6 +4353,12 @@ packages:
   stringify-entities@4.0.4:
     resolution: {integrity: sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==}
 
+  style-to-js@1.0.0:
+    resolution: {integrity: sha512-OiaJVLD+ybcul+6oAdwTOKLFewvYapPLG4H3JiYBYUS0yoi29Ag1IiqprbVARaxiAXvkk+4B8aNcG7lyEDKebg==}
+
+  style-to-object@0.3.0:
+    resolution: {integrity: sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==}
+
   tiny-lru@11.4.7:
     resolution: {integrity: sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==}
     engines: {node: '>=12'}
@@ -4279,6 +4384,12 @@ packages:
 
   trim-lines@3.0.1:
     resolution: {integrity: sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==}
+
+  trough@1.0.5:
+    resolution: {integrity: sha512-rvuRbTarPXmMb79SmzEp8aqXNKcK+y0XaB298IXueQ8I2PsrATcPBCSPyK/dDNa2iWOhKlfNnOjdAOTBU/nkFA==}
+
+  trough@2.2.0:
+    resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
 
   ts-algebra@2.0.0:
     resolution: {integrity: sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==}
@@ -4310,6 +4421,12 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  unified@11.0.0:
+    resolution: {integrity: sha512-65zgPyv0vyXnJpw4fbGmoXjP0/6cBmnnesl4lSPGU2tYuzLWtuicRBFcaV6kgzitGrBHj6pgXYomMw1VQe/cQg==}
+
+  unified@9.2.2:
+    resolution: {integrity: sha512-Sg7j110mtefBD+qunSLO1lqOEKdrwBFBrR6Qd8f4uwkhWNlbkaqwHse6e7QvD3AP/MNoJdEDLaf8OxYyoWgorQ==}
+
   unist-util-is@6.0.1:
     resolution: {integrity: sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==}
 
@@ -4318,6 +4435,9 @@ packages:
 
   unist-util-remove-position@5.0.0:
     resolution: {integrity: sha512-Hp5Kh3wLxv0PHj9m2yZhhLt58KzPtEYKQQ4yxfYFEO7EvHwzyDYnduhHnY1mDxoqr7VUwVuHXk9RXKIiYS1N8Q==}
+
+  unist-util-stringify-position@2.0.3:
+    resolution: {integrity: sha512-3faScn5I+hy9VleOq/qNbAd6pAx7iH5jYBMS9I1HgQVijz/4mv5Bvw5iw1sC/90CODiKo81G/ps8AJrISn687g==}
 
   unist-util-stringify-position@4.0.0:
     resolution: {integrity: sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==}
@@ -4341,8 +4461,14 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vfile-message@2.0.4:
+    resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}
+
   vfile-message@4.0.3:
     resolution: {integrity: sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==}
+
+  vfile@4.2.1:
+    resolution: {integrity: sha512-O6AE4OskCG5S1emQ/4gl8zK586RqA3srz3nfK/Viy0UPToBc5Trp9BVFb1u0CjsKrAWwnpr4ifM/KBXPWwJbCA==}
 
   vfile@6.0.3:
     resolution: {integrity: sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==}
@@ -7898,6 +8024,10 @@ snapshots:
 
   '@types/earcut@3.0.0': {}
 
+  '@types/estree-jsx@1.0.5':
+    dependencies:
+      '@types/estree': 1.0.9
+
   '@types/estree@1.0.9': {}
 
   '@types/hast@3.0.5':
@@ -7925,6 +8055,8 @@ snapshots:
       csstype: 3.2.3
 
   '@types/retry@0.12.0': {}
+
+  '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
 
@@ -8065,6 +8197,10 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  bail@1.0.5: {}
+
+  bail@2.0.2: {}
+
   base64-js@1.5.1: {}
 
   bignumber.js@9.0.0: {}
@@ -8108,6 +8244,8 @@ snapshots:
   character-entities-legacy@3.0.0: {}
 
   character-entities@2.0.2: {}
+
+  character-reference-invalid@2.0.1: {}
 
   chokidar@4.0.3:
     dependencies:
@@ -8230,6 +8368,8 @@ snapshots:
   escape-html@1.0.3: {}
 
   escape-string-regexp@5.0.0: {}
+
+  estree-util-is-identifier-name@3.0.0: {}
 
   estree-walker@3.0.3:
     dependencies:
@@ -8407,11 +8547,33 @@ snapshots:
       stringify-entities: 4.0.4
       zwitch: 2.0.4
 
+  hast-util-to-jsx-runtime@2.3.6:
+    dependencies:
+      '@types/estree': 1.0.9
+      '@types/hast': 3.0.5
+      '@types/unist': 3.0.3
+      comma-separated-tokens: 2.0.3
+      devlop: 1.1.0
+      estree-util-is-identifier-name: 3.0.0
+      hast-util-whitespace: 3.0.0
+      mdast-util-mdx-expression: 2.0.1
+      mdast-util-mdx-jsx: 3.2.0
+      mdast-util-mdxjs-esm: 2.0.1
+      property-information: 7.2.0
+      space-separated-tokens: 2.0.2
+      style-to-js: 1.0.0
+      unist-util-position: 5.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   hast-util-whitespace@3.0.0:
     dependencies:
       '@types/hast': 3.0.5
 
   hono@4.13.3: {}
+
+  html-url-attributes@3.0.1: {}
 
   html-void-elements@3.0.0: {}
 
@@ -8457,9 +8619,28 @@ snapshots:
 
   inherits@2.0.4: {}
 
+  inline-style-parser@0.1.1: {}
+
   ip-address@10.5.0: {}
 
   ipaddr.js@1.9.1: {}
+
+  is-alphabetical@2.0.1: {}
+
+  is-alphanumerical@2.0.1:
+    dependencies:
+      is-alphabetical: 2.0.1
+      is-decimal: 2.0.1
+
+  is-buffer@2.0.5: {}
+
+  is-decimal@2.0.1: {}
+
+  is-hexadecimal@2.0.1: {}
+
+  is-plain-obj@2.1.0: {}
+
+  is-plain-obj@4.1.0: {}
 
   is-promise@4.0.0: {}
 
@@ -8680,6 +8861,45 @@ snapshots:
       mdast-util-from-markdown: 2.0.3
       mdast-util-to-markdown: 2.1.0
       unist-util-remove-position: 5.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-expression@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdx-jsx@3.2.0:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/unist': 3.0.3
+      ccount: 2.0.1
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.0.0
+      parse-entities: 4.0.2
+      stringify-entities: 4.0.4
+      unist-util-stringify-position: 4.0.0
+      vfile-message: 4.0.3
+    transitivePeerDependencies:
+      - supports-color
+
+  mdast-util-mdxjs-esm@2.0.1:
+    dependencies:
+      '@types/estree-jsx': 1.0.5
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      devlop: 1.1.0
+      mdast-util-from-markdown: 2.0.3
+      mdast-util-to-markdown: 2.0.0
     transitivePeerDependencies:
       - supports-color
 
@@ -9038,6 +9258,16 @@ snapshots:
       '@types/retry': 0.12.0
       retry: 0.13.1
 
+  parse-entities@4.0.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      character-entities-legacy: 3.0.0
+      character-reference-invalid: 2.0.1
+      decode-named-character-reference: 1.3.0
+      is-alphanumerical: 2.0.1
+      is-decimal: 2.0.1
+      is-hexadecimal: 2.0.1
+
   parse-svg-path@0.2.0: {}
 
   parseurl@1.3.3: {}
@@ -9136,6 +9366,24 @@ snapshots:
       react: 19.2.8
       scheduler: 0.27.0
 
+  react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.8):
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      '@types/react': 19.2.18
+      devlop: 1.1.0
+      hast-util-to-jsx-runtime: 2.3.6
+      html-url-attributes: 3.0.1
+      mdast-util-to-hast: 13.2.1
+      react: 19.2.8
+      remark-parse: 11.0.0
+      remark-rehype: 11.1.2
+      unified: 11.0.0
+      unist-util-visit: 5.1.0
+      vfile: 6.0.3
+    transitivePeerDependencies:
+      - supports-color
+
   react@18.2.0:
     dependencies:
       loose-envify: 1.4.0
@@ -9155,6 +9403,40 @@ snapshots:
   regex@6.1.0:
     dependencies:
       regex-utilities: 2.3.0
+
+  remark-gfm@4.0.1:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-gfm: 3.1.0
+      micromark-extension-gfm: 3.0.0
+      remark-parse: 11.0.0
+      remark-stringify: 11.0.0
+      unified: 11.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-parse@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-from-markdown: 2.0.3
+      micromark-util-types: 2.0.2
+      unified: 11.0.0
+    transitivePeerDependencies:
+      - supports-color
+
+  remark-rehype@11.1.2:
+    dependencies:
+      '@types/hast': 3.0.5
+      '@types/mdast': 4.0.4
+      mdast-util-to-hast: 13.2.1
+      unified: 11.0.0
+      vfile: 6.0.3
+
+  remark-stringify@11.0.0:
+    dependencies:
+      '@types/mdast': 4.0.4
+      mdast-util-to-markdown: 2.0.0
+      unified: 11.0.0
 
   require-from-string@2.0.2: {}
 
@@ -9326,6 +9608,14 @@ snapshots:
       character-entities-html4: 2.1.0
       character-entities-legacy: 3.0.0
 
+  style-to-js@1.0.0:
+    dependencies:
+      style-to-object: 0.3.0
+
+  style-to-object@0.3.0:
+    dependencies:
+      inline-style-parser: 0.1.1
+
   tiny-lru@11.4.7: {}
 
   tinybench@2.9.0: {}
@@ -9342,6 +9632,10 @@ snapshots:
   toidentifier@1.0.1: {}
 
   trim-lines@3.0.1: {}
+
+  trough@1.0.5: {}
+
+  trough@2.2.0: {}
 
   ts-algebra@2.0.0: {}
 
@@ -9369,6 +9663,26 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  unified@11.0.0:
+    dependencies:
+      '@types/unist': 3.0.3
+      '@ungap/structured-clone': 1.3.3
+      bail: 2.0.2
+      devlop: 1.1.0
+      is-plain-obj: 4.1.0
+      trough: 2.2.0
+      vfile: 6.0.3
+
+  unified@9.2.2:
+    dependencies:
+      '@types/unist': 2.0.11
+      bail: 1.0.5
+      extend: 3.0.2
+      is-buffer: 2.0.5
+      is-plain-obj: 2.1.0
+      trough: 1.0.5
+      vfile: 4.2.1
+
   unist-util-is@6.0.1:
     dependencies:
       '@types/unist': 3.0.3
@@ -9381,6 +9695,10 @@ snapshots:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-visit: 5.1.0
+
+  unist-util-stringify-position@2.0.3:
+    dependencies:
+      '@types/unist': 2.0.11
 
   unist-util-stringify-position@4.0.0:
     dependencies:
@@ -9405,10 +9723,22 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vfile-message@2.0.4:
+    dependencies:
+      '@types/unist': 2.0.11
+      unist-util-stringify-position: 2.0.3
+
   vfile-message@4.0.3:
     dependencies:
       '@types/unist': 3.0.3
       unist-util-stringify-position: 4.0.0
+
+  vfile@4.2.1:
+    dependencies:
+      '@types/unist': 2.0.11
+      is-buffer: 2.0.5
+      unist-util-stringify-position: 2.0.3
+      vfile-message: 2.0.4
 
   vfile@6.0.3:
     dependencies:


### PR DESCRIPTION
### 摘要

本 PR 包含三个相互独立但都围绕对话体验的功能块，共 4 个提交：

1. **对话消息 Markdown 渲染**：`RichText` 此前只做纯文本分段，Markdown 源码（标题、加粗、代码块、表格、列表、引用）全部原样显示。改用 `react-markdown` + `remark-gfm` 渲染，并保留 @提及高亮。
2. **发送交互实时化**：修复「发送后输入框不清空、用户消息不上屏、思考过程展示不佳」——改为乐观更新（发送瞬间清空输入框、立即上屏用户消息），liveTurns 独立区块 + 实时徽章，回合结束保留 8 秒。
3. **自动滚动**：进入长会话、发送消息、实时输出时自动滚动到底部（用户手动上翻时不打扰）。
4. **模型交互日志模块**：记录每次模型 API 交互（时间/模型/状态/耗时/token/HTTP 状态码/错误信息），设置面板新增「日志记录」查看界面；严格遵守隐私红线（不存密钥、prompt 明文、响应明文）。

### 提交明细

| 提交 | 内容 |
|---|---|
| `4d28a75` feat(web): render markdown in chat messages with react-markdown and GFM | markdown 渲染 + mention 插件 |
| `8513af6` fix(web): optimistic message send and live-turn visibility with auto-scroll | 乐观发送 + liveTurns 实时展示 + 自动滚动 |
| `4706fde` fix(web): auto-scroll to latest on session switch | 切会话自动滚底 |
| `7d11d1d` feat(server): record HTTP status and capture silent turn failures in model logs | 日志模块 + HTTP 状态码 + 静默失败捕获 |

### 关键实现说明

**Markdown 渲染**（`ChatWorkbench.tsx` / `mention-plugin.ts`）

- `react-markdown` + `remark-gfm`，默认不渲染原始 HTML（无 XSS 面）
- @提及：remark 插件把 token 重写为 `data.hName='mark'`，mdast→hast 直接生成 `<mark>`；用 `(?<![A-Za-z0-9])` 排除邮箱误判

**乐观发送**（`App.tsx`）

- `setDraft('')` 移到点击发送瞬间；用户消息立即上屏（`local-owner-<时间戳>` 乐观消息），成功后用服务端 transcript 替换，失败按 id 回滚

**自动滚动**（`ChatWorkbench.tsx`）

- 消息/实时输出变化时跟随滚动（距底部 <160px 才跟随）；切会话强制滚底（轮询直到稳定）；手动上翻不打扰

**模型交互日志**（`contracts` / `persistence` / `server` / `web`）

- SQLite 新表 `model_interaction_logs`（migration v11→v12，含 `http_status` 列）
- 采集点：turn 级（`TurnInteractionLoggingRuntime` 装饰器，含静默失败捕获）+ discovery 级（真实 HTTP 往返）
- **修复**：worker 发 `turn.failed` 事件但不抛异常（空回复）时也记录为 failed——502 类错误不再漏记
- 查询 API：列表（分页+筛选）/详情（workspace 归属校验）/清空
- 前端：设置 → 日志记录（列表/详情/筛选/清空/空态）
- 隐私：只存摘要统计；错误信息过 `SECRET_PATTERNS` 清洗（`sk-…`→`[已隐藏]`）再截断

### 验证结果

- [x] `pnpm verify` 全绿：**20 文件 / 123 测试通过**（含 mention 插件 5 测、日志路由/存储测试、extractHttpStatus 3 测、静默失败集成测试）
- [x] `pnpm test:e2e`：7/7 通过（日志面板 e2e：发消息→日志→详情→筛选→清空→空态）
- [x] Playwright 实测：markdown 渲染（h1/加粗/代码块/表格/列表/引用/@提及）、自动滚动（发送/切会话/手动上翻不打扰）均验证通过
- [x] 三视口截图 + console 记录已产出（`artifacts/ui-world-conversations/`）
- [x] 隐私实测：日志 JSON 不含 prompt 明文、不含密钥
- [x] `git status` 无凭据 / 私有会话 / 数据库 / 本地运行目录

### 补充说明

- 新增依赖（react-markdown/remark-gfm/unist-util-visit/remark-parse/unified）均无 postinstall 脚本，`allowBuilds` 白名单无需改动
- 日志 `durationMs` 语义：turn=整轮延迟（含工具调用），discovery=单次 HTTP 往返；`token` 字段因 worker 未透出当前恒为空（字段已预留，后继迭代在 harness-adapter 采集）
- `promptMessageCount` 为近似值（1 + 工具调用数），非真实消息数