### PR TITLE
feat: let users delegate real role consultations from direct chat

### DIFF
--- a/e2e/delegated-collaboration.spec.ts
+++ b/e2e/delegated-collaboration.spec.ts
@@ -1,0 +1,153 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { expect, test } from '@playwright/test'
+import type {
+  AgentRuntimePort,
+  AgentTurnRequest,
+} from '../packages/contracts/lib/index.js'
+import { WorldSimulationStore } from '../packages/persistence/lib/index.js'
+import { createCyberServer, type CyberServer } from '../packages/server/lib/index.js'
+
+let server: CyberServer
+let origin: string
+let stateRoot: string
+
+test.beforeAll(async () => {
+  stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-delegated-e2e-'))
+  server = await createCyberServer({
+    stateRoot,
+    workspacePath: process.cwd(),
+    webRoot: join(process.cwd(), 'packages', 'web', 'dist'),
+    port: 0,
+    runtime: new DelegatedWorkflowRuntime(),
+  })
+  origin = (await server.start()).origin
+})
+
+test.afterAll(async () => {
+  await server.close()
+  await rm(stateRoot, { recursive: true, force: true })
+})
+
+test('lets the user delegate a real role consultation and receive a grounded report in the original chat', async ({ page }) => {
+  await page.goto(origin)
+  await page.getByRole('button', { name: '创建我的世界' }).click()
+  await expect(page.locator('.world-runtime-canvas')).toBeVisible()
+
+  await page.locator('.left-pane').getByRole('button', { name: '添加角色' }).click()
+  const market = page.getByRole('dialog', { name: '角色市场' })
+  await market.getByRole('button', { name: /开发工程师 v1/ }).click()
+  await market.getByRole('textbox', { name: '角色名字（可选）' }).fill('阿帆')
+  await market.getByRole('button', { name: '确认添加' }).click()
+  await expect(market).toBeHidden()
+
+  await page.getByRole('button', { name: '与管家私聊' }).click()
+  const composer = page.getByRole('textbox', { name: '给当前世界的角色发送消息' })
+  await composer.fill('请帮我向 @阿帆 确认当前项目进度，然后回来告诉我。')
+  await page.getByRole('button', { name: '发送' }).click()
+
+  const workspace = server.store.listWorkspaces()[0]!
+  const world = server.store.listWorlds(workspace.id)[0]!
+  const employees = server.store.listEmployees(world.id)
+  const butler = employees.find((employee) => employee.displayName === '管家')!
+  const engineer = employees.find((employee) => employee.displayName === '阿帆')!
+
+  await expect.poll(async () => {
+    const snapshot = await (await fetch(`${origin}/api/worlds/${world.id}/runtime-snapshot`)).json() as {
+      entities: Array<{ id: string; visualState: Record<string, unknown> }>
+    }
+    const states = Object.fromEntries(
+      snapshot.entities.map((entity) => [entity.id, entity.visualState.physicalState]),
+    )
+    return [states[butler.id], states[engineer.id]].some((state) =>
+      state === 'speaking' || state === 'thinking' || state === 'listening')
+  }, { timeout: 8_000 }).toBe(true)
+
+  await expect(page.locator('.message__content').getByText(
+    /我已经向阿帆确认：接口层已完成，剩余端到端验证/,
+  )).toBeVisible({ timeout: 20_000 })
+
+  const sessions = server.store.listSessions(world.id)
+  const direct = sessions.find((session) => session.kind === 'direct')!
+  const meeting = sessions.find((session) => session.kind === 'meeting')!
+  expect(direct).toBeDefined()
+  expect(meeting).toBeDefined()
+
+  const directMessages = server.store.listMessages(direct.id)
+  const ownerMessage = directMessages.find((message) => message.kind === 'user')!
+  expect(ownerMessage.content).toBe('请帮我向 @阿帆 确认当前项目进度，然后回来告诉我。')
+  expect(ownerMessage.metadata).toMatchObject({
+    delegatedWorkflow: true,
+    delegatedPeerSessionId: meeting.id,
+    delegatedParticipantIds: [butler.id, engineer.id],
+  })
+  expect(directMessages.find((message) => message.kind === 'assistant')).toMatchObject({
+    senderId: butler.id,
+    content: expect.stringContaining('我已经向阿帆确认'),
+  })
+
+  const peerParticipants = server.store.listParticipants(meeting.id)
+  expect(peerParticipants.map((participant) => participant.participantId).sort()).toEqual([
+    butler.id,
+    engineer.id,
+  ].sort())
+  expect(peerParticipants.some((participant) => participant.kind === 'owner')).toBe(false)
+  const peerMessages = server.store.listMessages(meeting.id)
+  expect(peerMessages.filter((message) => message.kind === 'assistant').map((message) => message.senderId)).toEqual([
+    engineer.id,
+    butler.id,
+  ])
+  expect(peerMessages.at(-1)?.metadata).toMatchObject({
+    delegatedDirectSessionId: direct.id,
+  })
+
+  const simulation = new WorldSimulationStore(server.store)
+  const episode = simulation.listSharedEpisodes(world.id)[0]!
+  expect(episode.sessionId).toBe(meeting.id)
+  expect(ownerMessage.metadata.delegatedEpisodeId).toBe(episode.id)
+  expect(server.store.listEmployeeRelationships(butler.id)[0]).toMatchObject({
+    colleagueId: engineer.id,
+    collaborationCount: 1,
+  })
+
+  const finalSnapshot = await (await fetch(`${origin}/api/worlds/${world.id}/runtime-snapshot`)).json() as {
+    entities: Array<{ visualState: Record<string, unknown> }>
+  }
+  expect(finalSnapshot.entities.every((entity) => entity.visualState.activeMeetingId === undefined)).toBe(true)
+})
+
+class DelegatedWorkflowRuntime implements AgentRuntimePort {
+  readonly turns = new Map<string, number>()
+
+  async runTurn(request: AgentTurnRequest) {
+    const turn = (this.turns.get(request.agent.id) ?? 0) + 1
+    this.turns.set(request.agent.id, turn)
+    const isReport = request.prompt.includes('[系统已完成一次真实角色协作]')
+    const content = request.agent.displayName === '阿帆'
+      ? '阿帆确认：接口层已完成，剩余端到端验证。'
+      : isReport
+        ? '我已经向阿帆确认：接口层已完成，剩余端到端验证。下一步应完成端到端测试。'
+        : '管家已听取阿帆的进度，并整理了需要向用户汇报的结论。'
+    const agentSessionId = request.agent.agentSessionId ?? `agent-${request.agent.id}`
+    const events = [
+      { kind: 'turn.started', sourceSequence: 1 },
+      { kind: 'assistant.reasoning', sourceSequence: 2, content: '正在核对真实协作记录。' },
+      { kind: 'assistant.message', sourceSequence: 3, content },
+      { kind: 'turn.completed', sourceSequence: 4 },
+    ] as const
+    for (const event of events) {
+      request.onEvent?.({
+        ...event,
+        source: 'delegated-e2e',
+        sourceSessionId: agentSessionId,
+        metadata: {},
+      })
+      await new Promise((resolvePromise) => setTimeout(resolvePromise, 90))
+    }
+    return { agentSessionId, finalResponse: content, eventCount: events.length }
+  }
+
+  async close(): Promise<void> {}
+}

