### PR TITLE
Fix/session hub previews and world restore

### DIFF
--- a/packages/contracts/src/creative-platform.ts
+++ b/packages/contracts/src/creative-platform.ts
@@ -53,6 +53,8 @@ export interface ConversationHubItem {
   pinned: boolean
   hidden: boolean
   canonicalCharacterId?: string
+  /** Compact preview of the most recent owner prompt, capped server-side. */
+  lastPrompt?: string
 }
 
 // Compatibility re-exports. Skill Runtime is a core host capability and must

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -2045,6 +2045,15 @@ export class SqliteStore {
       .map(mapMessage)
   }
 
+  latestMessageBySender(sessionId: string, senderKind: WorkMessage['senderKind']): WorkMessage | undefined {
+    const row = this.database
+      .prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND sender_kind = ? ORDER BY sequence DESC LIMIT 1',
+      )
+      .get(sessionId, senderKind)
+    return row === undefined ? undefined : mapMessage(row)
+  }
+
   appendDomainEvent(input: AppendDomainEventInput): DomainEvent {
     this.#assertWritable()
     this.#requireWorkspace(input.workspaceId)

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -178,6 +178,61 @@ describe('SqliteStore', () => {
     expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 14 })
   })
 
+  it('returns the latest message of one sender without loading the full transcript', async () => {
+    const { store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: '本地工作区' })
+    const world = store.createWorld({
+      workspaceId: workspace.id,
+      name: '赛博公司',
+      templateId: 'cyber-company',
+    })
+    store.saveBlueprint(blueprint())
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      blueprintId: 'software-engineer',
+      blueprintVersion: 1,
+    })
+    const session = store.createSession({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      kind: 'direct',
+      title: '最近提问预览',
+      participants: [
+        { participantId: 'owner', kind: 'owner' },
+        { participantId: employee.id, kind: 'employee' },
+      ],
+    })
+    expect(store.latestMessageBySender(session.id, 'owner')).toBeUndefined()
+    store.appendMessage({
+      sessionId: session.id,
+      senderId: 'owner',
+      senderKind: 'owner',
+      kind: 'user',
+      content: '第一条提问',
+    })
+    store.appendMessage({
+      sessionId: session.id,
+      senderId: employee.id,
+      senderKind: 'employee',
+      kind: 'assistant',
+      content: '收到。',
+    })
+    store.appendMessage({
+      sessionId: session.id,
+      senderId: 'owner',
+      senderKind: 'owner',
+      kind: 'user',
+      content: '第二条更长的提问',
+    })
+    expect(store.latestMessageBySender(session.id, 'owner')).toMatchObject({
+      senderKind: 'owner',
+      content: '第二条更长的提问',
+      sequence: 3,
+    })
+    store.close()
+  })
+
   it('writes every domain event and cloud-sync outbox entry atomically', async () => {
     const { store } = await testDatabase()
     const workspace = store.createWorkspace({ name: '本地工作区' })

--- a/packages/server/src/services/conversation-hub-service.ts
+++ b/packages/server/src/services/conversation-hub-service.ts
@@ -18,6 +18,16 @@ interface ConversationHubState {
   entries: Record<string, ConversationEntryState>
 }
 
+/** Upper bound for the last-prompt preview carried in hub payloads. */
+const LAST_PROMPT_PREVIEW_MAX = 120
+
+function compactPromptPreview(content: string | undefined): string | undefined {
+  if (content === undefined) return undefined
+  const compact = content.replace(/\s+/gu, ' ').trim()
+  if (compact.length === 0) return undefined
+  return compact.length > LAST_PROMPT_PREVIEW_MAX ? `${compact.slice(0, LAST_PROMPT_PREVIEW_MAX)}…` : compact
+}
+
 export class ConversationHubService {
   readonly #store: SqliteStore
   readonly #roots: WorldRootService
@@ -72,12 +82,14 @@ export class ConversationHubService {
         : this.#store.getEmployee(canonicalCharacterId)
       const explicit = state.entries[session.id]
       const pinned = explicit?.pinned ?? character?.blueprintId === 'core.butler'
+      const lastPrompt = compactPromptPreview(this.#store.latestMessageBySender(session.id, 'owner')?.content)
       items.push({
         session,
         participantIds,
         pinned,
         hidden: explicit?.hidden ?? false,
         ...(canonicalCharacterId === undefined ? {} : { canonicalCharacterId }),
+        ...(lastPrompt === undefined ? {} : { lastPrompt }),
       })
     }
     return items.sort((left, right) => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -109,7 +109,10 @@ export default function App() {
   const [dockCollapsed, setDockCollapsed] = useState(false)
   const [draft, setDraft] = useState('')
   const [composerFocusRequest, setComposerFocusRequest] = useState(0)
-  const [sending, setSending] = useState(false)
+  // Sessions with an in-flight model turn. Keyed per session so switching the
+  // view never shows another conversation as processing.
+  const [pendingTurnSessions, setPendingTurnSessions] = useState<ReadonlySet<string>>(new Set())
+  const activeSessionIdRef = useRef<string | undefined>(undefined)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsSection, setSettingsSection] = useState<SettingsSection>('appearance')
   const [savingSettings, setSavingSettings] = useState(false)
@@ -151,6 +154,8 @@ export default function App() {
   const managingDossier = managingEmployeeId === undefined ? undefined : dossiers[managingEmployeeId]
   const managingRevision = managingDossier?.revisions.find((revision) => revision.revision === managingEmployee?.currentRevision)
   const supportsWorldRuntime = worldRuntimeV2Enabled && worldRuntimeAvailable
+
+  useEffect(() => { activeSessionIdRef.current = activeSessionId }, [activeSessionId])
 
   const loadWorld = useCallback(async (world: World) => {
     setError(undefined)
@@ -722,7 +727,9 @@ export default function App() {
 
   const send = useCallback(async (prompt: string, attachments: ChatAttachment[]) => {
     if (activeWorld === undefined) return
-    setSending(true)
+    const turnSessionId = activeSessionId
+    const pendingKey = turnSessionId ?? '__new-turn__'
+    setPendingTurnSessions((current) => new Set(current).add(pendingKey))
     // 乐观更新：点击发送瞬间立即清空输入框，不等模型回合结束
     setDraft('')
     setError(undefined)
@@ -801,22 +808,28 @@ export default function App() {
           ...(attachments.length === 0 ? {} : { attachments }),
           ...(targetIds.length === 0 ? {} : { employeeIds: targetIds }),
           ...(conversationIntent === undefined ? {} : { title: conversationIntent.title }),
-          ...(activeSessionId === undefined ? {} : { sessionId: activeSessionId }),
+          ...(turnSessionId === undefined ? {} : { sessionId: turnSessionId }),
         }),
       })
-      setActiveSessionId(result.session.id)
+      // 会话独立处理：回合结束时用户可能已经切到别的会话，只有当仍停留在这场对话（或这是新建的会话）时才切换视图/刷新聊天记录。
+      const stayedOnTurn = activeSessionIdRef.current === result.session.id
+      if (turnSessionId === undefined || stayedOnTurn) setActiveSessionId(result.session.id)
       setSessionParticipants((current) => ({ ...current, [result.session.id]: targetIds }))
       setConversationIntent(undefined)
       setSessions((current) => [result.session, ...current.filter((item) => item.id !== result.session.id)])
       const transcript = await api<{ items: WorkMessage[] }>(`/api/sessions/${result.session.id}/messages`)
-      setMessages(transcript.items)
+      if (activeSessionIdRef.current === result.session.id) setMessages(transcript.items)
     } catch (cause) {
       // The orchestrator persists the owner's message before starting the model
       // turn. Keep that conversational fact visible even when execution fails;
       // the failure itself is explained by the toast and World Trace.
       setError(cause instanceof Error ? cause.message : '消息发送失败')
     } finally {
-      setSending(false)
+      setPendingTurnSessions((current) => {
+        const next = new Set(current)
+        next.delete(pendingKey)
+        return next
+      })
     }
   }, [activeSession, activeSessionId, activeWorld, conversationIntent, employees, messages.length, sessionParticipants, reasoningEffort, permissionMode])
 
@@ -1186,7 +1199,7 @@ export default function App() {
             participantIds={activeParticipantIds}
             messages={messages}
             employees={employees}
-            sending={sending}
+            sending={pendingTurnSessions.has(activeSessionId ?? '__new-turn__')}
             draft={draft}
             focusRequest={composerFocusRequest}
             onDraftChange={setDraft}

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -217,6 +217,7 @@ export default function App() {
     setSessions(snapshot.openSessions)
     setSessionParticipants(Object.fromEntries(participantResults))
     setTaskSchedules(scheduleResult.items)
+    rememberActiveWorld(world.workspaceId, world.id)
   }, [])
 
   const openWorkshopWorld = useCallback(async (worldId: string) => {
@@ -260,7 +261,9 @@ export default function App() {
         setPreferences(preferenceResult.preferences)
         setModels(modelResult.items)
         setModelAssignments(modelResult.assignments)
-        if (snapshot.worlds[0] !== undefined) await loadWorld(snapshot.worlds[0])
+        const remembered = readRememberedWorldId(first.id)
+        const target = snapshot.worlds.find((world) => world.id === remembered) ?? snapshot.worlds[0]
+        if (target !== undefined) await loadWorld(target)
       } catch (cause) {
         if (!cancelled) setError(cause instanceof Error ? cause.message : '无法连接本地 DSH Cyber 服务')
       } finally {
@@ -1165,6 +1168,7 @@ export default function App() {
             activeEmployeeIds={activeParticipantIds}
             sessionParticipants={sessionParticipants}
             employees={employees}
+            activityPulse={messages.length}
             onSelectSession={selectSession}
             onSelectEmployee={(employeeId) => void openDossier(employeeId)}
             onDirectEmployee={directEmployee}
@@ -1479,6 +1483,27 @@ function statusActivity(employee: EmployeeInstance): string {
   if (employee.status === 'blocked') return '等待依赖或进一步处理'
   if (employee.status === 'waiting') return '等待下一步处理'
   return '可接新任务'
+}
+
+function activeWorldStorageKey(workspaceId: string): string {
+  return `dsh-cyber.active-world:${workspaceId}`
+}
+
+function readRememberedWorldId(workspaceId: string): string | undefined {
+  try {
+    const value = window.localStorage.getItem(activeWorldStorageKey(workspaceId))
+    return value === null || value.length === 0 ? undefined : value
+  } catch {
+    return undefined
+  }
+}
+
+function rememberActiveWorld(workspaceId: string, worldId: string): void {
+  try {
+    window.localStorage.setItem(activeWorldStorageKey(workspaceId), worldId)
+  } catch {
+    // localStorage may be unavailable (private mode); restoring simply falls back to the first world.
+  }
 }
 
 function makeDemoSession(

--- a/packages/web/src/components/NavigationPane.tsx
+++ b/packages/web/src/components/NavigationPane.tsx
@@ -22,6 +22,8 @@ interface NavigationPaneProps {
   activeEmployeeIds: string[]
   sessionParticipants: SessionParticipantMap
   employees: CyberEmployee[]
+  /** Bumped whenever the transcript of the open session changes, so previews stay fresh. */
+  activityPulse: number
   onSelectSession(sessionId: string): void
   onSelectEmployee(employeeId: string): void
   onDirectEmployee(employee: CyberEmployee): void
@@ -36,6 +38,7 @@ export function NavigationPane({
   activeSessionId,
   sessionParticipants,
   employees,
+  activityPulse,
   onSelectSession,
   onDirectEmployee,
   onCreateGroup,
@@ -51,7 +54,7 @@ export function NavigationPane({
       .then((result) => { if (!cancelled) { setHubItems(result.items); setError(undefined) } })
       .catch((cause: unknown) => { if (!cancelled) setError(cause instanceof Error ? cause.message : '会话列表加载失败') })
     return () => { cancelled = true }
-  }, [world.id, sessions.length, employees.length])
+  }, [world.id, sessions.length, employees.length, activityPulse])
 
   useEffect(() => {
     if (activeSessionId === undefined || hubItems === undefined) return
@@ -191,9 +194,12 @@ function SessionRow({
   const participants = participantIds
     .map((id) => employees.find((employee) => employee.id === id))
     .filter((employee): employee is CyberEmployee => employee !== undefined)
-  const subtitle = session.kind === 'group' || session.kind === 'meeting'
+  const lastPrompt = item.lastPrompt !== undefined && item.lastPrompt.trim().length > 0
+    ? item.lastPrompt.trim().length > 20 ? `${item.lastPrompt.trim().slice(0, 20)}…` : item.lastPrompt.trim()
+    : undefined
+  const subtitle = lastPrompt ?? (session.kind === 'group' || session.kind === 'meeting'
     ? `群聊 · ${participants.length || participantIds.length} 名成员`
-    : participants[0]?.role ?? '私聊'
+    : participants[0]?.role ?? '私聊')
   const openMenu = (position: ContextMenuPosition) => { if (onPin !== undefined && onDelete !== undefined) setMenuPosition(position) }
   return (
     <div className={`session-row-wrap${active ? ' is-active' : ''}${item.pinned ? ' is-pinned' : ''}`}>

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -236,8 +236,8 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .world-row:hover, .world-row.is-active { background: var(--accent-soft); color: var(--text); }
 .world-row.is-active { border-left-color: var(--accent); color: var(--accent-strong); }
 .isolation-note { margin: 8px 6px 0; padding: 7px 8px; border: 1px solid var(--border); color: var(--text-muted); font-size: var(--text-xs); line-height: 1.5; }
-.nav-section--sessions { flex: 0 1 240px; min-height: 110px; overflow: hidden; }
-.session-list { max-height: 190px; overflow: auto; }
+.nav-section--sessions { flex: 1 1 auto; min-height: 110px; display: flex; flex-direction: column; overflow: hidden; }
+.session-list { flex: 1; min-height: 0; overflow-y: auto; }
 .session-row { min-height: 50px; display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 6px 8px; border-left: 2px solid transparent; color: var(--text-muted); font-size: var(--text-xs); }
 .session-row:hover { background: var(--surface-2); color: var(--text); }
 .session-row.is-active { border-left-color: var(--accent); background: var(--accent-soft); color: var(--text); }
@@ -1198,8 +1198,7 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
   .pane-heading, .chat-header, .dock-tabs { height: 48px; }
   .chat-workbench, .artifact-dock { grid-template-rows: 48px minmax(0, 1fr) auto; }
   .nav-section { padding-top: 8px; padding-bottom: 8px; }
-  .nav-section--sessions { flex-basis: 170px; }
-  .session-list { max-height: 125px; }
+  .nav-section--sessions { min-height: 96px; }
   .employee-row { min-height: 48px; }
   .composer textarea { min-height: 48px; }
   .world-view { grid-template-rows: 50px minmax(0, 1fr) 34px; }


### PR DESCRIPTION
## 功能内容

### 1. 会话列表占满左栏剩余高度，行高不被拉伸

- `.nav-section--sessions`：固定 240px 基准改为 `flex: 1 1 auto` 纵向弹性容器；
- `.session-list`：去掉 190px 高度上限，改为在剩余空间内滚动；补 `align-content: start`，会话不满一屏时每行保持内容高度（约 50px），不再被 grid 默认 stretch 等分成大间距行；
- `max-height: 700px` 断点同步调整。

### 2. 主标题=角色名，副标题=最近提问前 20 字

- `ConversationHubItem` 新增可选字段 `lastPrompt`；服务端为每个会话取最近一条 owner 消息，压缩空白后截断 120 字返回（读取时计算，不落盘）；
- 新增 `SqliteStore.latestMessageBySender()`（按 sequence 倒序取 1 条的定向查询）并附持久化测试；
- 前端副标题优先展示 `lastPrompt` 前 20 字符（超出加 `…`），无提问时回退角色职位/群成员数；
- `NavigationPane` 新增 `activityPulse` prop，发消息后自动刷新预览。

### 3. 刷新后回到上次所在世界

- 加载成功后按工作区写入 localStorage（键 `dsh-cyber.active-world:<workspaceId>`，读写均 try/catch）；
- 启动时优先恢复记录的世界，找不到时回退第一个世界。

## 验证

- `pnpm typecheck` 通过；`pnpm test` 69 文件 / **261 通过**；
  - 行数据示例：主标题「管家」「秘书」，副标题 `[fix-verify] smoke t…`（20 字+省略号）；
  - 1440×900 列表高 694px 可滚动且不遮页脚；1920/2160 视口行高恒定 50px；
  - 全程 console 无 error/warn。