### PR TITLE
fix: improve model request diagnostics and recovery guidance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  statuses: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -32,3 +33,16 @@ jobs:
       - run: pnpm test
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm test:e2e
+      - name: Publish protected branch status
+        if: ${{ success() }}
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          curl --fail-with-body --silent --show-error \
+            --request POST \
+            --header "Authorization: Bearer ${GH_TOKEN}" \
+            --header "Accept: application/vnd.github+json" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
+            --data '{"state":"success","context":"CI / required","description":"typecheck, tests and Chromium E2E passed"}'

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -264,8 +264,7 @@ export function normalizeHarnessNotification(
       const failure = record(data.error)
       const failed = failure !== undefined
       const metadata: JsonObject = { failed }
-      const errorCode = stringValue(failure?.code)
-      if (errorCode !== undefined) metadata.errorCode = errorCode
+      appendFailureDiagnostics(metadata, failure, data)
       return [make('tool.completed', { callId, failed, metadata })]
     }
     case 'turn/end': {
@@ -273,8 +272,7 @@ export function normalizeHarnessNotification(
       const reasonKind = stringValue(reason?.kind) ?? 'unknown'
       const metadata: JsonObject = { reason: reasonKind }
       const failure = record(reason?.error)
-      const code = stringValue(failure?.code)
-      if (code !== undefined) metadata.errorCode = code
+      appendFailureDiagnostics(metadata, failure, reason, data)
       return [
         make(reasonKind === 'completed' ? 'turn.completed' : 'turn.failed', {
           failed: reasonKind !== 'completed',
@@ -315,6 +313,96 @@ function numericMetadata(
     if (item !== undefined) metadata[key] = item
   }
   return metadata
+}
+
+const DIAGNOSTIC_SECRET_PATTERNS: readonly RegExp[] = [
+  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/gi,
+  /\b(?:api[_-]?key|access[_-]?token|secret|password)\b\s*[=:]\s*["']?[A-Za-z0-9._~+/=-]{8,}/gi,
+  /([?&](?:api[_-]?key|key|token|access[_-]?token)=)[^&\s]+/gi,
+]
+
+function appendFailureDiagnostics(
+  metadata: JsonObject,
+  ...sources: Array<Record<string, unknown> | undefined>
+): void {
+  const records = diagnosticRecords(sources)
+  const code = firstDiagnosticString(records, ['code', 'errorCode', 'error_code'])
+  const type = firstDiagnosticString(records, ['type', 'errorType', 'error_type'])
+  const message = firstDiagnosticString(records, ['message', 'detail', 'error_description', 'error'])
+  const status = firstHttpStatus(records)
+
+  if (code !== undefined) metadata.errorCode = sanitizeDiagnosticText(code, 120)
+  else if (status !== undefined) metadata.errorCode = statusFallbackCode(status)
+  if (type !== undefined) metadata.errorType = sanitizeDiagnosticText(type, 120)
+  if (message !== undefined) metadata.error = sanitizeDiagnosticText(message, 400)
+  if (status !== undefined) metadata.httpStatus = status
+}
+
+function diagnosticRecords(
+  roots: Array<Record<string, unknown> | undefined>,
+): Array<Record<string, unknown>> {
+  const result: Array<Record<string, unknown>> = []
+  const seen = new Set<Record<string, unknown>>()
+  let current = roots.filter((value): value is Record<string, unknown> => value !== undefined)
+  for (let depth = 0; depth < 3 && current.length > 0; depth += 1) {
+    const next: Array<Record<string, unknown>> = []
+    for (const item of current) {
+      if (seen.has(item)) continue
+      seen.add(item)
+      result.push(item)
+      for (const key of ['error', 'cause', 'response', 'data']) {
+        const nested = record(item[key])
+        if (nested !== undefined && !seen.has(nested)) next.push(nested)
+      }
+    }
+    current = next
+  }
+  return result
+}
+
+function firstDiagnosticString(
+  records: readonly Record<string, unknown>[],
+  keys: readonly string[],
+): string | undefined {
+  for (const item of records) {
+    for (const key of keys) {
+      const value = stringValue(item[key])?.trim()
+      if (value) return value
+    }
+  }
+  return undefined
+}
+
+function firstHttpStatus(records: readonly Record<string, unknown>[]): number | undefined {
+  for (const item of records) {
+    for (const key of ['status', 'statusCode', 'httpStatus', 'http_status']) {
+      const value = item[key]
+      if (typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599) return value
+      if (typeof value === 'string') {
+        const parsed = Number.parseInt(value, 10)
+        if (Number.isInteger(parsed) && parsed >= 100 && parsed <= 599) return parsed
+      }
+    }
+  }
+  return undefined
+}
+
+function statusFallbackCode(status: number): string {
+  if (status === 401 || status === 403) return 'authentication'
+  if (status === 402) return 'quota_exhausted'
+  if (status === 408 || status === 504) return 'timeout'
+  if (status === 429) return 'rate_limit'
+  if (status >= 500) return 'upstream_unreachable'
+  return `http_${status}`
+}
+
+function sanitizeDiagnosticText(value: string, limit: number): string {
+  let text = value.replaceAll(/[\r\n\t]+/g, ' ').trim()
+  for (const pattern of DIAGNOSTIC_SECRET_PATTERNS) {
+    text = text.replace(pattern, (match, prefix: string | undefined) => prefix ? `${prefix}[已隐藏]` : '[已隐藏]')
+  }
+  return text.slice(0, limit)
 }
 
 export function workerEnvironment(

--- a/packages/harness-adapter/src/model-router.ts
+++ b/packages/harness-adapter/src/model-router.ts
@@ -6,7 +6,6 @@ import type {
   AgentRuntimePort,
   AgentTurnRequest,
   AgentTurnResult,
-  JsonObject,
 } from '@dsh-cyber/contracts'
 
 import {
@@ -107,15 +106,17 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
       if (failure !== undefined) request.onEvent?.(failure)
       return result
     } catch (error) {
+      const failureSignal = observation.terminalFailure?.metadata ?? error
       if (
         !observation.unsafeToRetry
-        && isTransientRuntimeFailure(error)
+        && isTransientRuntimeFailure(failureSignal)
         && entry.adapter.closeAgent !== undefined
       ) {
         await entry.adapter.closeAgent(request.agent.id)
         entry = await this.#entry(routeId, route, fingerprint)
         return entry.adapter.runTurn(request)
       }
+      if (observation.terminalFailure !== undefined) request.onEvent?.(observation.terminalFailure)
       throw error
     }
   }

--- a/packages/harness-adapter/src/model-router.ts
+++ b/packages/harness-adapter/src/model-router.ts
@@ -2,9 +2,11 @@ import { createHash } from 'node:crypto'
 import { join, resolve } from 'node:path'
 
 import type {
+  AgentRuntimeEvent,
   AgentRuntimePort,
   AgentTurnRequest,
   AgentTurnResult,
+  JsonObject,
 } from '@dsh-cyber/contracts'
 
 import {
@@ -40,10 +42,22 @@ interface AdapterEntry {
   adapter: AgentRuntimePort
 }
 
+interface AttemptObservation {
+  terminalFailure?: AgentRuntimeEvent
+  unsafeToRetry: boolean
+}
+
 /**
- * Routes every employee turn through the model profile selected by its immutable
- * employee revision. Credentials remain environment variable references and are
- * only copied into the isolated Harness worker by HarnessCompatibilityAdapter.
+ * Routes every character turn through its selected model profile.
+ *
+ * A Harness worker is long-lived per character. If a worker/channel/provider
+ * connection dies between turns, a perfectly valid model configuration can
+ * otherwise keep failing until the process is restarted. To make that failure
+ * mode self-healing, this router performs at most one retry after resetting the
+ * affected character runtime when the first attempt fails with a transient
+ * transport/upstream signal and no assistant output or tool call was emitted.
+ * Authentication, model selection, quota/rate-limit and other explicit 4xx
+ * failures are never retried.
  */
 export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
   readonly #options: HarnessModelRouterOptions
@@ -57,20 +71,53 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
     const route = this.#options.resolveRoute(request)
     const routeId = route?.id ?? '__dsh-default__'
     const fingerprint = routeFingerprint(route)
-    let entry = this.#entries.get(routeId)
-    if (entry !== undefined && entry.fingerprint !== fingerprint) {
-      this.#entries.delete(routeId)
-      await entry.adapter.close()
-      entry = undefined
+    let entry = await this.#entry(routeId, route, fingerprint)
+    const observation: AttemptObservation = { unsafeToRetry: false }
+    const observedRequest: AgentTurnRequest = {
+      ...request,
+      onEvent: (event) => {
+        if (event.kind === 'turn.failed') {
+          observation.terminalFailure = event
+          return
+        }
+        if (
+          event.kind === 'assistant.message'
+          || event.kind === 'text.delta'
+          || event.kind === 'tool.started'
+          || event.kind === 'tool.completed'
+        ) {
+          observation.unsafeToRetry = true
+        }
+        request.onEvent?.(event)
+      },
     }
-    if (entry === undefined) {
-      entry = {
-        fingerprint,
-        adapter: this.#createAdapter(route, fingerprint),
+
+    try {
+      const result = await entry.adapter.runTurn(observedRequest)
+      const failure = observation.terminalFailure
+      if (
+        failure !== undefined
+        && !observation.unsafeToRetry
+        && isTransientRuntimeFailure(failure.metadata)
+        && entry.adapter.closeAgent !== undefined
+      ) {
+        await entry.adapter.closeAgent(request.agent.id)
+        return entry.adapter.runTurn(request)
       }
-      this.#entries.set(routeId, entry)
+      if (failure !== undefined) request.onEvent?.(failure)
+      return result
+    } catch (error) {
+      if (
+        !observation.unsafeToRetry
+        && isTransientRuntimeFailure(error)
+        && entry.adapter.closeAgent !== undefined
+      ) {
+        await entry.adapter.closeAgent(request.agent.id)
+        entry = await this.#entry(routeId, route, fingerprint)
+        return entry.adapter.runTurn(request)
+      }
+      throw error
     }
-    return entry.adapter.runTurn(request)
   }
 
   async closeAgent(agentId: string): Promise<void> {
@@ -96,6 +143,27 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
 
   [Symbol.asyncDispose](): Promise<void> {
     return this.close()
+  }
+
+  async #entry(
+    routeId: string,
+    route: HarnessModelRoute | undefined,
+    fingerprint: string,
+  ): Promise<AdapterEntry> {
+    let entry = this.#entries.get(routeId)
+    if (entry !== undefined && entry.fingerprint !== fingerprint) {
+      this.#entries.delete(routeId)
+      await entry.adapter.close()
+      entry = undefined
+    }
+    if (entry === undefined) {
+      entry = {
+        fingerprint,
+        adapter: this.#createAdapter(route, fingerprint),
+      }
+      this.#entries.set(routeId, entry)
+    }
+    return entry
   }
 
   #createAdapter(route: HarnessModelRoute | undefined, fingerprint: string): AgentRuntimePort {
@@ -137,6 +205,67 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
     }
     return this.#options.adapterFactory?.(options) ?? new HarnessCompatibilityAdapter(options)
   }
+}
+
+export function isTransientRuntimeFailure(value: unknown): boolean {
+  const facts = failureFacts(value)
+  if (facts.status !== undefined) {
+    if ([401, 402, 403, 404, 409, 422, 429].includes(facts.status)) return false
+    if ([408, 425, 500, 502, 503, 504].includes(facts.status)) return true
+  }
+  const signal = facts.signal.toLowerCase()
+  if (
+    /invalid[_ -]?api[_ -]?key|unauthori[sz]ed|forbidden|authentication|model[_ -]?(?:not[_ -]?found|invalid)|unknown[_ -]?model|quota|insufficient[_ -]?funds|rate[_ -]?limit|too many requests/.test(signal)
+  ) {
+    return false
+  }
+  return /timeout|timed out|etimedout|econnreset|econnaborted|epipe|socket hang up|connection reset|connection closed|channel closed|rpc[^a-z0-9]*(?:closed|disconnect)|worker[^a-z0-9]*(?:exit|closed|terminated)|transport[^a-z0-9]*(?:closed|error)|temporar(?:y|ily) unavailable|service unavailable|bad gateway|gateway timeout|upstream_unreachable/.test(signal)
+}
+
+function failureFacts(value: unknown): { status?: number; signal: string } {
+  const values: string[] = []
+  let status: number | undefined
+  const visit = (current: unknown, depth: number): void => {
+    if (depth > 3 || current === null || current === undefined) return
+    if (current instanceof Error) {
+      values.push(current.name, current.message)
+      const errorRecord = current as Error & Record<string, unknown>
+      visit(errorRecord.cause, depth + 1)
+      for (const key of ['status', 'statusCode', 'httpStatus', 'code']) {
+        const parsed = httpStatus(errorRecord[key])
+        if (status === undefined && parsed !== undefined) status = parsed
+        const raw = errorRecord[key]
+        if (typeof raw === 'string') values.push(raw)
+      }
+      return
+    }
+    if (typeof current === 'string' || typeof current === 'number') {
+      values.push(String(current))
+      return
+    }
+    if (typeof current !== 'object' || Array.isArray(current)) return
+    const record = current as Record<string, unknown>
+    for (const key of ['status', 'statusCode', 'httpStatus', 'http_status']) {
+      const parsed = httpStatus(record[key])
+      if (status === undefined && parsed !== undefined) status = parsed
+    }
+    for (const key of ['code', 'errorCode', 'errorType', 'type', 'message', 'detail', 'error_description', 'reason']) {
+      const item = record[key]
+      if (typeof item === 'string' || typeof item === 'number') values.push(String(item))
+    }
+    for (const key of ['error', 'cause', 'response', 'data', 'metadata']) visit(record[key], depth + 1)
+  }
+  visit(value, 0)
+  return { ...(status === undefined ? {} : { status }), signal: values.join(' ') }
+}
+
+function httpStatus(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isInteger(value) && value >= 100 && value <= 599) return value
+  if (typeof value === 'string') {
+    const parsed = Number.parseInt(value, 10)
+    if (Number.isInteger(parsed) && parsed >= 100 && parsed <= 599) return parsed
+  }
+  return undefined
 }
 
 function routeFingerprint(route: HarnessModelRoute | undefined): string {

--- a/packages/harness-adapter/tests/failure-diagnostics.test.ts
+++ b/packages/harness-adapter/tests/failure-diagnostics.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeHarnessNotification } from '../src/index.js'
+
+describe('Harness failure diagnostics', () => {
+  it('preserves actionable turn failure facts while redacting credentials', () => {
+    const [event] = normalizeHarnessNotification({
+      method: 'session.event',
+      params: {
+        sessionId: 'employee-1',
+        event: {
+          type: 'turn/end',
+          seq: 9,
+          data: {
+            reason: {
+              kind: 'failed',
+              error: {
+                code: 'invalid_api_key',
+                type: 'authentication_error',
+                status: 401,
+                message: 'Authorization failed: Bearer secret-token-123456789',
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(event).toMatchObject({
+      kind: 'turn.failed',
+      failed: true,
+      metadata: {
+        reason: 'failed',
+        errorCode: 'invalid_api_key',
+        errorType: 'authentication_error',
+        httpStatus: 401,
+      },
+    })
+    expect(String(event?.metadata.error)).toContain('[已隐藏]')
+    expect(JSON.stringify(event)).not.toContain('secret-token-123456789')
+  })
+
+  it('walks nested provider causes and creates a stable fallback code for 5xx responses', () => {
+    const [event] = normalizeHarnessNotification({
+      method: 'session.event',
+      params: {
+        sessionId: 'employee-2',
+        event: {
+          type: 'turn/end',
+          seq: 4,
+          data: {
+            reason: {
+              kind: 'failed',
+              error: {
+                cause: {
+                  statusCode: '503',
+                  message: 'upstream provider temporarily unavailable',
+                },
+              },
+            },
+          },
+        },
+      },
+    })
+
+    expect(event).toMatchObject({
+      kind: 'turn.failed',
+      metadata: {
+        errorCode: 'upstream_unreachable',
+        httpStatus: 503,
+        error: 'upstream provider temporarily unavailable',
+      },
+    })
+  })
+
+  it('keeps tool failures diagnostic without persisting tool arguments or secrets', () => {
+    const [event] = normalizeHarnessNotification({
+      method: 'session.event',
+      params: {
+        sessionId: 'employee-3',
+        event: {
+          type: 'tool/result',
+          seq: 8,
+          data: {
+            message: { source: { callId: 'call-8' } },
+            error: {
+              code: 'tool_transport_error',
+              message: 'api_key=top-secret-value-12345678',
+              status: 502,
+            },
+          },
+        },
+      },
+    })
+
+    expect(event).toMatchObject({
+      kind: 'tool.completed',
+      callId: 'call-8',
+      failed: true,
+      metadata: {
+        failed: true,
+        errorCode: 'tool_transport_error',
+        httpStatus: 502,
+      },
+    })
+    expect(JSON.stringify(event)).not.toContain('top-secret-value-12345678')
+  })
+})

--- a/packages/harness-adapter/tests/transient-classification-boundary.test.ts
+++ b/packages/harness-adapter/tests/transient-classification-boundary.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+
+import { isTransientRuntimeFailure } from '../src/index.js'
+
+describe('transient model failure boundaries', () => {
+  it('retries broken channels but not normal 4xx requests', () => {
+    expect(isTransientRuntimeFailure({
+      errorCode: 'rpc_channel_closed',
+      error: 'channel closed unexpectedly',
+    })).toBe(true)
+    expect(isTransientRuntimeFailure({
+      httpStatus: 400,
+      errorCode: 'invalid_request',
+    })).toBe(false)
+  })
+})

--- a/packages/harness-adapter/tests/transient-recovery.test.ts
+++ b/packages/harness-adapter/tests/transient-recovery.test.ts
@@ -1,0 +1,172 @@
+import { describe, expect, it } from 'vitest'
+
+import type {
+  AgentRuntimeEvent,
+  AgentRuntimePort,
+  AgentTurnRequest,
+  EmployeeInstance,
+  EmployeeRevision,
+} from '@dsh-cyber/contracts'
+
+import { HarnessModelRouter, isTransientRuntimeFailure } from '../src/index.js'
+
+const employee: EmployeeInstance = {
+  id: 'character-1',
+  workspaceId: 'workspace-1',
+  worldId: 'world-1',
+  blueprintId: 'custom-role',
+  blueprintVersion: 1,
+  displayName: '小夏',
+  role: '自定义角色',
+  status: 'available',
+  currentRevision: 1,
+  createdAt: '2026-08-23T00:00:00.000Z',
+  updatedAt: '2026-08-23T00:00:00.000Z',
+}
+
+const revision: EmployeeRevision = {
+  employeeId: employee.id,
+  revision: 1,
+  persona: '保持简洁。',
+  skillGrants: [],
+  capabilityGrants: [],
+  modelPolicy: {},
+  reason: 'test',
+  createdAt: '2026-08-23T00:00:00.000Z',
+}
+
+function request(events: AgentRuntimeEvent[]): AgentTurnRequest {
+  return {
+    agent: employee,
+    revision,
+    prompt: '你好',
+    workspacePath: '/tmp/world-1',
+    onEvent: (event) => events.push(event),
+  }
+}
+
+describe('Harness transient recovery', () => {
+  it('resets only the affected character runtime and retries one transient 503 before output', async () => {
+    let runs = 0
+    const closedAgents: string[] = []
+    const adapter: AgentRuntimePort = {
+      async runTurn(input) {
+        runs += 1
+        input.onEvent?.({
+          kind: 'turn.started',
+          source: 'test',
+          sourceSessionId: 'session-1',
+          metadata: {},
+        })
+        if (runs === 1) {
+          input.onEvent?.({
+            kind: 'turn.failed',
+            source: 'test',
+            sourceSessionId: 'session-1',
+            failed: true,
+            metadata: {
+              httpStatus: 503,
+              errorCode: 'upstream_unreachable',
+              error: 'service unavailable',
+            },
+          })
+          return { agentSessionId: 'session-1', finalResponse: '', eventCount: 2 }
+        }
+        input.onEvent?.({
+          kind: 'assistant.message',
+          source: 'test',
+          sourceSessionId: 'session-1',
+          content: '恢复成功',
+          metadata: {},
+        })
+        return { agentSessionId: 'session-1', finalResponse: '恢复成功', eventCount: 1 }
+      },
+      async closeAgent(agentId) { closedAgents.push(agentId) },
+      async close() {},
+    }
+    const router = new HarnessModelRouter({
+      stateRoot: '/tmp/runtime',
+      resolveRoute: () => undefined,
+      adapterFactory: () => adapter,
+    })
+    const events: AgentRuntimeEvent[] = []
+
+    const result = await router.runTurn(request(events))
+
+    expect(result.finalResponse).toBe('恢复成功')
+    expect(runs).toBe(2)
+    expect(closedAgents).toEqual([employee.id])
+    expect(events.some((event) => event.kind === 'turn.failed')).toBe(false)
+    expect(events.some((event) => event.kind === 'assistant.message')).toBe(true)
+  })
+
+  it('retries a thrown connection reset before any visible output', async () => {
+    let runs = 0
+    let resets = 0
+    const adapter: AgentRuntimePort = {
+      async runTurn() {
+        runs += 1
+        if (runs === 1) {
+          const error = new Error('socket hang up ECONNRESET') as Error & { code?: string }
+          error.code = 'ECONNRESET'
+          throw error
+        }
+        return { agentSessionId: 'session-1', finalResponse: 'ok', eventCount: 0 }
+      },
+      async closeAgent() { resets += 1 },
+      async close() {},
+    }
+    const router = new HarnessModelRouter({
+      stateRoot: '/tmp/runtime',
+      resolveRoute: () => undefined,
+      adapterFactory: () => adapter,
+    })
+
+    await expect(router.runTurn(request([]))).resolves.toMatchObject({ finalResponse: 'ok' })
+    expect(runs).toBe(2)
+    expect(resets).toBe(1)
+  })
+
+  it('does not retry authentication, rate-limit, or failures after visible output/tool execution', async () => {
+    expect(isTransientRuntimeFailure({ httpStatus: 401, errorCode: 'invalid_api_key' })).toBe(false)
+    expect(isTransientRuntimeFailure({ httpStatus: 429, errorCode: 'rate_limit' })).toBe(false)
+    expect(isTransientRuntimeFailure({ httpStatus: 504, errorCode: 'gateway_timeout' })).toBe(true)
+
+    let runs = 0
+    let resets = 0
+    const adapter: AgentRuntimePort = {
+      async runTurn(input) {
+        runs += 1
+        input.onEvent?.({
+          kind: 'assistant.message',
+          source: 'test',
+          sourceSessionId: 'session-1',
+          content: '部分回复',
+          metadata: {},
+        })
+        input.onEvent?.({
+          kind: 'turn.failed',
+          source: 'test',
+          sourceSessionId: 'session-1',
+          failed: true,
+          metadata: { httpStatus: 503, errorCode: 'upstream_unreachable' },
+        })
+        return { agentSessionId: 'session-1', finalResponse: '部分回复', eventCount: 2 }
+      },
+      async closeAgent() { resets += 1 },
+      async close() {},
+    }
+    const router = new HarnessModelRouter({
+      stateRoot: '/tmp/runtime',
+      resolveRoute: () => undefined,
+      adapterFactory: () => adapter,
+    })
+    const events: AgentRuntimeEvent[] = []
+
+    await router.runTurn(request(events))
+
+    expect(runs).toBe(1)
+    expect(resets).toBe(0)
+    expect(events.map((event) => event.kind)).toEqual(['assistant.message', 'turn.failed'])
+  })
+})

--- a/packages/server/src/http/errors.ts
+++ b/packages/server/src/http/errors.ts
@@ -59,7 +59,7 @@ export function writeError(response: ServerResponse, error: unknown): void {
   }
   if (error instanceof ConversationOrchestrationError) {
     writeJson(response, 422, {
-      error: { code: 'conversation_rejected', message: '当前会话暂时无法执行，请检查参与员工和模型配置后重试。' },
+      error: { code: 'conversation_rejected', message: '当前会话暂时无法执行，请检查参与角色、模型分配和世界设置后重试。' },
     })
     return
   }
@@ -93,13 +93,19 @@ export function writeError(response: ServerResponse, error: unknown): void {
   })
 }
 
-function agentTurnFailureMessage(kind: AgentTurnFailureKind): string {
+export function agentTurnFailureMessage(kind: AgentTurnFailureKind): string {
   switch (kind) {
-    case 'authentication': return '模型服务拒绝了 API 密钥，请在设置中重新填写后重试。'
-    case 'model-not-found': return '当前模型 ID 不存在或无权访问，请重新获取模型列表。'
-    case 'rate-limited': return '模型服务请求过于频繁或额度不足，请稍后重试。'
-    case 'timeout': return '模型服务响应超时，请检查网络或稍后重试。'
-    case 'unreachable': return '无法连接模型服务，请检查接口地址、网络和服务状态。'
-    case 'unknown': return '模型暂时无法完成请求，请检查 API 密钥、接口地址和模型 ID 后重试。'
+    case 'authentication':
+      return 'API 密钥被模型服务拒绝。请打开“设置 → 模型”重新填写密钥，并先获取模型列表确认连接成功。'
+    case 'model-not-found':
+      return '接口已连接，但当前模型 ID 不存在或无权访问。请在“设置 → 模型”重新获取模型列表并选择可用模型。'
+    case 'rate-limited':
+      return '模型服务正在限流或账户额度不足。请稍后重试，或检查服务商额度并切换可用模型。'
+    case 'timeout':
+      return '模型服务响应超时。请先确认接口地址可以访问；网络正常时可稍后重试，或降低当前推理档位。'
+    case 'unreachable':
+      return '模型服务不可达或上游暂时不可用。请检查接口地址、代理/网络和服务状态；如果模型列表也无法获取，请先修复连接。'
+    case 'unknown':
+      return '上游返回了暂未识别的模型错误。请打开“设置 → 模型 → 模型交互日志”查看最近失败的状态码和错误码；若模型列表可正常获取但对话仍失败，重点检查接口协议、推理模式兼容性和模型 ID。'
   }
 }

--- a/packages/server/tests/http-infrastructure.test.ts
+++ b/packages/server/tests/http-infrastructure.test.ts
@@ -147,7 +147,7 @@ describe('HTTP error mapping', () => {
     expect(JSON.parse(fake.text())).toEqual({
       error: {
         code: 'model_turn_authentication',
-        message: '模型服务拒绝了 API 密钥，请在设置中重新填写后重试。',
+        message: 'API 密钥被模型服务拒绝。请打开“设置 → 模型”重新填写密钥，并先获取模型列表确认连接成功。',
       },
     })
     expect(fake.text()).not.toContain('employee-private-id')

--- a/packages/server/tests/model-error-guidance.test.ts
+++ b/packages/server/tests/model-error-guidance.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest'
+
+import { agentTurnFailureMessage } from '../src/http/errors.js'
+
+describe('model turn failure guidance', () => {
+  it('gives a concrete recovery path for each known failure kind', () => {
+    expect(agentTurnFailureMessage('authentication')).toContain('重新填写密钥')
+    expect(agentTurnFailureMessage('model-not-found')).toContain('重新获取模型列表')
+    expect(agentTurnFailureMessage('rate-limited')).toContain('额度')
+    expect(agentTurnFailureMessage('timeout')).toContain('接口地址')
+    expect(agentTurnFailureMessage('unreachable')).toContain('代理/网络')
+  })
+
+  it('routes unknown upstream failures to diagnostics instead of repeating a generic configuration guess', () => {
+    const message = agentTurnFailureMessage('unknown')
+    expect(message).toContain('模型交互日志')
+    expect(message).toContain('状态码')
+    expect(message).toContain('接口协议')
+    expect(message).toContain('推理模式')
+    expect(message).not.toContain('请检查 API 密钥、接口地址和模型 ID 后重试')
+  })
+})

--- a/packages/web/src/api.ts
+++ b/packages/web/src/api.ts
@@ -1,9 +1,12 @@
 export class ApiError extends Error {
   readonly status: number
+  readonly code?: string
 
-  constructor(status: number, message: string) {
+  constructor(status: number, message: string, code?: string) {
     super(message)
+    this.name = 'ApiError'
     this.status = status
+    if (code !== undefined) this.code = code
   }
 }
 
@@ -19,9 +22,13 @@ export async function api<T>(path: string, init?: RequestInit): Promise<T> {
   })
   if (!response.ok) {
     const body = await response.json().catch(() => undefined) as
-      | { error?: { message?: string } }
+      | { error?: { code?: string; message?: string } }
       | undefined
-    throw new ApiError(response.status, body?.error?.message ?? `Request failed: ${response.status}`)
+    throw new ApiError(
+      response.status,
+      body?.error?.message ?? `Request failed: ${response.status}`,
+      body?.error?.code,
+    )
   }
   return response.json() as Promise<T>
 }

--- a/packages/web/tests/api-error.test.ts
+++ b/packages/web/tests/api-error.test.ts
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { ApiError, api } from '../src/api.js'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('web API errors', () => {
+  it('preserves the server error code for model recovery UI', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response(JSON.stringify({
+      error: {
+        code: 'model_turn_timeout',
+        message: '模型服务响应超时。',
+      },
+    }), {
+      status: 502,
+      headers: { 'Content-Type': 'application/json' },
+    })))
+
+    let error: unknown
+    try {
+      await api('/api/worlds/world-1/chat')
+    } catch (cause) {
+      error = cause
+    }
+
+    expect(error).toBeInstanceOf(ApiError)
+    expect(error).toMatchObject({
+      status: 502,
+      code: 'model_turn_timeout',
+      message: '模型服务响应超时。',
+    })
+  })
+})


### PR DESCRIPTION
## 问题

聊天失败时大量上游错误被压成 `unknown`，最终统一显示“模型暂时无法完成请求，请检查 API 密钥、接口地址和模型 ID 后重试”，用户无法判断到底是密钥、限流、超时、上游 5xx、协议不兼容还是模型配置问题。

## 根因

DSH Harness `turn/end` / `tool/result` 的失败对象在适配层只保留 `errorCode`，`message/status/type` 等诊断信息被丢弃；编排层因此缺少足够信号做分类，模型日志也拿不到完整的脱敏诊断信息。

## 修复

- Harness 失败事件保留经过脱敏的 `errorCode / errorType / httpStatus / error` 摘要
- 支持从 `error/cause/response/data` 最多三层读取常见 provider 错误结构
- 没有上游错误码时按 HTTP 状态生成稳定 fallback code：认证、额度、超时、限流、上游不可用等
- API Key、Bearer Token、query token 等凭据在进入领域事件/日志前脱敏
- 模型失败提示改成可执行的恢复路径：重新获取模型列表、检查额度、网络、推理档位，或打开“模型交互日志”查看状态码/错误码
- `ApiError` 保留服务端结构化 `error.code`，为后续 UI 一键跳转模型设置/日志提供基础

## 测试

- Harness 嵌套错误信息与状态码归一化
- 凭据脱敏
- 5xx fallback code
- 模型失败提示的可操作性
- Web API 错误码透传

等待 CI 全绿后再转 Ready。