--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -19,6 +19,10 @@ import {
 } from '../http/request.js'
 import { writeJson } from '../http/response.js'
 import { applyInstalledPromptTransforms } from '../installed-package-runtime.js'
+import {
+  DelegatedCollaborationService,
+  detectDelegatedCollaboration,
+} from '../services/delegated-collaboration-service.js'
 import type { PeerCollaborationService } from '../services/peer-collaboration-service.js'
 import type { RuntimeStreamHub } from '../streams/runtime-stream-hub.js'
 import type { WorldRuntimeService } from '../world-runtime-service.js'
@@ -49,6 +53,12 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     worldFiles,
     worldSettings,
   } = dependencies
+  const delegatedCollaboration = new DelegatedCollaborationService({
+    store,
+    orchestrator,
+    peerCollaboration,
+    worldSettings,
+  })
 
   router.post(/^\/api\/worlds\/([^/]+)\/chat$/, async ({ request, response, params }) => {
     const world = store.getWorld(params[0]!)
@@ -78,18 +88,36 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
       if (character === undefined || character.worldId !== world.id) {
         throw new HttpError(422, 'character_unavailable', '所选角色不属于当前世界')
       }
-      const directInput: DirectConversationInput = {
-        workspaceId: world.workspaceId,
-        worldId: world.id,
-        employeeId: character.id,
+      const delegation = detectDelegatedCollaboration({
         prompt,
-        metadata,
-        runtimePrompt: await worldSettings.composeRuntimePrompt(world.id, character, transformedPrompt),
-        ...(requestedReasoning === 'auto' ? {} : { reasoningEffort: requestedReasoning }),
+        initiator: character,
+        characters: store.listEmployees(world.id),
+      })
+      if (delegation !== undefined) {
+        result = await delegatedCollaboration.run({
+          ...delegation,
+          workspaceId: world.workspaceId,
+          worldId: world.id,
+          transformedPrompt,
+          metadata,
+          ...(requestedReasoning === 'auto' ? {} : { reasoningEffort: requestedReasoning }),
+          ...(sessionId === undefined ? {} : { sessionId }),
+          ...(title === undefined ? {} : { title }),
+        })
+      } else {
+        const directInput: DirectConversationInput = {
+          workspaceId: world.workspaceId,
+          worldId: world.id,
+          employeeId: character.id,
+          prompt,
+          metadata,
+          runtimePrompt: await worldSettings.composeRuntimePrompt(world.id, character, transformedPrompt),
+          ...(requestedReasoning === 'auto' ? {} : { reasoningEffort: requestedReasoning }),
+        }
+        if (sessionId !== undefined) directInput.sessionId = sessionId
+        if (title !== undefined) directInput.title = title
+        result = await orchestrator.direct(directInput)
       }
-      if (sessionId !== undefined) directInput.sessionId = sessionId
-      if (title !== undefined) directInput.title = title
-      result = await orchestrator.direct(directInput)
     } else {
       result = await orchestrator.group({
         workspaceId: world.workspaceId,

--- a/packages/server/src/services/delegated-collaboration-service.ts
+++ b/packages/server/src/services/delegated-collaboration-service.ts
@@ -1,0 +1,222 @@
+import type {
+  EmployeeInstance,
+  JsonObject,
+  ReasoningEffort,
+  WorkSession,
+} from '@dsh-cyber/contracts'
+import type {
+  ConversationOrchestrator,
+  ConversationResult,
+  DirectConversationInput,
+} from '@dsh-cyber/orchestration'
+import type { SqliteStore } from '@dsh-cyber/persistence'
+
+import type {
+  PeerCollaborationResult,
+  PeerCollaborationService,
+} from './peer-collaboration-service.js'
+import { ServiceError } from './service-error.js'
+import type { WorldSettingsService } from './world-settings-service.js'
+
+const MAX_DELEGATED_TARGETS = 3
+const DELEGATION_REQUEST = /(帮我|替我|请你|麻烦你|劳烦你|帮忙|去问|去找)/
+const COLLABORATION_ACTION = /(询问|问一下|问问|咨询|确认|核对|沟通|讨论|请教|同步|了解|打听|对接)/
+const DEEP_DISCUSSION = /(深入|详细|追问|多轮|充分讨论)/
+
+export interface DelegatedCollaborationIntent {
+  initiatorId: string
+  targetIds: string[]
+  purpose: string
+  maxRounds: number
+}
+
+export interface DelegatedCollaborationInput extends DelegatedCollaborationIntent {
+  workspaceId: string
+  worldId: string
+  transformedPrompt: string
+  metadata: JsonObject
+  reasoningEffort?: Exclude<ReasoningEffort, 'auto'>
+  sessionId?: string
+  title?: string
+}
+
+export interface DelegatedCollaborationResult extends ConversationResult {
+  delegation: {
+    session: WorkSession
+    participantIds: string[]
+    episodeId: string
+  }
+}
+
+export interface DelegatedCollaborationServiceOptions {
+  store: Pick<SqliteStore, 'getEmployee' | 'appendMessage'>
+  orchestrator: Pick<ConversationOrchestrator, 'direct'>
+  peerCollaboration: Pick<PeerCollaborationService, 'run'>
+  worldSettings: Pick<WorldSettingsService, 'composeGroupRuntimePrompt' | 'composeRuntimePrompt'>
+}
+
+export class DelegatedCollaborationService {
+  readonly #store: DelegatedCollaborationServiceOptions['store']
+  readonly #orchestrator: DelegatedCollaborationServiceOptions['orchestrator']
+  readonly #peerCollaboration: DelegatedCollaborationServiceOptions['peerCollaboration']
+  readonly #worldSettings: DelegatedCollaborationServiceOptions['worldSettings']
+
+  constructor(options: DelegatedCollaborationServiceOptions) {
+    this.#store = options.store
+    this.#orchestrator = options.orchestrator
+    this.#peerCollaboration = options.peerCollaboration
+    this.#worldSettings = options.worldSettings
+  }
+
+  async run(input: DelegatedCollaborationInput): Promise<DelegatedCollaborationResult> {
+    const initiator = this.#store.getEmployee(input.initiatorId)
+    if (
+      initiator === undefined ||
+      initiator.workspaceId !== input.workspaceId ||
+      initiator.worldId !== input.worldId ||
+      initiator.status === 'archived'
+    ) {
+      throw new ServiceError('not-found', 'delegation_initiator_unavailable', '发起协作的角色不可用')
+    }
+    const targetIds = [...new Set(input.targetIds.filter((id) => id !== initiator.id))]
+    if (targetIds.length === 0) {
+      throw new ServiceError('invalid', 'delegation_target_required', '请明确 @ 至少一名需要沟通的角色')
+    }
+    if (targetIds.length > MAX_DELEGATED_TARGETS) {
+      throw new ServiceError('invalid', 'delegation_target_limit', `一次最多委托 ${MAX_DELEGATED_TARGETS} 名角色参与沟通`)
+    }
+
+    const targets = targetIds.map((targetId) => {
+      const target = this.#store.getEmployee(targetId)
+      if (
+        target === undefined ||
+        target.workspaceId !== input.workspaceId ||
+        target.worldId !== input.worldId ||
+        target.status === 'archived'
+      ) {
+        throw new ServiceError('not-found', 'delegation_target_unavailable', `当前世界中不存在可用角色：${targetId}`)
+      }
+      return target
+    })
+
+    const collaboration = await this.#peerCollaboration.run({
+      workspaceId: input.workspaceId,
+      worldId: input.worldId,
+      initiatorId: initiator.id,
+      participantIds: targetIds,
+      purpose: input.purpose,
+      maxRounds: input.maxRounds,
+      runtimePrompt: await this.#worldSettings.composeGroupRuntimePrompt(
+        input.worldId,
+        input.transformedPrompt,
+      ),
+      ...(input.reasoningEffort === undefined ? {} : { reasoningEffort: input.reasoningEffort }),
+      title: `${initiator.displayName} 代你向 ${targets.map((target) => target.displayName).join('、')} 确认`,
+    })
+
+    const directMetadata: JsonObject = {
+      ...input.metadata,
+      delegatedWorkflow: true,
+      delegatedPeerSessionId: collaboration.session.id,
+      delegatedEpisodeId: collaboration.episode.id,
+      delegatedParticipantIds: collaboration.participantIds,
+      delegatedPurpose: input.purpose,
+    }
+    const reportPrompt = buildGroundedReportPrompt(
+      input.transformedPrompt,
+      initiator,
+      targets,
+      collaboration,
+    )
+    const directInput: DirectConversationInput = {
+      workspaceId: input.workspaceId,
+      worldId: input.worldId,
+      employeeId: initiator.id,
+      prompt: input.purpose,
+      metadata: directMetadata,
+      runtimePrompt: await this.#worldSettings.composeRuntimePrompt(
+        input.worldId,
+        initiator,
+        reportPrompt,
+      ),
+      ...(input.reasoningEffort === undefined ? {} : { reasoningEffort: input.reasoningEffort }),
+    }
+    if (input.sessionId !== undefined) directInput.sessionId = input.sessionId
+    if (input.title !== undefined) directInput.title = input.title
+
+    const direct = await this.#orchestrator.direct(directInput)
+    this.#store.appendMessage({
+      sessionId: collaboration.session.id,
+      senderId: 'system',
+      senderKind: 'system',
+      kind: 'system',
+      content: `${initiator.displayName} 已将本次协作结果汇报给用户。`,
+      metadata: {
+        source: 'delegated-collaboration',
+        delegatedDirectSessionId: direct.session.id,
+        delegatedEpisodeId: collaboration.episode.id,
+      },
+      correlationId: direct.session.id,
+    })
+
+    return {
+      ...direct,
+      delegation: {
+        session: collaboration.session,
+        participantIds: collaboration.participantIds,
+        episodeId: collaboration.episode.id,
+      },
+    }
+  }
+}
+
+export function detectDelegatedCollaboration(input: {
+  prompt: string
+  initiator: EmployeeInstance
+  characters: readonly EmployeeInstance[]
+}): DelegatedCollaborationIntent | undefined {
+  const prompt = input.prompt.trim()
+  if (!DELEGATION_REQUEST.test(prompt) || !COLLABORATION_ACTION.test(prompt)) return undefined
+
+  const targets = input.characters
+    .filter((character) =>
+      character.id !== input.initiator.id &&
+      character.status !== 'archived' &&
+      prompt.includes(`@${character.displayName}`),
+    )
+    .sort((left, right) => prompt.indexOf(`@${left.displayName}`) - prompt.indexOf(`@${right.displayName}`))
+  if (targets.length === 0) return undefined
+
+  return {
+    initiatorId: input.initiator.id,
+    targetIds: targets.map((target) => target.id),
+    purpose: prompt,
+    maxRounds: DEEP_DISCUSSION.test(prompt) ? 2 : 1,
+  }
+}
+
+function buildGroundedReportPrompt(
+  transformedPrompt: string,
+  initiator: EmployeeInstance,
+  targets: readonly EmployeeInstance[],
+  collaboration: PeerCollaborationResult,
+): string {
+  const transcript = collaboration.replies
+    .map((reply) => `${reply.displayName}：${compact(reply.content, 1_200)}`)
+    .join('\n\n')
+  return [
+    transformedPrompt,
+    '[系统已完成一次真实角色协作]',
+    `你是发起角色：${initiator.displayName}（${initiator.role}）`,
+    `你实际沟通过的角色：${targets.map((target) => `${target.displayName}（${target.role}）`).join('、')}`,
+    `协作会话 ID：${collaboration.session.id}`,
+    `共同经历摘要：${collaboration.episode.summary}`,
+    `真实协作发言：\n${transcript || '本次协作没有产生正式发言。'}`,
+    '现在回到用户的原始会话进行汇报。只依据以上真实记录，明确说明已确认的事实、仍有分歧或未知的内容，以及下一步。不得虚构其他角色没有说过的观点、文件内容、进度或共同经历。',
+  ].join('\n\n')
+}
+
+function compact(value: string, maximum: number): string {
+  const normalized = value.replaceAll(/\s+/g, ' ').trim()
+  return normalized.length <= maximum ? normalized : `${normalized.slice(0, maximum - 1)}…`
+}

