### PR TITLE
fix:web-search-and-dossier-facts

### DIFF
--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -121,6 +121,15 @@ test('runs direct and group conversations with real world lifecycle, persistence
   expect(taskEvents.filter((event) => event.type === 'task.started').length).toBeGreaterThan(taskStartedBeforeIntent)
   expect(server.store.getEmployee(engineer.id)?.status).toBe('available')
 
+  await dock.getByRole('button', { name: '档案', exact: true }).click()
+  await dock.getByRole('article').filter({ hasText: '阿帆' }).getByRole('button', { name: /完整档案/ }).click()
+  await dock.getByRole('button', { name: '事迹', exact: true }).click()
+  await expect(dock.getByText('完成一次有工具证据的任务').first()).toBeVisible()
+  await expect(dock.getByText(/search_workspace/).first()).toBeVisible()
+  await dock.getByRole('button', { name: '日志', exact: true }).click()
+  await expect(dock.getByText(/当日已完成 \d+ 次有真实记录的会话或任务/)).toBeVisible()
+  await dock.getByRole('button', { name: '世界', exact: true }).click()
+
   const meetingStartedBefore = server.store.listWorldDomainEvents(worldId).filter((event) => event.type === 'meeting.started').length
   await page.getByRole('button', { name: '创建群聊' }).click()
   const groupDialog = page.getByRole('dialog', { name: '创建群聊' })
@@ -266,6 +275,8 @@ test('creates, edits, restores, and deletes a private-network sub2api model prof
   await editor.getByRole('textbox', { name: '接口地址' }).fill('http://172.16.1.125:11434/v1/')
   await editor.getByLabel('模型 ID').fill('qwen3.5:9b')
   await editor.getByRole('textbox', { name: /API 密钥/ }).fill('sk-e2e-test-only-not-real')
+  await editor.getByRole('checkbox', { name: /启用联网搜索/ }).check()
+  await editor.getByRole('textbox', { name: /搜索服务地址/ }).fill('https://search.example.test/anthropic/v1')
   await editor.getByRole('button', { name: '获取可用模型' }).click()
   const modelSelect = editor.getByRole('combobox', { name: '选择可用模型' })
   await expect(modelSelect).toBeVisible()
@@ -276,7 +287,7 @@ test('creates, edits, restores, and deletes a private-network sub2api model prof
   await modelSelect.selectOption('qwen3.5:9b')
   await editor.getByRole('button', { name: '添加并保存' }).click()
   await expect(editor.getByRole('status')).toContainText('模型配置已添加并保存')
-  await expect(settings.getByRole('article').filter({ hasText: '公司 sub2api' })).toContainText('qwen3.5:9b')
+  await expect(settings.getByRole('article').filter({ hasText: '公司 sub2api' })).toContainText('联网搜索已启用')
 
   await settings.getByRole('button', { name: '编辑公司 sub2api' }).click()
   await editor.getByLabel('模型 ID').fill('qwen3.5')
@@ -300,6 +311,7 @@ test('creates, edits, restores, and deletes a private-network sub2api model prof
   const restored = settings.getByRole('article').filter({ hasText: '公司 sub2api' })
   await expect(restored).toContainText('qwen3.5')
   await expect(restored).toContainText('API 密钥已保存')
+  await expect(restored).toContainText('联网搜索已启用')
   await page.screenshot({ path: join(process.cwd(), 'artifacts', 'ui-world-conversations', 'model-settings-1920x1080.png') })
 
   page.once('dialog', (dialog) => dialog.accept())

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -195,9 +195,10 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
     const environment = workerEnvironment(
       this.#options.inheritedEnvironment ?? process.env,
       spec,
-      this.#options.providerProfile?.apiKeyEnv === undefined
-        ? []
-        : [this.#options.providerProfile.apiKeyEnv],
+      [...new Set([
+        this.#options.providerProfile?.apiKeyEnv,
+        this.#options.providerProfile?.webSearch?.apiKeyEnv,
+      ].filter((value): value is string => value !== undefined))],
     )
     const harness = new DeepSeekHarness({
       launch: {
@@ -522,6 +523,7 @@ function employeeSystemPrompt(employee: EmployeeInstance, revision: EmployeeRevi
     'The blueprint or job title used when this character was first created is provenance metadata only. Do not restore or infer an older template identity unless the current Persona explicitly keeps it.',
     'Stay consistent with your current identity, maintain your own persistent conversation, and never impersonate another character.',
     'When another character\'s statement is included in a collaboration prompt, respond to its substance and identify agreements or disagreements.',
+    'If web search is unavailable, explain the cause in plain Chinese and direct the user to 设置 → 模型 → 编辑当前模型 → 启用联网搜索. Never invent results or tell the user to configure a hidden "Web Models" page.',
     'Give concise, evidence-based answers from your current identity, memory and granted capabilities.',
   ].join('\n\n')
 }

--- a/packages/harness-adapter/src/model-router.ts
+++ b/packages/harness-adapter/src/model-router.ts
@@ -20,6 +20,10 @@ export interface HarnessModelRoute {
   baseURL: string
   modelId: string
   apiKeyEnv?: string
+  webSearch?: {
+    baseURL: string
+    apiKeyEnv: string
+  }
   contextWindow?: number
   maxTokens?: number
   reasoningEfforts?: false | Partial<Record<'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max', string | null>>
@@ -202,6 +206,7 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
         },
         ...(route.reasoning === undefined ? {} : { reasoning: route.reasoning }),
         ...(route.apiKeyEnv === undefined ? {} : { apiKeyEnv: route.apiKeyEnv }),
+        ...(route.webSearch === undefined ? {} : { webSearch: route.webSearch }),
       }
     }
     return this.#options.adapterFactory?.(options) ?? new HarnessCompatibilityAdapter(options)

--- a/packages/harness-adapter/src/profile.ts
+++ b/packages/harness-adapter/src/profile.ts
@@ -29,6 +29,10 @@ export interface HarnessProviderProfile {
   }
   reasoning?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
   apiKeyEnv?: string
+  webSearch?: {
+    baseURL: string
+    apiKeyEnv: string
+  }
 }
 
 export interface HarnessCompatibilityReport {
@@ -74,19 +78,24 @@ export async function ensureHarnessProfile(
     profilePatchPath,
     providerProfile === undefined
       ? '# Machine-local DSH Cyber worker overrides. Bundle policy remains authoritative.\n[]\n'
-      : `${JSON.stringify([
-          {
-            id: 'llm-pi-ai',
-            config: { providers: { [providerProfile.route]: providerRoute(providerProfile) } },
-          },
-        ], null, 2)}\n`,
+      : `${JSON.stringify(providerPatch(providerProfile), null, 2)}\n`,
   )
   if (providerProfile !== undefined) {
     validateProviderProfile(providerProfile)
     const route = providerRoute(providerProfile)
     await writeTextAtomic(
       settingsPath,
-      `${JSON.stringify({ 'llm-pi-ai': { providers: { [providerProfile.route]: route } } }, null, 2)}\n`,
+      `${JSON.stringify({
+        'llm-pi-ai': { providers: { [providerProfile.route]: route } },
+        ...(providerProfile.webSearch === undefined
+          ? {}
+          : {
+              'web-search-deepseek': {
+                apiKeyEnv: providerProfile.webSearch.apiKeyEnv,
+                baseURL: providerProfile.webSearch.baseURL,
+              },
+            }),
+      }, null, 2)}\n`,
     )
   }
   const require = createRequire(import.meta.url)
@@ -102,6 +111,23 @@ export async function ensureHarnessProfile(
     profilePatchPath,
     settingsPath,
   }
+}
+
+function providerPatch(providerProfile: HarnessProviderProfile): Array<Record<string, unknown>> {
+  const patch: Array<Record<string, unknown>> = [{
+    id: 'llm-pi-ai',
+    config: { providers: { [providerProfile.route]: providerRoute(providerProfile) } },
+  }]
+  if (providerProfile.webSearch !== undefined) {
+    patch.push({
+      id: 'web-search-deepseek',
+      config: {
+        apiKeyEnv: providerProfile.webSearch.apiKeyEnv,
+        baseURL: providerProfile.webSearch.baseURL,
+      },
+    })
+  }
+  return patch
 }
 
 function providerRoute(providerProfile: HarnessProviderProfile): Record<string, unknown> {
@@ -221,5 +247,12 @@ function validateProviderProfile(profile: HarnessProviderProfile): void {
   }
   if (profile.apiKeyEnv !== undefined && !/^[A-Z_][A-Z0-9_]*$/.test(profile.apiKeyEnv)) {
     throw new Error('Invalid provider credential environment variable')
+  }
+  if (profile.webSearch !== undefined) {
+    const searchEndpoint = new URL(profile.webSearch.baseURL)
+    if (searchEndpoint.protocol !== 'https:') throw new Error('Web search URL must use HTTPS')
+    if (!/^[A-Z_][A-Z0-9_]*$/.test(profile.webSearch.apiKeyEnv)) {
+      throw new Error('Invalid web search credential environment variable')
+    }
   }
 }

--- a/packages/harness-adapter/tests/adapter.test.ts
+++ b/packages/harness-adapter/tests/adapter.test.ts
@@ -99,6 +99,39 @@ describe('Harness profile and adapter', () => {
     expect(await readFile(profile.profilePatchPath, 'utf8')).toContain('[]')
   })
 
+  it('binds an explicitly enabled web search provider to the model credential reference', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-cyber-web-search-profile-'))
+    const profile = await ensureHarnessProfile(directory, 'dsh-cyber-worker', {
+      route: 'cyber-search-test',
+      displayName: 'DeepSeek 测试',
+      api: 'openai-completions',
+      baseURL: 'https://api.deepseek.com/v1',
+      model: { id: 'deepseek-chat' },
+      apiKeyEnv: 'DSH_CYBER_MODEL_KEY_TEST',
+      webSearch: {
+        baseURL: 'https://api.deepseek.com/anthropic/v1',
+        apiKeyEnv: 'DSH_CYBER_MODEL_KEY_TEST',
+      },
+    })
+    const patch = JSON.parse(await readFile(profile.profilePatchPath, 'utf8')) as Array<{ id: string; config: Record<string, unknown> }>
+    const settings = JSON.parse(await readFile(profile.settingsPath, 'utf8')) as Record<string, unknown>
+
+    expect(patch).toContainEqual(expect.objectContaining({
+      id: 'web-search-deepseek',
+      config: {
+        apiKeyEnv: 'DSH_CYBER_MODEL_KEY_TEST',
+        baseURL: 'https://api.deepseek.com/anthropic/v1',
+      },
+    }))
+    expect(settings).toMatchObject({
+      'web-search-deepseek': {
+        apiKeyEnv: 'DSH_CYBER_MODEL_KEY_TEST',
+        baseURL: 'https://api.deepseek.com/anthropic/v1',
+      },
+    })
+    expect(JSON.stringify({ patch, settings })).not.toContain('sk-')
+  })
+
   it('keeps one independent runtime and stable Harness session per employee', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-adapter-'))
     const specs: HarnessRuntimeSpec[] = []
@@ -253,6 +286,10 @@ describe('Harness profile and adapter', () => {
         baseURL: 'https://models.example.test/v1',
         modelId: 'model-b',
         apiKeyEnv: 'MODEL_B_API_KEY',
+        webSearch: {
+          baseURL: 'https://search.example.test/anthropic/v1',
+          apiKeyEnv: 'MODEL_B_API_KEY',
+        },
       }],
     ])
     const created: HarnessAdapterOptions[] = []
@@ -313,6 +350,10 @@ describe('Harness profile and adapter', () => {
     })
     expect(created[1]?.providerProfile).toMatchObject({
       apiKeyEnv: 'MODEL_B_API_KEY',
+      webSearch: {
+        baseURL: 'https://search.example.test/anthropic/v1',
+        apiKeyEnv: 'MODEL_B_API_KEY',
+      },
       model: { id: 'model-b' },
     })
     expect(JSON.stringify(created)).not.toContain('apiKeyValue')

--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -24,6 +24,7 @@ import {
   detectDelegatedCollaboration,
 } from '../services/delegated-collaboration-service.js'
 import { ConversationHubService } from '../services/conversation-hub-service.js'
+import type { EmployeeActivityProjectionService } from '../services/employee-activity-projection-service.js'
 import type { CharacterSkillRuntime } from '../services/character-skill-runtime.js'
 import type { PeerCollaborationService } from '../services/peer-collaboration-service.js'
 import type { RuntimeStreamHub } from '../streams/runtime-stream-hub.js'
@@ -45,6 +46,7 @@ export interface ConversationRoutesDependencies {
   worldFiles: WorldFileService
   worldSettings: WorldSettingsService
   worldTrace: WorldTraceService
+  employeeActivity: EmployeeActivityProjectionService
 }
 
 export function registerConversationRoutes(router: Router, dependencies: ConversationRoutesDependencies): void {
@@ -59,6 +61,7 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     worldFiles,
     worldSettings,
     worldTrace,
+    employeeActivity,
   } = dependencies
   const delegatedCollaboration = new DelegatedCollaborationService({
     store,
@@ -160,6 +163,7 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
         ...(title === undefined ? {} : { title }),
       })
     }
+    for (const employeeId of employeeIds) employeeActivity.project(employeeId)
     worldRuntime.publishCurrent(world.id)
     writeJson(response, 200, result)
     } finally {

--- a/packages/server/src/routes/model-routes.ts
+++ b/packages/server/src/routes/model-routes.ts
@@ -86,6 +86,7 @@ export function registerModelRoutes(router: Router, dependencies: ModelRoutesDep
     }
     let profile
     try {
+      validateWebSearchSettings(settings, credentialEnvName)
       profile = store.saveModelProfile({
         id: profileId,
         workspaceId: params[0]!,
@@ -200,6 +201,29 @@ export function registerModelRoutes(router: Router, dependencies: ModelRoutesDep
     )
     writeJson(response, 200, { removed })
   })
+}
+
+function validateWebSearchSettings(
+  settings: Record<string, unknown> | undefined,
+  credentialEnvName: string | undefined,
+): void {
+  if (settings?.webSearchEnabled !== true) return
+  if (credentialEnvName === undefined) {
+    throw new HttpError(422, 'web_search_credential_missing', '启用联网搜索前，请先配置 API 密钥或凭据环境变量。')
+  }
+  const value = settings.webSearchBaseUrl
+  if (typeof value !== 'string' || !value.trim()) {
+    throw new HttpError(422, 'web_search_base_url_missing', '启用联网搜索后，需要填写搜索服务地址。')
+  }
+  let url: URL
+  try {
+    url = new URL(value.trim())
+  } catch {
+    throw new HttpError(422, 'web_search_base_url_invalid', '联网搜索服务地址格式不正确。')
+  }
+  if (url.protocol !== 'https:') {
+    throw new HttpError(422, 'web_search_base_url_insecure', '联网搜索服务必须使用 HTTPS 地址。')
+  }
 }
 
 function validateModelBaseUrl(

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -43,6 +43,7 @@ import { AmbientLifeSettingsService } from './services/ambient-life-settings-ser
 import { AssetService } from './services/asset-service.js'
 import { CharacterProfileRuntime } from './services/character-profile-runtime.js'
 import { CharacterSkillRuntime } from './services/character-skill-runtime.js'
+import { EmployeeActivityProjectionService } from './services/employee-activity-projection-service.js'
 import { harnessModelRoute } from './services/harness-model-route.js'
 import { ModelCatalogService } from './services/model-catalog-service.js'
 import { ModelCredentialService } from './services/model-credential-service.js'
@@ -189,6 +190,8 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
     actions: skillActions,
   })
   const worldTrace = new WorldTraceService({ store, actions: skillActions })
