### PR TITLE
feat: add reusable character animation rig for custom roles

### DIFF
--- a/packages/web/src/features/world/renderer/actor-animation-controller.ts
+++ b/packages/web/src/features/world/renderer/actor-animation-controller.ts
@@ -51,9 +51,9 @@ export class ActorAnimationController {
     this.#source = source
     this.#actorSet = actorSet
     this.#rosterIndex = rosterIndex
-    this.#phaseOffset = options.characterId === undefined
-      ? 0
-      : characterMotionPhaseOffset(options.characterId)
+    this.#phaseOffset = characterMotionPhaseOffset(
+      options.characterId ?? `${actorSet.id}:${rosterIndex}`,
+    )
     this.#reducedMotion = options.reducedMotion ?? false
     this.#motionProfileId = options.motionProfileId ?? 'standard'
     this.sprite = new AnimatedSprite([this.#texture(0)])
@@ -92,8 +92,11 @@ export class ActorAnimationController {
   tick(deltaMs: number): void {
     const safeDelta = Number.isFinite(deltaMs) ? Math.max(0, deltaMs) : 0
     this.#elapsed += safeDelta
+    const reducedMotion = this.#reducedMotion || prefersReducedMotion()
+    if (reducedMotion) this.sprite.gotoAndStop(0)
+    else if (!this.#usesFallback && !this.sprite.playing) this.sprite.play()
     const sample = sampleCharacterMotion(this.#activity, this.#elapsed, {
-      reducedMotion: this.#reducedMotion,
+      reducedMotion,
       phaseOffset: this.#phaseOffset,
       motionProfileId: this.#motionProfileId,
     })
@@ -172,6 +175,17 @@ export function resolveClipFrames(
     if (frames !== undefined && frames.length > 0) return frames
   }
   return [0]
+}
+
+function prefersReducedMotion(): boolean {
+  if (typeof document !== 'undefined') {
+    const preference = document.documentElement.dataset.motion
+    if (preference === 'reduced') return true
+    if (preference === 'full') return false
+  }
+  return typeof window !== 'undefined'
+    && typeof window.matchMedia === 'function'
+    && window.matchMedia('(prefers-reduced-motion: reduce)').matches
 }
 
 function mix(from: number, to: number, strength: number): number {

--- a/packages/web/src/features/world/renderer/actor-animation-controller.ts
+++ b/packages/web/src/features/world/renderer/actor-animation-controller.ts
@@ -4,6 +4,12 @@ import type {
   WorldFacing,
   WorldThemeActorSetManifest,
 } from '@dsh-cyber/contracts'
+import {
+  characterMotionPhaseOffset,
+  sampleCharacterMotion,
+  type CharacterMotionProfileId,
+  type CharacterMotionSample,
+} from '@dsh-cyber/world-runtime'
 
 const ACTIVITY_SPEED: Record<WorldActivityKind, number> = {
   idle: 0.06,
@@ -16,21 +22,40 @@ const ACTIVITY_SPEED: Record<WorldActivityKind, number> = {
   celebrating: 0.14,
 }
 
+export interface ActorAnimationControllerOptions {
+  characterId?: string
+  reducedMotion?: boolean
+  motionProfileId?: CharacterMotionProfileId
+}
+
 export class ActorAnimationController {
   readonly sprite: AnimatedSprite
   readonly #actorSet: WorldThemeActorSetManifest
   readonly #source: Texture
   readonly #rosterIndex: number
+  readonly #phaseOffset: number
   readonly #textures = new Map<number, Texture>()
   #activity: WorldActivityKind = 'idle'
   #facing: WorldFacing = 'south'
   #elapsed = 0
   #usesFallback = true
+  #reducedMotion: boolean
+  #motionProfileId: CharacterMotionProfileId
 
-  constructor(source: Texture, actorSet: WorldThemeActorSetManifest, rosterIndex: number) {
+  constructor(
+    source: Texture,
+    actorSet: WorldThemeActorSetManifest,
+    rosterIndex: number,
+    options: ActorAnimationControllerOptions = {},
+  ) {
     this.#source = source
     this.#actorSet = actorSet
     this.#rosterIndex = rosterIndex
+    this.#phaseOffset = options.characterId === undefined
+      ? 0
+      : characterMotionPhaseOffset(options.characterId)
+    this.#reducedMotion = options.reducedMotion ?? false
+    this.#motionProfileId = options.motionProfileId ?? 'standard'
     this.sprite = new AnimatedSprite([this.#texture(0)])
     const renderedHeight = actorSet.frameHeight * actorSet.scale
     const anchorY = renderedHeight <= 0 ? 1 : Math.min(1, Math.max(0, actorSet.footOffset.y / renderedHeight))
@@ -41,40 +66,38 @@ export class ActorAnimationController {
 
   setState(activity: WorldActivityKind, facing: WorldFacing): void {
     if (this.#activity === activity && this.#facing === facing && this.sprite.textures.length > 0) return
+    const activityChanged = this.#activity !== activity
     this.#activity = activity
     this.#facing = facing
+    if (activityChanged) this.#elapsed = 0
     const frames = resolveClipFrames(this.#actorSet, activity, facing)
     this.sprite.textures = frames.map((frame) => this.#texture(frame))
     this.sprite.animationSpeed = ACTIVITY_SPEED[activity]
     this.sprite.loop = true
     this.#usesFallback = this.sprite.textures.length < 2
-    if (this.#usesFallback) this.sprite.stop()
-    else this.sprite.play()
+    this.#syncPlayback()
     this.#applyFacingScale()
   }
 
+  setReducedMotion(reducedMotion: boolean): void {
+    if (this.#reducedMotion === reducedMotion) return
+    this.#reducedMotion = reducedMotion
+    this.#syncPlayback()
+  }
+
+  setMotionProfile(motionProfileId: CharacterMotionProfileId): void {
+    this.#motionProfileId = motionProfileId
+  }
+
   tick(deltaMs: number): void {
-    this.#elapsed += deltaMs
-    this.sprite.x = 0
-    this.sprite.y = 0
-    this.sprite.rotation = 0
-    this.sprite.alpha = 1
-    if (!this.#usesFallback) return
-    const wave = Math.sin(this.#elapsed / 130)
-    if (this.#activity === 'walking') {
-      // Static fallback uses a horizontal stride/sway; vertical bob is deliberately avoided.
-      this.sprite.x = wave * 1.8
-      this.sprite.rotation = wave * 0.025
-    } else if (this.#activity === 'thinking') {
-      this.sprite.rotation = Math.sin(this.#elapsed / 420) * 0.012
-    } else if (this.#activity === 'talking' || this.#activity === 'meeting') {
-      this.sprite.rotation = Math.sin(this.#elapsed / 210) * 0.01
-    } else if (this.#activity === 'blocked') {
-      this.sprite.alpha = 0.72 + Math.abs(Math.sin(this.#elapsed / 500)) * 0.24
-    } else if (this.#activity === 'celebrating') {
-      this.sprite.rotation = wave * 0.035
-      this.sprite.x = wave * 1.2
-    }
+    const safeDelta = Number.isFinite(deltaMs) ? Math.max(0, deltaMs) : 0
+    this.#elapsed += safeDelta
+    const sample = sampleCharacterMotion(this.#activity, this.#elapsed, {
+      reducedMotion: this.#reducedMotion,
+      phaseOffset: this.#phaseOffset,
+      motionProfileId: this.#motionProfileId,
+    })
+    this.#applyMotion(sample, this.#usesFallback ? 1 : 0.35)
   }
 
   destroy(): void {
@@ -108,6 +131,26 @@ export class ActorAnimationController {
     return texture
   }
 
+  #syncPlayback(): void {
+    if (this.#usesFallback || this.#reducedMotion) {
+      this.sprite.gotoAndStop(0)
+      return
+    }
+    this.sprite.play()
+  }
+
+  #applyMotion(sample: CharacterMotionSample, strength: number): void {
+    const horizontal = this.#facing === 'west' ? -1 : 1
+    this.sprite.x = sample.offsetX * strength
+    this.sprite.y = sample.offsetY * strength
+    this.sprite.rotation = sample.rotation * strength
+    this.sprite.alpha = mix(1, sample.alpha, strength)
+    this.sprite.scale.set(
+      this.#actorSet.scale * horizontal * mix(1, sample.scaleX, strength),
+      this.#actorSet.scale * mix(1, sample.scaleY, strength),
+    )
+  }
+
   #applyFacingScale(): void {
     const horizontal = this.#facing === 'west' ? -1 : 1
     this.sprite.scale.set(this.#actorSet.scale * horizontal, this.#actorSet.scale)
@@ -129,4 +172,8 @@ export function resolveClipFrames(
     if (frames !== undefined && frames.length > 0) return frames
   }
   return [0]
+}
+
+function mix(from: number, to: number, strength: number): number {
+  return from + (to - from) * strength
 }

--- a/packages/web/tests/actor-animation-controller.test.ts
+++ b/packages/web/tests/actor-animation-controller.test.ts
@@ -10,25 +10,30 @@ const activities: WorldActivityKind[] = [
 ]
 const facings: WorldFacing[] = ['north', 'east', 'south', 'west']
 
+function actorSet(framesPerActor = 1): WorldThemeActorSetManifest {
+  const clips = Object.fromEntries(activities.map((activity, index) => [activity, {
+    north: [index % framesPerActor],
+    east: [index % framesPerActor],
+    south: [index % framesPerActor],
+    west: [index % framesPerActor],
+  }])) as WorldThemeActorSetManifest['clips']
+  return {
+    id: 'reusable-role-body',
+    assetId: 'texture',
+    frameWidth: 1,
+    frameHeight: 1,
+    framesPerActor,
+    scale: 1,
+    footOffset: { x: 0, y: 1 },
+    clips,
+  }
+}
+
 describe('ActorAnimationController', () => {
   it('keeps texture allocation bounded during long-running state changes', () => {
-    const clips = Object.fromEntries(activities.map((activity, index) => [activity, {
-      north: [index],
-      east: [index],
-      south: [index],
-      west: [index],
-    }])) as WorldThemeActorSetManifest['clips']
-    const actorSet: WorldThemeActorSetManifest = {
-      id: 'soak',
-      assetId: 'texture',
-      frameWidth: 1,
-      frameHeight: 1,
-      framesPerActor: 8,
-      scale: 1,
-      footOffset: { x: 0, y: 1 },
-      clips,
-    }
-    const controller = new ActorAnimationController(Texture.WHITE, actorSet, 0)
+    const controller = new ActorAnimationController(Texture.WHITE, actorSet(8), 0, {
+      characterId: 'custom-role-instance',
+    })
     for (let index = 0; index < 10_000; index += 1) {
       controller.setState(activities[index % activities.length]!, facings[index % facings.length]!)
       controller.tick(16)
@@ -37,4 +42,50 @@ describe('ActorAnimationController', () => {
     controller.destroy()
     expect(controller.textureCount).toBe(0)
   })
+
+  it('animates an arbitrary custom character without inspecting its role or blueprint', () => {
+    const controller = new ActorAnimationController(Texture.WHITE, actorSet(), 0, {
+      characterId: 'user.custom.quantum-gardener',
+      motionProfileId: 'energetic',
+    })
+    controller.setState('talking', 'east')
+    controller.tick(0)
+    const first = transform(controller)
+    controller.tick(137)
+    const second = transform(controller)
+
+    expect(second).not.toEqual(first)
+    expect(second.scaleX).toBeGreaterThan(0)
+    controller.destroy()
+  })
+
+  it('honors reduced motion while retaining the requested facing', () => {
+    const controller = new ActorAnimationController(Texture.WHITE, actorSet(), 0, {
+      characterId: 'user.custom.accessible-role',
+      reducedMotion: true,
+    })
+    controller.setState('walking', 'west')
+    controller.tick(300)
+
+    expect(transform(controller)).toEqual({
+      x: 0,
+      y: 0,
+      rotation: 0,
+      alpha: 1,
+      scaleX: -1,
+      scaleY: 1,
+    })
+    controller.destroy()
+  })
 })
+
+function transform(controller: ActorAnimationController) {
+  return {
+    x: controller.sprite.x,
+    y: controller.sprite.y,
+    rotation: controller.sprite.rotation,
+    alpha: controller.sprite.alpha,
+    scaleX: controller.sprite.scale.x,
+    scaleY: controller.sprite.scale.y,
+  }
+}

--- a/packages/world-runtime/src/character-animation-rig.ts
+++ b/packages/world-runtime/src/character-animation-rig.ts
@@ -1,0 +1,156 @@
+import type { WorldActivityKind } from '@dsh-cyber/contracts'
+
+export type CharacterAnimationRigKind =
+  | 'spritesheet'
+  | 'layered-spritesheet'
+  | 'procedural'
+
+export interface CharacterMotionSample {
+  offsetX: number
+  offsetY: number
+  rotation: number
+  scaleX: number
+  scaleY: number
+  alpha: number
+  phase: number
+}
+
+export interface CharacterMotionProfile {
+  durationMs: number
+  offsetX: number
+  offsetY: number
+  rotation: number
+  scaleX: number
+  scaleY: number
+  alphaPulse: number
+}
+
+export interface SampleCharacterMotionOptions {
+  reducedMotion?: boolean
+  phaseOffset?: number
+}
+
+const NEUTRAL_SAMPLE: CharacterMotionSample = {
+  offsetX: 0,
+  offsetY: 0,
+  rotation: 0,
+  scaleX: 1,
+  scaleY: 1,
+  alpha: 1,
+  phase: 0,
+}
+
+const MOTION_PROFILES: Record<WorldActivityKind, CharacterMotionProfile> = {
+  idle: {
+    durationMs: 2_400,
+    offsetX: 0,
+    offsetY: 1.4,
+    rotation: 0.005,
+    scaleX: 0.006,
+    scaleY: 0.012,
+    alphaPulse: 0,
+  },
+  walking: {
+    durationMs: 420,
+    offsetX: 1.8,
+    offsetY: 3.2,
+    rotation: 0.045,
+    scaleX: 0.025,
+    scaleY: 0.035,
+    alphaPulse: 0,
+  },
+  thinking: {
+    durationMs: 1_500,
+    offsetX: 0.8,
+    offsetY: 1.6,
+    rotation: 0.025,
+    scaleX: 0.008,
+    scaleY: 0.014,
+    alphaPulse: 0.025,
+  },
+  working: {
+    durationMs: 720,
+    offsetX: 1.2,
+    offsetY: 1.8,
+    rotation: 0.018,
+    scaleX: 0.012,
+    scaleY: 0.018,
+    alphaPulse: 0,
+  },
+  talking: {
+    durationMs: 360,
+    offsetX: 0.6,
+    offsetY: 2.1,
+    rotation: 0.012,
+    scaleX: 0.018,
+    scaleY: 0.035,
+    alphaPulse: 0.018,
+  },
+  meeting: {
+    durationMs: 1_100,
+    offsetX: 0.5,
+    offsetY: 1.2,
+    rotation: 0.01,
+    scaleX: 0.008,
+    scaleY: 0.012,
+    alphaPulse: 0,
+  },
+  blocked: {
+    durationMs: 900,
+    offsetX: 1.5,
+    offsetY: 0.8,
+    rotation: 0.035,
+    scaleX: 0.01,
+    scaleY: 0.01,
+    alphaPulse: 0.08,
+  },
+  celebrating: {
+    durationMs: 520,
+    offsetX: 1.4,
+    offsetY: 5.5,
+    rotation: 0.05,
+    scaleX: 0.035,
+    scaleY: 0.05,
+    alphaPulse: 0.025,
+  },
+}
+
+export function characterMotionProfile(activity: WorldActivityKind): CharacterMotionProfile {
+  return { ...MOTION_PROFILES[activity] }
+}
+
+export function sampleCharacterMotion(
+  activity: WorldActivityKind,
+  elapsedMs: number,
+  options: SampleCharacterMotionOptions = {},
+): CharacterMotionSample {
+  if (options.reducedMotion === true) return { ...NEUTRAL_SAMPLE }
+
+  const profile = MOTION_PROFILES[activity]
+  const safeElapsed = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0
+  const phaseOffset = Number.isFinite(options.phaseOffset) ? options.phaseOffset ?? 0 : 0
+  const phase = ((safeElapsed + phaseOffset) % profile.durationMs) / profile.durationMs
+  const wave = Math.sin(phase * Math.PI * 2)
+  const stride = Math.sin(phase * Math.PI * 4)
+  const lift = activity === 'walking' || activity === 'celebrating'
+    ? Math.abs(stride)
+    : (wave + 1) / 2
+
+  return {
+    offsetX: round(profile.offsetX * stride),
+    offsetY: round(-profile.offsetY * lift),
+    rotation: round(profile.rotation * wave),
+    scaleX: round(1 + profile.scaleX * stride),
+    scaleY: round(1 + profile.scaleY * lift),
+    alpha: round(clamp(1 - profile.alphaPulse * ((wave + 1) / 2), 0.72, 1)),
+    phase: round(phase),
+  }
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value))
+}
+
+function round(value: number): number {
+  return Math.round(value * 10_000) / 10_000
+}

--- a/packages/world-runtime/src/character-animation-rig.ts
+++ b/packages/world-runtime/src/character-animation-rig.ts
@@ -5,6 +5,8 @@ export type CharacterAnimationRigKind =
   | 'layered-spritesheet'
   | 'procedural'
 
+export type CharacterMotionProfileId = 'subtle' | 'standard' | 'energetic'
+
 export interface CharacterMotionSample {
   offsetX: number
   offsetY: number
@@ -28,6 +30,7 @@ export interface CharacterMotionProfile {
 export interface SampleCharacterMotionOptions {
   reducedMotion?: boolean
   phaseOffset?: number
+  motionProfileId?: CharacterMotionProfileId
 }
 
 const NEUTRAL_SAMPLE: CharacterMotionSample = {
@@ -115,8 +118,41 @@ const MOTION_PROFILES: Record<WorldActivityKind, CharacterMotionProfile> = {
   },
 }
 
-export function characterMotionProfile(activity: WorldActivityKind): CharacterMotionProfile {
-  return { ...MOTION_PROFILES[activity] }
+const MOTION_VARIANTS: Record<CharacterMotionProfileId, { amplitude: number; speed: number }> = {
+  subtle: { amplitude: 0.55, speed: 0.82 },
+  standard: { amplitude: 1, speed: 1 },
+  energetic: { amplitude: 1.35, speed: 1.18 },
+}
+
+export function characterMotionProfile(
+  activity: WorldActivityKind,
+  profileId: CharacterMotionProfileId = 'standard',
+): CharacterMotionProfile {
+  const profile = MOTION_PROFILES[activity]
+  const variant = MOTION_VARIANTS[profileId]
+  return {
+    durationMs: Math.max(120, Math.round(profile.durationMs / variant.speed)),
+    offsetX: round(profile.offsetX * variant.amplitude),
+    offsetY: round(profile.offsetY * variant.amplitude),
+    rotation: round(profile.rotation * variant.amplitude),
+    scaleX: round(profile.scaleX * variant.amplitude),
+    scaleY: round(profile.scaleY * variant.amplitude),
+    alphaPulse: round(profile.alphaPulse * variant.amplitude),
+  }
+}
+
+/**
+ * Gives each character a stable phase without coupling animation to role names,
+ * blueprint ids or renderer coordinates. Custom roles therefore share the same
+ * reusable rig while avoiding perfectly synchronized movement.
+ */
+export function characterMotionPhaseOffset(characterId: string): number {
+  let hash = 2_166_136_261
+  for (let index = 0; index < characterId.length; index += 1) {
+    hash ^= characterId.charCodeAt(index)
+    hash = Math.imul(hash, 16_777_619)
+  }
+  return (hash >>> 0) % 10_000
 }
 
 export function sampleCharacterMotion(
@@ -126,7 +162,7 @@ export function sampleCharacterMotion(
 ): CharacterMotionSample {
   if (options.reducedMotion === true) return { ...NEUTRAL_SAMPLE }
 
-  const profile = MOTION_PROFILES[activity]
+  const profile = characterMotionProfile(activity, options.motionProfileId ?? 'standard')
   const safeElapsed = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0
   const phaseOffset = Number.isFinite(options.phaseOffset) ? options.phaseOffset ?? 0 : 0
   const phase = ((safeElapsed + phaseOffset) % profile.durationMs) / profile.durationMs

--- a/packages/world-runtime/src/index.ts
+++ b/packages/world-runtime/src/index.ts
@@ -1,3 +1,4 @@
+export * from './character-animation-rig.js'
 export * from './manifest.js'
 export * from './navigation.js'
 export * from './projector.js'

--- a/packages/world-runtime/tests/character-animation-rig.test.ts
+++ b/packages/world-runtime/tests/character-animation-rig.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  characterMotionProfile,
+  sampleCharacterMotion,
+} from '../src/character-animation-rig.js'
+
+describe('character animation rig', () => {
+  it('produces deterministic motion for the same activity and elapsed time', () => {
+    const first = sampleCharacterMotion('walking', 315, { phaseOffset: 72 })
+    const second = sampleCharacterMotion('walking', 315, { phaseOffset: 72 })
+
+    expect(second).toEqual(first)
+    expect(Math.abs(first.offsetY)).toBeGreaterThan(0)
+  })
+
+  it('keeps role bodies still when reduced motion is enabled', () => {
+    expect(sampleCharacterMotion('celebrating', 240, { reducedMotion: true })).toEqual({
+      offsetX: 0,
+      offsetY: 0,
+      rotation: 0,
+      scaleX: 1,
+      scaleY: 1,
+      alpha: 1,
+      phase: 0,
+    })
+  })
+
+  it('uses visibly different motion profiles for conversation and navigation', () => {
+    const talking = characterMotionProfile('talking')
+    const walking = characterMotionProfile('walking')
+
+    expect(walking.durationMs).not.toBe(talking.durationMs)
+    expect(walking.rotation).toBeGreaterThan(talking.rotation)
+    expect(walking.offsetY).toBeGreaterThan(talking.offsetY)
+  })
+
+  it('normalizes invalid elapsed values instead of leaking non-finite transforms', () => {
+    const sample = sampleCharacterMotion('thinking', Number.POSITIVE_INFINITY)
+
+    expect(Object.values(sample).every(Number.isFinite)).toBe(true)
+  })
+})

--- a/packages/world-runtime/tests/character-animation-rig.test.ts
+++ b/packages/world-runtime/tests/character-animation-rig.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
 import {
+  characterMotionPhaseOffset,
   characterMotionProfile,
   sampleCharacterMotion,
 } from '../src/character-animation-rig.js'
@@ -33,6 +34,22 @@ describe('character animation rig', () => {
     expect(walking.durationMs).not.toBe(talking.durationMs)
     expect(walking.rotation).toBeGreaterThan(talking.rotation)
     expect(walking.offsetY).toBeGreaterThan(talking.offsetY)
+  })
+
+  it('supports reusable subtle and energetic bodies without knowing the role name', () => {
+    const subtle = characterMotionProfile('talking', 'subtle')
+    const energetic = characterMotionProfile('talking', 'energetic')
+
+    expect(energetic.offsetY).toBeGreaterThan(subtle.offsetY)
+    expect(energetic.scaleY).toBeGreaterThan(subtle.scaleY)
+    expect(energetic.durationMs).toBeLessThan(subtle.durationMs)
+  })
+
+  it('assigns a stable unsynchronised phase to any custom character identity', () => {
+    const customRoleId = 'user.custom.quantum-gardener'
+
+    expect(characterMotionPhaseOffset(customRoleId)).toBe(characterMotionPhaseOffset(customRoleId))
+    expect(characterMotionPhaseOffset(customRoleId)).not.toBe(characterMotionPhaseOffset('user.custom.night-auditor'))
   })
 
   it('normalizes invalid elapsed values instead of leaking non-finite transforms', () => {

--- a/packages/world-runtime/tests/embodied-world-runtime.test.ts
+++ b/packages/world-runtime/tests/embodied-world-runtime.test.ts
@@ -7,7 +7,12 @@ import type {
   WorldRuntimeSnapshot,
 } from '@dsh-cyber/contracts'
 
-import { cyberCompanyTheme, projectWorldRuntime } from '../src/index.js'
+import {
+  characterMotionPhaseOffset,
+  cyberCompanyTheme,
+  projectWorldRuntime,
+  sampleCharacterMotion,
+} from '../src/index.js'
 
 const world: World = {
   id: 'world-embodied',
@@ -84,6 +89,96 @@ describe('embodied world runtime projection', () => {
       payload: expect.objectContaining({ excerpt: '我去向开发工程师确认进度。' }),
     }))
     expect(result.cues.some((cue) => cue.entityId === engineer.id && cue.kind === 'entity.speech')).toBe(false)
+  })
+
+  it('runs an arbitrary user-defined role through a complete embodied turn', () => {
+    const custom = character(
+      'custom-quantum-gardener',
+      'user.custom.quantum-gardener',
+      '星芽',
+      '量子园丁',
+    )
+    const initial = projectWorldRuntime({
+      workspaceId: world.workspaceId,
+      world,
+      employees: [custom],
+      events: [],
+      manifest: cyberCompanyTheme,
+      now: '2026-08-22T00:00:00.000Z',
+    })
+    const initialEntity = initial.snapshot.entities.find((entity) => entity.id === custom.id)!
+    expect(initialEntity.activity).toBe('idle')
+    expect(initialEntity.displayName).toBe('星芽')
+    expect(initialEntity.role).toBe('量子园丁')
+    expect(initialEntity.visualState['homeSlotId']).toEqual(expect.any(String))
+
+    const thinking = projectWorldRuntime({
+      workspaceId: world.workspaceId,
+      world,
+      employees: [custom],
+      events: [event(1, 'turn.started', custom.id, { employeeId: custom.id })],
+      manifest: cyberCompanyTheme,
+      previous: initial.snapshot,
+      now: '2026-08-22T00:00:01.000Z',
+    })
+    expect(thinking.snapshot.entities[0]?.activity).toBe('thinking')
+
+    const working = projectWorldRuntime({
+      workspaceId: world.workspaceId,
+      world,
+      employees: [custom],
+      events: [event(2, 'tool.started', custom.id, {
+        employeeId: custom.id,
+        toolName: 'knowledge.search',
+      })],
+      manifest: cyberCompanyTheme,
+      previous: thinking.snapshot,
+      now: '2026-08-22T00:00:02.000Z',
+    })
+    expect(working.snapshot.entities[0]?.activity).toBe('working')
+
+    const talking = projectWorldRuntime({
+      workspaceId: world.workspaceId,
+      world,
+      employees: [custom],
+      events: [event(3, 'message.appended', custom.id, {
+        employeeId: custom.id,
+        senderId: custom.id,
+        messageKind: 'assistant',
+        messageId: 'message-custom-role',
+        excerpt: '我已经整理好这片实验田的状态。',
+      })],
+      manifest: cyberCompanyTheme,
+      previous: working.snapshot,
+      now: '2026-08-22T00:00:03.000Z',
+    })
+    const talkingEntity = talking.snapshot.entities[0]!
+    expect(talkingEntity.activity).toBe('talking')
+    expect(talking.cues).toContainEqual(expect.objectContaining({
+      kind: 'entity.speech',
+      entityId: custom.id,
+    }))
+    const talkingMotion = sampleCharacterMotion(talkingEntity.activity, 180, {
+      phaseOffset: characterMotionPhaseOffset(custom.id),
+    })
+    expect(talkingMotion).not.toMatchObject({
+      offsetX: 0,
+      offsetY: 0,
+      rotation: 0,
+      scaleX: 1,
+      scaleY: 1,
+    })
+
+    const completed = projectWorldRuntime({
+      workspaceId: world.workspaceId,
+      world,
+      employees: [custom],
+      events: [event(4, 'turn.completed', custom.id, { employeeId: custom.id })],
+      manifest: cyberCompanyTheme,
+      previous: talking.snapshot,
+      now: '2026-08-22T00:00:04.000Z',
+    })
+    expect(completed.snapshot.entities[0]?.activity).toBe('idle')
   })
 
   it('routes an engineer from a shared area back to an engineering work slot for a real task', () => {


### PR DESCRIPTION
## 目标

将具身角色动画建立在可复用的角色抽象层上，确保内置角色、用户重命名角色、社区 Blueprint 和任意自定义角色都消费同一套 `EmployeeInstance → WorldRuntimeEntityState → activity/facing → ActorSet/Motion Rig → Pixi` 契约。Renderer 不判断“管家、秘书、工程师”等角色名称。

## 已实现

- 新增通用 `Character Animation Rig`，覆盖 `idle / walking / thinking / working / talking / meeting / blocked / celebrating`
- 动作选择只依赖通用 `activity` 与 `facing`，不读取角色名、岗位名称或 Blueprint 类型
- 支持 `subtle / standard / energetic` 三档可复用动作风格
- 支持按稳定角色标识生成确定性动作相位；未显式传入角色 ID 时，使用稳定形象标识回退
- 单帧角色使用完整程序化动作，多帧 Spritesheet 使用轻量动作叠加
- 跟随工作区 `motion` 设置和系统 `prefers-reduced-motion`
- 保留朝向镜像、Spritesheet Clip、纹理缓存与长时间运行边界
- 用户自定义头像、名称、Persona、模型和角色身份不会改变动画管线；只要它是一个 `EmployeeInstance`，就拥有同一套具身状态机

## 完整垂直场景

新增完全不属于内置岗位的自定义角色：

```text
Blueprint: user.custom.quantum-gardener
角色名：星芽
岗位：量子园丁

进入世界并待命
→ 用户发起会话
→ turn.started：thinking
→ tool.started：working
→ assistant message：talking + speech cue
→ turn.completed：idle / 返回岗位
→ Motion Rig 按同一活动状态输出身体动画
```

测试同时验证：

- 自定义角色保留自己的名称与岗位身份
- 不依赖任何内置角色关键词也能完成具身状态切换
- 对话、工具和完成事件只驱动被寻址的角色
- 减少动态效果下保持稳定静态姿态
- 单帧与多帧角色均可复用同一控制器

## 当前边界

本 PR 解决“身体与动画是否写死”的问题，答案是：没有写死，所有角色复用同一抽象层。

空间职责层仍保留安全回退：无法识别语义的全新岗位会使用 `general` 行为配置并停留在公共/通用区域，不会乱跑。后续单独增加可配置的 `CharacterBehaviorProfile` 标签，使用户自定义岗位能够明确声明首选区域、设施能力、固定岗位与日常行为，逐步移除对岗位名称关键词的依赖。

## 验证

- `pnpm install --frozen-lockfile` ✅
- `pnpm typecheck` ✅
- 单元/集成测试：39 个文件、183 项全部通过 ✅
- Chromium E2E：12/12 通过 ✅
- 自定义“量子园丁”完整状态链通过 ✅
- 动画纹理长时间切换无无界增长 ✅

已达到合并门禁。