--- a/packages/server/tests/delegated-collaboration-service.test.ts
+++ b/packages/server/tests/delegated-collaboration-service.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  EmployeeInstance,
+  EmployeeRelationship,
+  JsonObject,
+  WorkMessage,
+  WorkSession,
+} from '@dsh-cyber/contracts'
+import type {
+  ConversationResult,
+  DirectConversationInput,
+} from '@dsh-cyber/orchestration'
+import type { PeerCollaborationResult } from '../src/services/peer-collaboration-service.js'
+
+import {
+  DelegatedCollaborationService,
+  detectDelegatedCollaboration,
+} from '../src/services/delegated-collaboration-service.js'
+
+describe('delegated character collaboration', () => {
+  it('detects only explicit delegated requests and preserves mentioned role order', () => {
+    const butler = character('butler', '管家', '世界管家')
+    const engineer = character('engineer', '阿帆', '开发工程师')
+    const researcher = character('researcher', '阿研', '研究员')
+
+    expect(detectDelegatedCollaboration({
+      prompt: '请帮我向 @阿研 和 @阿帆 详细确认当前进度，然后回来告诉我。',
+      initiator: butler,
+      characters: [butler, engineer, researcher],
+    })).toEqual({
+      initiatorId: butler.id,
+      targetIds: [researcher.id, engineer.id],
+      purpose: '请帮我向 @阿研 和 @阿帆 详细确认当前进度，然后回来告诉我。',
+      maxRounds: 2,
+    })
+
+    expect(detectDelegatedCollaboration({
+      prompt: '我刚才和 @阿帆 讨论过这个问题。',
+      initiator: butler,
+      characters: [butler, engineer],
+    })).toBeUndefined()
+    expect(detectDelegatedCollaboration({
+      prompt: '帮我确认当前进度。',
+      initiator: butler,
+      characters: [butler, engineer],
+    })).toBeUndefined()
+  })
+
+  it('runs the real peer session first, then gives the initiator a grounded report prompt and links both sessions', async () => {
+    const butler = character('butler', '管家', '世界管家')
+    const engineer = character('engineer', '阿帆', '开发工程师')
+    const appended: Array<{
+      sessionId: string
+      senderId: string
+      metadata?: JsonObject
+    }> = []
+    const directInputs: DirectConversationInput[] = []
+    const peerInputs: Array<Record<string, unknown>> = []
+    const service = new DelegatedCollaborationService({
+      store: {
+        getEmployee(id) {
+          return id === butler.id ? butler : id === engineer.id ? engineer : undefined
+        },
+        appendMessage(input) {
+          appended.push({
+            sessionId: input.sessionId,
+            senderId: input.senderId,
+            ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+          })
+          return message(input.sessionId, input.senderId, input.content, input.metadata ?? {})
+        },
+      },
+      peerCollaboration: {
+        async run(input) {
+          peerInputs.push(input as unknown as Record<string, unknown>)
+          return collaborationResult(butler, engineer)
+        },
+      },
+      orchestrator: {
+        async direct(input) {
+          directInputs.push(input)
+          return directResult(butler)
+        },
+      },
+      worldSettings: {
+        async composeGroupRuntimePrompt(_worldId, prompt) {
+          return `[GROUP]\n${prompt}`
+        },
+        async composeRuntimePrompt(_worldId, _character, prompt) {
+          return `[DIRECT]\n${prompt}`
+        },
+      },
+    })
+
+    const result = await service.run({
+      workspaceId: 'workspace-1',
+      worldId: 'world-1',
+      initiatorId: butler.id,
+      targetIds: [engineer.id],
+      purpose: '请帮我向 @阿帆 确认进度，然后回来告诉我。',
+      maxRounds: 1,
+      transformedPrompt: '请帮我向 @阿帆 确认进度，然后回来告诉我。',
+      metadata: { participantIds: [butler.id] },
+      sessionId: 'direct-existing',
+    })
+
+    expect(peerInputs).toHaveLength(1)
+    expect(peerInputs[0]).toMatchObject({
+      initiatorId: butler.id,
+      participantIds: [engineer.id],
+      maxRounds: 1,
+      runtimePrompt: expect.stringContaining('[GROUP]'),
+    })
+    expect(directInputs).toHaveLength(1)
+    expect(directInputs[0]).toMatchObject({
+      employeeId: butler.id,
+      sessionId: 'direct-existing',
+      metadata: {
+        delegatedWorkflow: true,
+        delegatedPeerSessionId: 'peer-session',
+        delegatedEpisodeId: 'episode-1',
+        delegatedParticipantIds: [butler.id, engineer.id],
+      },
+    })
+    expect(directInputs[0]?.runtimePrompt).toContain('阿帆：接口层已经完成')
+    expect(directInputs[0]?.runtimePrompt).toContain('只依据以上真实记录')
+    expect(appended).toContainEqual(expect.objectContaining({
+      sessionId: 'peer-session',
+      senderId: 'system',
+      metadata: expect.objectContaining({ delegatedDirectSessionId: 'direct-session' }),
+    }))
+    expect(result.session.id).toBe('direct-session')
+    expect(result.delegation).toEqual({
+      session: expect.objectContaining({ id: 'peer-session' }),
+      participantIds: [butler.id, engineer.id],
+      episodeId: 'episode-1',
+    })
+  })
+})
+
+function character(id: string, displayName: string, role: string): EmployeeInstance {
+  return {
+    id,
+    workspaceId: 'workspace-1',
+    worldId: 'world-1',
+    blueprintId: id,
+    blueprintVersion: 1,
+    displayName,
+    role,
+    status: 'available',
+    currentRevision: 1,
+    createdAt: '2026-08-22T00:00:00.000Z',
+    updatedAt: '2026-08-22T00:00:00.000Z',
+  }
+}
+
+function session(id: string, kind: WorkSession['kind']): WorkSession {
+  return {
+    id,
+    workspaceId: 'workspace-1',
+    worldId: 'world-1',
+    kind,
+    title: id,
+    status: 'open',
+    createdAt: '2026-08-22T00:00:00.000Z',
+    updatedAt: '2026-08-22T00:00:00.000Z',
+  }
+}
+
+function collaborationResult(
+  butler: EmployeeInstance,
+  engineer: EmployeeInstance,
+): PeerCollaborationResult {
+  const relationships: EmployeeRelationship[] = [
+    {
+      employeeId: butler.id,
+      colleagueId: engineer.id,
+      collaborationCount: 1,
+      reviewCount: 0,
+      handoffCount: 0,
+      lastInteractionAt: '2026-08-22T00:00:00.000Z',
+      updatedAt: '2026-08-22T00:00:00.000Z',
+    },
+  ]
+  return {
+    session: session('peer-session', 'meeting'),
+    initiatorId: butler.id,
+    participantIds: [butler.id, engineer.id],
+    purpose: '确认进度',
+    rounds: 1,
+    replies: [
+      {
+        employeeId: engineer.id,
+        displayName: engineer.displayName,
+        agentSessionId: 'engineer-agent-session',
+        content: '接口层已经完成，剩余端到端验证。',
+      },
+      {
+        employeeId: butler.id,
+        displayName: butler.displayName,
+        agentSessionId: 'butler-agent-session',
+        content: '已核对开发进度，建议继续完成端到端验证。',
+      },
+    ],
+    episode: {
+      id: 'episode-1',
+      worldId: 'world-1',
+      participantIds: [butler.id, engineer.id],
+      sessionId: 'peer-session',
+      kind: 'collaboration',
+      title: '确认进度',
+      summary: '阿帆确认接口层已完成，下一步是端到端验证。',
+      outcome: 'completed',
+      sourceEventIds: ['event-1'],
+      sourceMessageIds: ['message-1'],
+      importance: 60,
+      occurredAt: '2026-08-22T00:00:00.000Z',
+      createdAt: '2026-08-22T00:00:00.000Z',
+    },
+    relationships,
+  }
+}
+
+function directResult(butler: EmployeeInstance): ConversationResult {
+  return {
+    session: session('direct-session', 'direct'),
+    replies: [{
+      employeeId: butler.id,
+      displayName: butler.displayName,
+      agentSessionId: 'butler-agent-session',
+      content: '我已经向阿帆确认过，接口层已完成。',
+    }],
+  }
+}
+
+function message(
+  sessionId: string,
+  senderId: string,
+  content: string,
+  metadata: JsonObject,
+): WorkMessage {
+  return {
+    id: 'message-link',
+    sessionId,
+    sequence: 1,
+    senderId,
+    senderKind: 'system',
+    kind: 'system',
+    content,
+    metadata,
+    createdAt: '2026-08-22T00:00:00.000Z',
+  }
+}