+  const employeeActivity = new EmployeeActivityProjectionService(store)
+  employeeActivity.projectAll()
   const runtimeUpdates = new RuntimeUpdateService(store, stateRoot, workspaceRoot)
   const assets = new AssetService(store, stateRoot)
   const worldFiles = new WorldFileService(worldRoots)
@@ -207,7 +210,7 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
   registerWorldRuntimeRoutes(router, { store, worldRuntime, worldStreamHub, worldAccess })
   registerWorldTraceRoutes(router, { store, trace: worldTrace, access: worldAccess })
   registerModelInteractionRoutes(router, { store, interactions })
-  registerConversationRoutes(router, { store, orchestrator, peerCollaboration, skillRuntime, runtimeStreamHub, worldRuntime, worldAccess, worldFiles, worldSettings, worldTrace })
+  registerConversationRoutes(router, { store, orchestrator, peerCollaboration, skillRuntime, runtimeStreamHub, worldRuntime, worldAccess, worldFiles, worldSettings, worldTrace, employeeActivity })
   registerEmployeeRoutes(router, { store, worldAccess })
 
   const httpServer = createServer((request, response) => {

--- a/packages/server/src/services/employee-activity-projection-service.ts
+++ b/packages/server/src/services/employee-activity-projection-service.ts
@@ -1,0 +1,136 @@
+import type { DomainEvent, WorkMessage } from '@dsh-cyber/contracts'
+import type { SqliteStore } from '@dsh-cyber/persistence'
+
+/**
+ * Builds the durable dossier read model from canonical conversation/runtime facts.
+ * Re-running the projection is safe: a completed turn event is consumed at most
+ * once by each growth record, which also backfills conversations created before
+ * this projection existed.
+ */
+export class EmployeeActivityProjectionService {
+  readonly #store: SqliteStore
+
+  constructor(store: SqliteStore) {
+    this.#store = store
+  }
+
+  projectAll(): void {
+    for (const workspace of this.#store.listWorkspaces()) {
+      for (const world of this.#store.listWorlds(workspace.id, true)) {
+        for (const employee of this.#store.listEmployees(world.id, true)) this.project(employee.id)
+      }
+    }
+  }
+
+  project(employeeId: string): void {
+    const employee = this.#store.getEmployee(employeeId)
+    if (employee === undefined) return
+
+    const completedTurns = this.#store.listWorldDomainEvents(employee.worldId)
+      .filter((event) => event.type === 'turn.completed' && event.actorId === employee.id && event.sessionId !== undefined)
+    if (completedTurns.length === 0) return
+
+    const milestones = this.#store.listEmployeeMilestones(employee.id, 500)
+    const projectedMilestoneEvents = new Set(milestones.flatMap((item) => item.sourceEventIds))
+    const journals = this.#store.listEmployeeJournals(employee.id, 366)
+    const projectedJournalEvents = new Set(journals.flatMap((item) => item.sourceEventIds))
+
+    for (const event of completedTurns) {
+      const messages = turnMessages(this.#store.listMessages(event.sessionId!), event)
+      if (messages.length === 0) continue
+      const presentation = turnPresentation(employee.displayName, messages)
+
+      if (!projectedMilestoneEvents.has(event.id)) {
+        this.#store.appendEmployeeMilestone({
+          employeeId: employee.id,
+          category: 'task',
+          title: presentation.title,
+          summary: presentation.summary,
+          sourceEventIds: [event.id],
+          sourceMessageIds: messages.map((message) => message.id),
+          actorId: employee.id,
+          occurredAt: event.createdAt,
+        })
+        projectedMilestoneEvents.add(event.id)
+      }
+
+      if (!projectedJournalEvents.has(event.id)) {
+        const localDate = localDateFor(event.createdAt)
+        const previous = this.#store.listEmployeeJournals(employee.id, 366)
+          .find((journal) => journal.localDate === localDate)
+        const sourceEventIds = unique([...(previous?.sourceEventIds ?? []), event.id])
+        const sourceMessageIds = unique([...(previous?.sourceMessageIds ?? []), ...messages.map((message) => message.id)])
+        const highlights = unique([...(previous?.highlights ?? []), presentation.highlight]).slice(-12)
+        this.#store.writeEmployeeJournal({
+          employeeId: employee.id,
+          localDate,
+          summary: `${employee.displayName} 当日已完成 ${sourceEventIds.length} 次有真实记录的会话或任务。`,
+          highlights,
+          sourceEventIds,
+          sourceMessageIds,
+        })
+        projectedJournalEvents.add(event.id)
+      }
+    }
+  }
+}
+
+function turnMessages(messages: WorkMessage[], event: DomainEvent): WorkMessage[] {
+  const traceTurnId = typeof event.payload.traceTurnId === 'string' ? event.payload.traceTurnId : undefined
+  const agentMessages = traceTurnId === undefined
+    ? messages.filter((message) => message.senderId === event.actorId)
+    : messages.filter((message) => message.senderId === event.actorId && message.metadata.traceTurnId === traceTurnId)
+  if (agentMessages.length === 0) return []
+  const firstSequence = Math.min(...agentMessages.map((message) => message.sequence))
+  const prompt = messages
+    .filter((message) => message.kind === 'user' && message.sequence < firstSequence)
+    .at(-1)
+  return [...(prompt === undefined ? [] : [prompt]), ...agentMessages]
+}
+
+function turnPresentation(employeeName: string, messages: WorkMessage[]): {
+  title: string
+  summary: string
+  highlight: string
+} {
+  const prompt = messages.find((message) => message.kind === 'user')
+  const reply = messages.filter((message) => message.kind === 'assistant').at(-1)
+  const toolCalls = messages.filter((message) => message.kind === 'tool-call')
+  const failedTools = messages.filter((message) => message.kind === 'tool-result' && message.metadata.failed === true)
+  const tools = unique(toolCalls.flatMap((message) => {
+    const name = message.metadata.toolName
+    return typeof name === 'string' && name.trim() ? [name.trim()] : []
+  }))
+  const request = compact(prompt?.content ?? '收到会话请求', 54)
+  const outcome = compact(reply?.content ?? '已完成本轮处理', 72)
+  const toolSummary = tools.length === 0
+    ? '未调用外部工具'
+    : `${failedTools.length === 0 ? '完成' : '尝试'} ${tools.join('、')} ${tools.length} 项工具调用`
+  return {
+    title: tools.length === 0 ? '完成一次真实对话' : '完成一次有工具证据的任务',
+    summary: `回应“${request}”；${toolSummary}。结果：${outcome}`,
+    highlight: `${employeeName} · ${request} · ${toolSummary}`,
+  }
+}
+
+function compact(value: string, limit: number): string {
+  const normalized = value.replaceAll(/\s+/g, ' ').trim()
+  return normalized.length <= limit ? normalized : `${normalized.slice(0, limit - 1)}…`
+}
+
+function localDateFor(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.valueOf())) return value.slice(0, 10)
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Shanghai',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  })
+  const parts = Object.fromEntries(formatter.formatToParts(date).map((part) => [part.type, part.value]))
+  return `${parts.year}-${parts.month}-${parts.day}`
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values.filter(Boolean))]
+}