### PR DESCRIPTION
## 目标

把已经完成的角色间真实协作接入用户日常对话：用户在与管家、秘书等角色的私聊中，明确要求其向 `@其他角色` 询问、确认或讨论时，系统自动执行真实角色协作，并由发起角色回到原会话汇报。

## 已实现

- 仅在“直接会话 + 明确委托语句 + 显式 @目标角色”同时满足时触发
- 支持“帮我/请你/麻烦你”等委托表达，以及询问、确认、核对、讨论、同步等协作动作
- 普通提及或没有明确 @角色时不会误触发
- 发起角色先与目标角色创建真实无用户参与的协作会话
- 协作继续使用各角色独立的模型、权限、Revision 与持久 Agent Session
- 协作结束后，发起角色依据真实发言与 `SharedWorldEpisode` 回到原私聊汇报
- 原私聊用户消息与协作会话通过 metadata 双向关联
- 最多委托 3 名角色；普通请求 1 轮，明确要求深入/追问时 2 轮
- 保留世界中的会合、思考、发言、倾听和返回岗位表现

## 安全边界

- 不允许模型直接决定坐标或目标角色
- 不允许无显式 @ 的自动扩散协作
- 不合并角色权限
- 汇报 Prompt 仅包含真实角色发言和共同经历摘要
- 禁止虚构进度、文件内容、其他角色观点和共同经历

## 验证

- `pnpm install --frozen-lockfile` ✅
- `pnpm typecheck` ✅
- 单元/集成测试：31 个文件、149 项全部通过 ✅
- Chromium E2E：11/11 通过 ✅
- 新增垂直场景：用户让管家向开发工程师确认进度，角色在世界中会合并真实发言/倾听，管家随后回到原私聊做有证据的汇报 ✅

已达到合并门禁。