--- a/packages/server/src/services/harness-model-route.ts
+++ b/packages/server/src/services/harness-model-route.ts
@@ -9,6 +9,10 @@ export function harnessModelRoute(
 ): HarnessModelRoute {
   const contextWindow = optionalPositiveInteger(profile.settings.contextWindow)
   const maxTokens = optionalPositiveInteger(profile.settings.maxTokens)
+  const webSearchEnabled = profile.settings.webSearchEnabled === true
+  const webSearchBaseUrl = typeof profile.settings.webSearchBaseUrl === 'string'
+    ? profile.settings.webSearchBaseUrl.trim()
+    : ''
   return {
     id: profile.id,
     displayName: profile.displayName,
@@ -16,6 +20,14 @@ export function harnessModelRoute(
     baseURL: profile.baseUrl,
     modelId: profile.modelId,
     ...(profile.credentialEnvName === undefined ? {} : { apiKeyEnv: profile.credentialEnvName }),
+    ...(webSearchEnabled && webSearchBaseUrl && profile.credentialEnvName !== undefined
+      ? {
+          webSearch: {
+            baseURL: webSearchBaseUrl,
+            apiKeyEnv: profile.credentialEnvName,
+          },
+        }
+      : {}),
     ...(contextWindow === undefined ? {} : { contextWindow }),
     ...(maxTokens === undefined ? {} : { maxTokens }),
     ...(reasoningEffort === undefined ? {} : { reasoning: reasoningEffort }),

--- a/packages/server/tests/employee-activity-projection-service.test.ts
+++ b/packages/server/tests/employee-activity-projection-service.test.ts
@@ -1,0 +1,99 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { BUILTIN_BLUEPRINTS } from '@dsh-cyber/catalog'
+import { SqliteStore } from '@dsh-cyber/persistence'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { EmployeeActivityProjectionService } from '../src/services/employee-activity-projection-service.js'
+
+const stores: SqliteStore[] = []
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close()
+})
+
+describe('EmployeeActivityProjectionService', () => {
+  it('backfills completed conversations into evidence-linked milestones and daily journals idempotently', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-cyber-employee-activity-'))
+    const store = await SqliteStore.open(join(directory, 'cyber.sqlite'))
+    stores.push(store)
+    for (const blueprint of BUILTIN_BLUEPRINTS) store.saveBlueprint(blueprint)
+    const workspace = store.createWorkspace({ name: '档案投影测试' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: '赛博公司', templateId: 'cyber-company' })
+    const blueprint = BUILTIN_BLUEPRINTS.find((item) => item.id === 'core.butler') ?? BUILTIN_BLUEPRINTS[0]!
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      blueprintId: blueprint.id,
+      blueprintVersion: blueprint.version,
+    })
+    const session = store.createSession({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      kind: 'direct',
+      title: '查询天气',
+      participants: [
+        { participantId: 'owner', kind: 'owner' },
+        { participantId: employee.id, kind: 'employee' },
+      ],
+    })
+    const prompt = store.appendMessage({
+      sessionId: session.id,
+      senderId: 'owner',
+      senderKind: 'owner',
+      kind: 'user',
+      content: '查询明天的天气',
+    })
+    const tool = store.appendMessage({
+      sessionId: session.id,
+      senderId: employee.id,
+      senderKind: 'employee',
+      kind: 'tool-call',
+      content: '调用工具：web_search',
+      metadata: { traceTurnId: 'turn-1', toolName: 'web_search' },
+    })
+    const result = store.appendMessage({
+      sessionId: session.id,
+      senderId: employee.id,
+      senderKind: 'employee',
+      kind: 'tool-result',
+      content: '工具执行完成',
+      metadata: { traceTurnId: 'turn-1', toolName: 'web_search', failed: false },
+    })
+    const reply = store.appendMessage({
+      sessionId: session.id,
+      senderId: employee.id,
+      senderKind: 'employee',
+      kind: 'assistant',
+      content: '已经查到天气并给出可靠来源。',
+      metadata: { traceTurnId: 'turn-1' },
+    })
+    const completed = store.appendDomainEvent({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      sessionId: session.id,
+      type: 'turn.completed',
+      actorId: employee.id,
+      actorKind: 'employee',
+      payload: { traceTurnId: 'turn-1' },
+    })
+
+    const projection = new EmployeeActivityProjectionService(store)
+    projection.project(employee.id)
+    projection.project(employee.id)
+
+    const dossier = store.getEmployeeDossier(employee.id)
+    const projected = dossier.milestones.filter((item) => item.sourceEventIds.includes(completed.id))
+    expect(projected).toHaveLength(1)
+    expect(projected[0]).toMatchObject({
+      title: '完成一次有工具证据的任务',
+      sourceMessageIds: [prompt.id, tool.id, result.id, reply.id],
+    })
+    expect(projected[0]?.summary).toContain('web_search')
+    expect(dossier.journals).toHaveLength(1)
+    expect(dossier.journals[0]?.sourceEventIds).toContain(completed.id)
+    expect(dossier.journals[0]?.highlights[0]).toContain('查询明天的天气')
+  })
+})

--- a/packages/server/tests/harness-model-route.test.ts
+++ b/packages/server/tests/harness-model-route.test.ts
@@ -1,0 +1,39 @@
+import type { ModelProfile } from '@dsh-cyber/contracts'
+import { describe, expect, it } from 'vitest'
+
+import { harnessModelRoute } from '../src/services/harness-model-route.js'
+
+function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
+  return {
+    id: 'profile-1',
+    workspaceId: 'workspace-1',
+    displayName: 'DeepSeek',
+    providerKind: 'deepseek',
+    baseUrl: 'https://api.deepseek.com/v1',
+    modelId: 'deepseek-chat',
+    api: 'openai-completions',
+    credentialEnvName: 'DSH_CYBER_MODEL_KEY_TEST',
+    isDefault: true,
+    settings: {},
+    createdAt: '2026-08-23T00:00:00.000Z',
+    updatedAt: '2026-08-23T00:00:00.000Z',
+    ...overrides,
+  }
+}
+
+describe('harnessModelRoute', () => {
+  it('only binds web search when the model profile explicitly enables a compatible endpoint', () => {
+    expect(harnessModelRoute(profile())).not.toHaveProperty('webSearch')
+    expect(harnessModelRoute(profile({
+      settings: {
+        webSearchEnabled: true,
+        webSearchBaseUrl: 'https://api.deepseek.com/anthropic/v1',
+      },
+    }))).toMatchObject({
+      webSearch: {
+        baseURL: 'https://api.deepseek.com/anthropic/v1',
+        apiKeyEnv: 'DSH_CYBER_MODEL_KEY_TEST',
+      },
+    })
+  })
+})

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -747,7 +747,9 @@ describe('Cyber local server', () => {
     expect(dossier.body.profile).toMatchObject({ birthday: '05-24', personalityTraits: ['严谨', '主动'] })
     expect(dossier.body.profile.appearance).toMatchObject({ avatarIndex: 6 })
     expect(dossier.body.employee.displayName).toBe('阿帆')
-    expect(dossier.body.milestones[0]).toMatchObject({ category: 'joined' })
+    expect(dossier.body.milestones).toEqual(expect.arrayContaining([
+      expect.objectContaining({ category: 'joined' }),
+    ]))
   })
 
   it('stores direct model API keys outside SQLite and restores them after restart', async () => {
@@ -789,11 +791,19 @@ describe('Cyber local server', () => {
         api: 'openai-completions',
         apiKey: secret,
         isDefault: true,
+        settings: {
+          webSearchEnabled: true,
+          webSearchBaseUrl: 'https://search.example.test/anthropic/v1',
+        },
       }),
     })
     expect(saved.response.status).toBe(201)
     expect(saved.body.profile).not.toHaveProperty('apiKey')
     expect(saved.body.profile.credentialEnvName).toMatch(/^DSH_CYBER_MODEL_KEY_[A-F0-9]{24}$/)
+    expect(saved.body.profile.settings).toMatchObject({
+      webSearchEnabled: true,
+      webSearchBaseUrl: 'https://search.example.test/anthropic/v1',
+    })
     const envName = saved.body.profile.credentialEnvName as string
 
     const listed = await json(started.origin, `/api/workspaces/${workspaceId}/model-profiles`)

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -320,14 +320,14 @@ export default function App() {
     setAppMode('workbench')
     setDockCollapsed(false)
     setDockTab('dossier')
-    if (dossiers[employeeId] !== undefined || demoMode) return
+    if (demoMode) return
     try {
       const dossier = await api<EmployeeDossier>(`/api/employees/${employeeId}/dossier`)
       setDossiers((current) => ({ ...current, [employeeId]: dossier }))
     } catch (cause) {
       setError(cause instanceof Error ? cause.message : '角色档案加载失败')
     }
-  }, [dossiers])
+  }, [demoMode])
 
   const directEmployee = useCallback((employee: CyberEmployee) => {
     const existing = sessions.find((session) => session.kind === 'direct' && (

--- a/packages/web/src/components/SettingsDialog.tsx
+++ b/packages/web/src/components/SettingsDialog.tsx
@@ -123,6 +123,7 @@ interface ModelProviderPreset {
   credentialEnvName: string
   credentialMode: ModelCredentialMode
   modelPlaceholder: string
+  webSearchBaseUrl?: string
 }
 
 type ModelCredentialMode = 'api-key' | 'environment' | 'none'
@@ -141,12 +142,14 @@ interface ModelDraft {
   hasStoredApiKey: boolean
   contextWindow: number
   maxTokens: number
+  webSearchEnabled: boolean
+  webSearchBaseUrl: string
   isDefault: boolean
   settings: ModelProfile['settings']
 }
 
 const MODEL_PRESETS: readonly ModelProviderPreset[] = [
-  { id: 'deepseek', label: 'DeepSeek', providerKind: 'deepseek', api: 'openai-completions', baseUrl: 'https://api.deepseek.com/v1', credentialEnvName: 'DEEPSEEK_API_KEY', credentialMode: 'api-key', modelPlaceholder: 'deepseek-chat' },
+  { id: 'deepseek', label: 'DeepSeek', providerKind: 'deepseek', api: 'openai-completions', baseUrl: 'https://api.deepseek.com/v1', credentialEnvName: 'DEEPSEEK_API_KEY', credentialMode: 'api-key', modelPlaceholder: 'deepseek-chat', webSearchBaseUrl: 'https://api.deepseek.com/anthropic/v1' },
   { id: 'openai', label: 'OpenAI', providerKind: 'openai-compatible-remote', api: 'openai-responses', baseUrl: 'https://api.openai.com/v1', credentialEnvName: 'OPENAI_API_KEY', credentialMode: 'api-key', modelPlaceholder: 'gpt-5' },
   { id: 'anthropic', label: 'Anthropic', providerKind: 'openai-compatible-remote', api: 'anthropic-messages', baseUrl: 'https://api.anthropic.com/v1', credentialEnvName: 'ANTHROPIC_API_KEY', credentialMode: 'api-key', modelPlaceholder: 'claude-sonnet-4-5' },
   { id: 'gemini', label: 'Google Gemini', providerKind: 'openai-compatible-remote', api: 'openai-completions', baseUrl: 'https://generativelanguage.googleapis.com/v1beta/openai', credentialEnvName: 'GEMINI_API_KEY', credentialMode: 'api-key', modelPlaceholder: 'gemini-2.5-pro' },
@@ -174,6 +177,8 @@ function modelDraftForPreset(preset: ModelProviderPreset, isDefault = false): Mo
     hasStoredApiKey: false,
     contextWindow: 64_000,
     maxTokens: 8_192,
+    webSearchEnabled: preset.webSearchBaseUrl !== undefined,
+    webSearchBaseUrl: preset.webSearchBaseUrl ?? '',
     isDefault,
     settings: {},
   }
@@ -200,6 +205,10 @@ function modelDraftForProfile(profile: ModelProfile): ModelDraft {
     hasStoredApiKey,
     contextWindow: modelSettingNumber(profile, 'contextWindow', 64_000),
     maxTokens: modelSettingNumber(profile, 'maxTokens', 8_192),
+    webSearchEnabled: profile.settings.webSearchEnabled === true,
+    webSearchBaseUrl: typeof profile.settings.webSearchBaseUrl === 'string'
+      ? profile.settings.webSearchBaseUrl
+      : '',
     isDefault: profile.isDefault,
     settings: profile.settings,
   }
@@ -497,6 +506,8 @@ function ModelSettings({
           providerId: draft.providerId,
           contextWindow: draft.contextWindow,
           maxTokens: draft.maxTokens,
+          webSearchEnabled: draft.webSearchEnabled,
+          ...(draft.webSearchEnabled ? { webSearchBaseUrl: draft.webSearchBaseUrl.trim() } : {}),
         },
       })
       setDraft(modelDraftForProfile(saved))
@@ -534,7 +545,7 @@ function ModelSettings({
             {models.map((model) => (
               <article key={model.id} className={draft.id === model.id ? 'is-active' : ''}>
                 <Cpu size={22} />
-                <div><strong>{model.displayName}</strong><span>{model.modelId}</span><small>{providerLabel(model)} · {credentialSummary(model)}</small></div>
+                <div><strong>{model.displayName}</strong><span>{model.modelId}</span><small>{providerLabel(model)} · {credentialSummary(model)} · {model.settings.webSearchEnabled === true ? '联网搜索已启用' : '未启用联网搜索'}</small></div>
                 <div className="model-profile-actions">
                   {model.isDefault ? <span className="model-default-badge"><CheckCircle size={14} />默认</span> : null}
                   <button type="button" aria-label={`编辑${model.displayName}`} onClick={() => editModel(model)}><PencilSimple size={15} />编辑</button>
@@ -564,6 +575,21 @@ function ModelSettings({
             <label><span>上下文窗口</span><input type="number" min="1024" step="1" value={draft.contextWindow} onChange={(event) => setDraft({ ...draft, contextWindow: Number(event.target.value) })} /></label>
             <label><span>最大输出 Token</span><input type="number" min="256" step="256" value={draft.maxTokens} onChange={(event) => setDraft({ ...draft, maxTokens: Number(event.target.value) })} /></label>
           </div>
+          <label className="model-default-control">
+            <input type="checkbox" checked={draft.webSearchEnabled} onChange={(event) => setDraft({
+              ...draft,
+              webSearchEnabled: event.target.checked,
+              webSearchBaseUrl: event.target.checked && !draft.webSearchBaseUrl
+                ? (MODEL_PRESETS.find((preset) => preset.id === draft.providerId)?.webSearchBaseUrl ?? '')
+                : draft.webSearchBaseUrl,
+            })} />
+            <span><strong>启用联网搜索</strong><small>通过 DSH 的网页搜索工具查询实时信息。只有兼容 DeepSeek Anthropic 搜索协议的服务才能启用。</small></span>
+          </label>
+          {draft.webSearchEnabled ? (
+            <div className="setting-grid model-setting-grid model-web-search-settings">
+              <label className="setting-grid__wide"><span>搜索服务地址</span><input inputMode="url" value={draft.webSearchBaseUrl} placeholder="https://api.deepseek.com/anthropic/v1" onChange={(event) => setDraft({ ...draft, webSearchBaseUrl: event.target.value })} /><small>搜索会复用上方已加密保存的 API 密钥；自定义网关请填写其 Anthropic 兼容搜索端点，不会自动把密钥发送给其他服务。</small></label>
+            </div>
+          ) : null}
           <label className="model-default-control"><input type="checkbox" checked={draft.isDefault || models.length === 0} disabled={models.length === 0} onChange={(event) => setDraft({ ...draft, isDefault: event.target.checked })} /><span><strong>设为全局默认模型</strong><small>未单独分配模型的世界和角色会使用此配置。</small></span></label>
           <footer><span>{draft.id ? '正在编辑已保存配置' : '新配置保存后立即可用于路由'}</span><button className="primary-button" type="submit" disabled={savingModel}>{savingModel ? '正在保存…' : draft.id ? '保存修改' : '添加并保存'}</button></footer>
         </form>
@@ -745,6 +771,16 @@ function validateModelDraft(draft: ModelDraft): string | undefined {
   if (!draft.modelId.trim()) return '请输入模型 ID。'
   if (!Number.isInteger(draft.contextWindow) || draft.contextWindow < 1_024) return '上下文窗口必须是不小于 1024 的整数。'
   if (!Number.isInteger(draft.maxTokens) || draft.maxTokens < 256) return '最大输出 Token 必须是不小于 256 的整数。'
+  if (draft.webSearchEnabled) {
+    if (!draft.webSearchBaseUrl.trim()) return '启用联网搜索后，请填写搜索服务地址。'
+    try {
+      const searchUrl = new URL(draft.webSearchBaseUrl.trim())
+      if (searchUrl.protocol !== 'https:') return '联网搜索服务必须使用 HTTPS 地址。'
+    } catch {
+      return '联网搜索服务地址格式不正确。'
+    }
+    if (draft.credentialMode === 'none') return '联网搜索需要 API 密钥或凭据环境变量。'
+  }
   return undefined
 }
 

--- a/packages/web/src/features/world/renderer/pixi-world-renderer.ts
+++ b/packages/web/src/features/world/renderer/pixi-world-renderer.ts
@@ -59,6 +59,7 @@ export class PixiWorldRenderer implements WorldRenderer<HTMLElement> {
   readonly #actors = new Map<string, ActorView>()
   readonly #objectHints = new Map<string, Graphics>()
   readonly #growthMarkers = new Map<string, GrowthMarkerView>()
+  readonly #actorBubbles = new Map<string, Container>()
   readonly #assetTextures = new Map<string, Texture>()
   readonly #layerTextures = new Set<Texture>()
   readonly #appliedCueIds = new Set<string>()
@@ -136,6 +137,7 @@ export class PixiWorldRenderer implements WorldRenderer<HTMLElement> {
     const activeIds = new Set(snapshot.entities.filter((entity) => entity.kind === 'agent').map((entity) => entity.id))
     for (const [entityId, actor] of this.#actors) {
       if (activeIds.has(entityId)) continue
+      this.#removeBubble(entityId)
       actor.animation.destroy()
       actor.root.destroy({ children: true })
       this.#actors.delete(entityId)
@@ -263,6 +265,8 @@ export class PixiWorldRenderer implements WorldRenderer<HTMLElement> {
     this.#objectHints.clear()
     for (const marker of this.#growthMarkers.values()) marker.root.destroy({ children: true })
     this.#growthMarkers.clear()
+    for (const bubble of this.#actorBubbles.values()) bubble.destroy({ children: true })
+    this.#actorBubbles.clear()
     this.#appliedCueIds.clear()
     this.#lastCueSequence.clear()
     if (this.#initialized) this.#app.destroy(true, { children: true, texture: false, textureSource: false })
@@ -430,6 +434,7 @@ export class PixiWorldRenderer implements WorldRenderer<HTMLElement> {
   #showBubble(actor: ActorView, text: string): void {
     const compact = text.replace(/\s+/g, ' ').trim().slice(0, 38)
     if (!compact) return
+    this.#removeBubble(actor.state.id)
     const bubble = new Container()
     const label = new Text({ text: compact, style: { fontFamily: 'Microsoft YaHei, sans-serif', fontSize: 14, fill: 0xf6f7f8, wordWrap: true, wordWrapWidth: 220, lineHeight: 20 } })
     const width = Math.min(240, Math.max(110, label.width + 24))
@@ -441,7 +446,18 @@ export class PixiWorldRenderer implements WorldRenderer<HTMLElement> {
     bubble.zIndex = 9_500
     bubble.addChild(plate, label)
     this.#effectsLayer.addChild(bubble)
-    window.setTimeout(() => bubble.destroy({ children: true }), 4_000)
+    this.#actorBubbles.set(actor.state.id, bubble)
+    window.setTimeout(() => {
+      if (this.#actorBubbles.get(actor.state.id) !== bubble) return
+      this.#removeBubble(actor.state.id)
+    }, 4_000)
+  }
+
+  #removeBubble(entityId: string): void {
+    const bubble = this.#actorBubbles.get(entityId)
+    if (bubble === undefined) return
+    this.#actorBubbles.delete(entityId)
+    bubble.destroy({ children: true })
   }
 
   #setLights(lightsOn: boolean): void {


### PR DESCRIPTION
## 结果

- 为模型配置增加显式、可持久化的 DSH 联网搜索开关与兼容服务地址
- 将真实会话、工具调用和完成事件幂等投影到员工事迹与每日日志
- 同一角色只保留一个瞬时气泡，避免状态与回复互相遮挡
- 档案每次打开重新读取最新投影

## 验证

- `pnpm typecheck`
- `pnpm test`：255 tests
- `pnpm verify`
- `pnpm test:e2e`：12 scenarios
- 1440x900、1920x1080、3840x2160 浏览器视觉检查
- 本地实际会话与档案投影检查，控制台无未解释 error/warn

## 安全

- 搜索能力默认关闭，只有用户显式启用后才绑定搜索提供方
- 搜索端点必须使用 HTTPS
- 凭据继续由现有本机加密凭据存储管理，不写入模型档案、日志或 Git
