### PR TITLE
feat: add installed plugin chat picker

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -177,6 +177,18 @@ export interface CyberMarketCommand {
   description: string
 }
 
+/** A safe, user-facing command exposed by an installed global plugin. */
+export interface InstalledPluginCommand {
+  packageId: string
+  packageVersion: string
+  displayName: string
+  summary: string
+  trigger: string
+  displayTrigger: string
+  description: string
+  automatic: boolean
+}
+
 export type CyberMarketActivation =
   | {
       kind: 'world-theme'

--- a/packages/server/src/installed-package-runtime.ts
+++ b/packages/server/src/installed-package-runtime.ts
@@ -24,6 +24,17 @@ export interface InstalledWorldTheme {
   manifest: WorldThemeManifestV1
 }
 
+export interface InstalledPromptTransformCommand {
+  packageId: string
+  packageVersion: string
+  displayName: string
+  summary: string
+  trigger: string
+  displayTrigger: string
+  description: string
+  automatic: boolean
+}
+
 export class InstalledPackageVerificationCache {
   readonly #verifiedPackages = new Set<string>()
   #fullVerificationPasses = 0
@@ -63,7 +74,7 @@ export async function applyInstalledPromptTransforms(
       assertPromptTransformPackage(installed)
       const definition = parsePromptTransformDefinition(await readEntrypoint<unknown>(installed, entrypoint.path))
       for (const [index, transform] of definition.transforms.entries()) {
-        if (!transformMatches(originalPrompt, transform.trigger)) continue
+        if (!transformMatches(originalPrompt, transform.trigger) && !transformMatches(originalPrompt, localizedPluginTrigger(installed.packageId, transform.trigger))) continue
         matched.push({
           packageId: installed.packageId,
           packageVersion: installed.version,
@@ -86,6 +97,53 @@ export async function applyInstalledPromptTransforms(
     .filter((item) => item.transform.mode === 'append')
     .map((item) => item.transform.instruction)
   return [...prepends, base, ...appends].join('\n\n')
+}
+
+/**
+ * Returns only the command metadata needed by the chat composer. The prompt
+ * instructions themselves never leave the server, so the picker cannot leak
+ * plugin implementation details or credentials into the browser.
+ */
+export async function loadInstalledPromptTransformCommands(
+  packages: InstalledPackage[],
+): Promise<InstalledPromptTransformCommand[]> {
+  const commands: InstalledPromptTransformCommand[] = []
+  for (const installed of packages.filter((item) => item.status === 'active' && item.kind === 'plugin')) {
+    const entrypoints = (installed.manifest.entrypoints ?? []).filter((entrypoint) => entrypoint.kind === 'prompt-transform')
+    if (entrypoints.length === 0) continue
+    try {
+      assertPromptTransformPackage(installed)
+      for (const entrypoint of entrypoints) {
+        const definition = parsePromptTransformDefinition(await readEntrypoint<unknown>(installed, entrypoint.path))
+        for (const transform of definition.transforms) {
+          commands.push({
+            packageId: installed.packageId,
+            packageVersion: installed.version,
+            displayName: installed.manifest.displayName,
+            summary: installed.manifest.summary,
+            trigger: transform.trigger,
+            displayTrigger: localizedPluginTrigger(installed.packageId, transform.trigger),
+            description: transform.description,
+            automatic: transform.trigger === 'always',
+          })
+        }
+      }
+    } catch {
+      // A malformed installed package stays unavailable to the picker. The
+      // runtime's strict parser remains the authority when a turn executes.
+    }
+  }
+  return commands.sort((left, right) => left.displayName.localeCompare(right.displayName) || left.trigger.localeCompare(right.trigger))
+}
+
+function localizedPluginTrigger(packageId: string, trigger: string): string {
+  const localized: Record<string, Record<string, string>> = {
+    'official-decision-log': { '/decision-log': '/决策记录' },
+    'official-meeting-notes': { '/meeting-summary': '/会议纪要' },
+    'official-release-check': { '/release-check': '/发布检查' },
+    'official-research-brief': { '/research-brief': '/研究简报' },
+  }
+  return localized[packageId]?.[trigger] ?? trigger
 }
 
 export async function loadInstalledBlueprints(packages: InstalledPackage[]): Promise<EmployeeBlueprint[]> {

--- a/packages/server/src/routes/package-routes.ts
+++ b/packages/server/src/routes/package-routes.ts
@@ -6,7 +6,7 @@ import { HttpError } from '../http/errors.js'
 import type { Router } from '../http/router.js'
 import { optionalString, packageManifest, readJson, requiredString } from '../http/request.js'
 import { writeJson } from '../http/response.js'
-import { loadInstalledBlueprints } from '../installed-package-runtime.js'
+import { loadInstalledBlueprints, loadInstalledPromptTransformCommands } from '../installed-package-runtime.js'
 import type { CharacterSkillRuntime } from '../services/character-skill-runtime.js'
 import { CreativeWorkshopService } from '../services/creative-workshop-service.js'
 import type { WorldMarketplaceService } from '../services/world-marketplace-service.js'
@@ -30,6 +30,13 @@ export function registerPackageRoutes(router: Router, dependencies: PackageRoute
       items: store.listInstalledPackages(workspaceId),
       transactions: store.listPackageInstallTransactions(workspaceId),
     })
+  })
+
+  router.get(/^\/api\/workspaces\/([^/]+)\/plugins$/, async ({ response, params }) => {
+    const workspaceId = params[0]!
+    if (store.getWorkspace(workspaceId) === undefined) throw new HttpError(404, 'workspace_not_found', 'Workspace not found')
+    const items = await loadInstalledPromptTransformCommands(store.listInstalledPackages(workspaceId))
+    writeJson(response, 200, { items })
   })
 
   router.get(/^\/api\/workspaces\/([^/]+)\/skill-catalog$/, ({ response, params }) => {

--- a/packages/server/src/services/world-root-service.ts
+++ b/packages/server/src/services/world-root-service.ts
@@ -22,7 +22,11 @@ export class WorldRootService {
     const managedRoot = await realpath(this.#root)
     const managedInfo = await lstat(this.#root)
     if (managedInfo.isSymbolicLink() || !managedInfo.isDirectory()) throw new Error('Managed world directory is not a real directory')
-    const rootPath = this.#safeWorldRoot(worldId)
+    // Resolve the child from the canonical managed path. On Windows the
+    // configured state root may contain an 8.3 alias (for example
+    // `ADMINI~1`) while realpath returns the long form (`Administrator`);
+    // mixing the two makes a valid child look like it escaped the sandbox.
+    const rootPath = this.#safeWorldRoot(worldId, managedRoot)
     await rejectSymlink(rootPath)
     const filesPath = join(rootPath, 'files')
     const assetsPath = join(rootPath, 'assets')
@@ -49,7 +53,7 @@ export class WorldRootService {
     const managedRoot = await realpath(this.#root)
     const managedInfo = await lstat(this.#root)
     if (managedInfo.isSymbolicLink() || !managedInfo.isDirectory()) throw new Error('Managed world directory is not a real directory')
-    const rootPath = this.#safeWorldRoot(worldId)
+    const rootPath = this.#safeWorldRoot(worldId, managedRoot)
     if (!isPathWithin(managedRoot, rootPath) || rootPath === managedRoot) {
       throw new Error('Refusing to remove a path outside the managed world directory')
     }
@@ -57,10 +61,10 @@ export class WorldRootService {
     await rm(rootPath, { recursive: true, force: true })
   }
 
-  #safeWorldRoot(worldId: string): string {
+  #safeWorldRoot(worldId: string, baseRoot = this.#root): string {
     const safeId = encodeURIComponent(worldId)
-    const rootPath = resolve(this.#root, safeId)
-    if (rootPath === this.#root || !rootPath.startsWith(`${this.#root}${sep}`)) {
+    const rootPath = resolve(baseRoot, safeId)
+    if (rootPath === baseRoot || !rootPath.startsWith(`${baseRoot}${sep}`)) {
       throw new Error('World root escaped managed data directory')
     }
     return rootPath

--- a/packages/server/tests/installed-package-runtime.test.ts
+++ b/packages/server/tests/installed-package-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   applyInstalledPromptTransforms,
   InstalledPackageVerificationCache,
   loadInstalledBlueprints,
+  loadInstalledPromptTransformCommands,
   loadInstalledWorldThemes,
   parsePromptTransformDefinition,
   readInstalledWorldThemeAsset,
@@ -23,12 +24,14 @@ describe('installed package entrypoints', () => {
     const content = `${JSON.stringify({ schemaVersion: 1, transforms: [{ id: 'meeting-summary', trigger: '/meeting-summary', description: '整理会议事实。', instruction: '输出决策、负责人和截止日期。', mode: 'prepend', priority: 10 }] })}\n`
     await writeFile(join(root, 'commands.json'), content, 'utf8')
     const installed = packageRecord(root, {
+      id: 'official-meeting-notes',
       kind: 'plugin',
       capabilities: ['prompt:transform'],
       files: [{ path: 'commands.json', sha256: createHash('sha256').update(content).digest('hex') }],
       entrypoints: [{ id: 'commands', kind: 'prompt-transform', path: 'commands.json' }],
     })
     await expect(applyInstalledPromptTransforms([installed], '/meeting-summary 今天的发布会')).resolves.toBe('输出决策、负责人和截止日期。\n\n/meeting-summary 今天的发布会')
+    await expect(applyInstalledPromptTransforms([installed], '/会议纪要 今天的发布会')).resolves.toBe('输出决策、负责人和截止日期。\n\n/会议纪要 今天的发布会')
     await expect(applyInstalledPromptTransforms([installed], '普通消息')).resolves.toBe('普通消息')
   })
 
@@ -42,6 +45,30 @@ describe('installed package entrypoints', () => {
       entrypoints: [{ id: 'commands', kind: 'prompt-transform', path: 'commands.json' }],
     })
     await expect(applyInstalledPromptTransforms([installed], '/meeting-summary 今天的发布会')).resolves.toBe('输出纪要。\n\n/meeting-summary 今天的发布会')
+  })
+
+  it('exposes only safe command metadata for the chat plugin picker', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-cyber-plugin-commands-'))
+    const content = `${JSON.stringify({ schemaVersion: 1, transforms: [{ id: 'research', trigger: '/research-brief', description: '整理研究简报。', instruction: '只在服务端使用。', mode: 'prepend', priority: 10 }] })}\n`
+    await writeFile(join(root, 'commands.json'), content, 'utf8')
+    const installed = packageRecord(root, {
+      id: 'official-research-brief',
+      displayName: 'Research Brief',
+      summary: 'Research helper',
+      capabilities: ['prompt:transform'],
+      files: [{ path: 'commands.json', sha256: createHash('sha256').update(content).digest('hex') }],
+      entrypoints: [{ id: 'commands', kind: 'prompt-transform', path: 'commands.json' }],
+    })
+    await expect(loadInstalledPromptTransformCommands([installed])).resolves.toEqual([{
+      packageId: 'official-research-brief',
+      packageVersion: '1.0.0',
+      displayName: 'Research Brief',
+      summary: 'Research helper',
+      trigger: '/research-brief',
+      displayTrigger: '/研究简报',
+      description: '整理研究简报。',
+      automatic: false,
+    }])
   })
 
   it('applies matching transforms by priority with deterministic mode semantics', async () => {

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -22,6 +22,7 @@ import type {
   EmployeeInstance,
   EmployeeRevision,
   InstalledPackage,
+  InstalledPluginCommand,
   JsonObject,
   LocalAssetMimeType,
   ModelAssignment,
@@ -119,6 +120,7 @@ export default function App() {
   const [packageMarketKind, setPackageMarketKind] = useState<CyberMarketKind>('theme')
   const [marketplaceItems, setMarketplaceItems] = useState<CyberMarketPackage[]>([])
   const [installedPackages, setInstalledPackages] = useState<InstalledPackage[]>([])
+  const [installedPluginCommands, setInstalledPluginCommands] = useState<InstalledPluginCommand[]>([])
   const [packageTransactions, setPackageTransactions] = useState<PackageInstallTransaction[]>([])
   const [packageLoading, setPackageLoading] = useState(false)
   const [packageInstalling, setPackageInstalling] = useState(false)
@@ -388,6 +390,17 @@ export default function App() {
     setPackageTransactions(result.transactions)
   }, [demoMode, workspace])
 
+  const loadInstalledPluginCommands = useCallback(async () => {
+    if (workspace === undefined || demoMode) return
+    const result = await api<{ items: InstalledPluginCommand[] }>(`/api/workspaces/${workspace.id}/plugins`)
+    setInstalledPluginCommands(result.items)
+  }, [demoMode, workspace])
+
+  useEffect(() => {
+    if (demoMode || workspace === undefined) return
+    void loadInstalledPluginCommands().catch(() => setInstalledPluginCommands([]))
+  }, [demoMode, loadInstalledPluginCommands, workspace])
+
   const searchMarketplace = useCallback(async (market: CyberMarketKind, query = '') => {
     if (workspace === undefined) return
     const result = await api<{ items: CyberMarketPackage[] }>(`/api/marketplace?market=${market}&workspaceId=${encodeURIComponent(workspace.id)}&q=${encodeURIComponent(query)}`)
@@ -455,12 +468,12 @@ export default function App() {
           method: 'POST',
           body: JSON.stringify(input),
         })
-        await loadPackages()
+        await Promise.all([loadPackages(), loadInstalledPluginCommands()])
       }
     } finally {
       setPackageInstalling(false)
     }
-  }, [loadPackages, workspace])
+  }, [demoMode, loadInstalledPluginCommands, loadPackages, workspace])
 
   const previewMarketplacePackage = useCallback(async (item: CyberMarketPackage): Promise<PackagePermissionPreview> => {
     if (workspace === undefined) throw new Error('工作区尚未就绪')
@@ -479,6 +492,22 @@ export default function App() {
       if (demoMode) {
         await installPackage({ manifest: item.manifest, sourceDirectory: item.sourceDirectory, approvalToken })
         const timestamp = new Date().toISOString()
+        const activation = item.activation
+        if (item.market === 'plugin' && activation?.kind === 'prompt-transform') {
+          setInstalledPluginCommands((current) => [
+            ...current.filter((command) => command.packageId !== item.manifest.id),
+            ...activation.commands.map((command) => ({
+              packageId: item.manifest.id,
+              packageVersion: item.manifest.version,
+              displayName: item.manifest.displayName,
+              summary: item.manifest.summary,
+              trigger: command.trigger,
+              displayTrigger: localizedPluginTrigger(item.manifest.id, command.trigger),
+              description: command.description,
+              automatic: activation.automatic,
+            })),
+          ])
+        }
         setMarketplaceItems((current) => current.map((candidate) => candidate.manifest.id === item.manifest.id
           ? { ...candidate, installedVersion: item.manifest.version }
           : candidate))
@@ -497,12 +526,12 @@ export default function App() {
           method: 'POST',
           body: JSON.stringify({ packageId: item.manifest.id, version: item.manifest.version, approvalToken }),
         })
-        await Promise.all([loadPackages(), searchMarketplace(item.market)])
+        await Promise.all([loadPackages(), searchMarketplace(item.market), item.market === 'plugin' ? loadInstalledPluginCommands() : Promise.resolve()])
       }
     } finally {
       setPackageInstalling(false)
     }
-  }, [installPackage, loadPackages, searchMarketplace, workspace])
+  }, [demoMode, installPackage, loadInstalledPluginCommands, loadPackages, searchMarketplace, workspace])
 
   const recruitEmployee = useCallback(async (
     blueprint: EmployeeBlueprint,
@@ -1182,6 +1211,7 @@ export default function App() {
             participantIds={activeParticipantIds}
             messages={messages}
             employees={employees}
+            installedPlugins={installedPluginCommands}
             sending={sending}
             draft={draft}
             focusRequest={composerFocusRequest}
@@ -1191,6 +1221,7 @@ export default function App() {
             onOpenDossier={(employeeId) => void openDossier(employeeId)}
             onOpenArtifact={() => { setAppMode('world'); setDockCollapsed(false); setDockTab('world') }}
             onRecruit={() => { setSelectedEmployeeId(undefined); setDockCollapsed(false); setDockTab('dossier') }}
+            onOpenPluginMarket={() => void openPackageMarket('plugin')}
           />
         )}
         right={(
@@ -1452,6 +1483,16 @@ function Onboarding({ error, onCreated }: { error?: string; onCreated(): Promise
       <a href="?demo=1">先体验交互演示</a>
     </main>
   )
+}
+
+function localizedPluginTrigger(packageId: string, trigger: string): string {
+  const localized: Record<string, Record<string, string>> = {
+    'official-decision-log': { '/decision-log': '/决策记录' },
+    'official-meeting-notes': { '/meeting-summary': '/会议纪要' },
+    'official-release-check': { '/release-check': '/发布检查' },
+    'official-research-brief': { '/research-brief': '/研究简报' },
+  }
+  return localized[packageId]?.[trigger] ?? trigger
 }
 
 function toCyberEmployee(employee: EmployeeInstance, index: number, dossier?: EmployeeDossier): CyberEmployee {

--- a/packages/web/src/components/ChatWorkbench.tsx
+++ b/packages/web/src/components/ChatWorkbench.tsx
@@ -1,9 +1,11 @@
 import {
   BracketsCurly,
+  CaretDown,
   CircleNotch,
   File as FileIcon,
   PaperPlaneRight,
   Paperclip,
+  PuzzlePiece,
   TerminalWindow,
   UserCircle,
   X,
@@ -11,7 +13,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from 'react'
 import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
-import type { ChatAttachment, JsonObject, LocalAssetMimeType, WorkMessage, WorkSession, World } from '@dsh-cyber/contracts'
+import type { ChatAttachment, InstalledPluginCommand, JsonObject, LocalAssetMimeType, WorkMessage, WorkSession, World } from '@dsh-cyber/contracts'
 
 import { mentionPlugin } from './mention-plugin.js'
 import type { ConversationIntent, CyberEmployee } from '../types.js'
@@ -26,6 +28,7 @@ interface ChatWorkbenchProps {
   participantIds?: string[]
   messages: WorkMessage[]
   employees: CyberEmployee[]
+  installedPlugins?: InstalledPluginCommand[]
   sending: boolean
   draft: string
   focusRequest?: number
@@ -35,9 +38,10 @@ interface ChatWorkbenchProps {
   onOpenDossier(employeeId: string): void
   onOpenArtifact(): void
   onRecruit(): void
+  onOpenPluginMarket?(): void
 }
 
-export function ChatWorkbench({ demoMode, world, session, intent, participantIds = [], messages, employees, sending, draft, focusRequest = 0, onDraftChange, onSend, onUploadAttachment, onOpenDossier, onOpenArtifact, onRecruit }: ChatWorkbenchProps) {
+export function ChatWorkbench({ demoMode, world, session, intent, participantIds = [], messages, employees, installedPlugins = [], sending, draft, focusRequest = 0, onDraftChange, onSend, onUploadAttachment, onOpenDossier, onOpenArtifact, onRecruit, onOpenPluginMarket }: ChatWorkbenchProps) {
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
   const scrollRef = useRef<HTMLDivElement>(null)
@@ -152,11 +156,47 @@ export function ChatWorkbench({ demoMode, world, session, intent, participantIds
         <div className="composer__toolbar"><div>
           <input ref={fileInputRef} className="composer-file-input" type="file" accept=".png,.jpg,.jpeg,.webp,.txt,.md,.json,.pdf" onChange={(event) => { const file = event.target.files?.[0]; if (file) void uploadAttachment(file) }} />
           <button className="icon-button" type="button" aria-label={uploading ? '正在上传附件' : '添加附件'} disabled={uploading} onClick={() => fileInputRef.current?.click()}>{uploading ? <CircleNotch size={18} className="spin" /> : <Paperclip size={18} />}</button>
-          <span className="composer__hint">Enter 发送 · Shift+Enter 换行</span>
+          <PluginPicker plugins={installedPlugins} draft={draft} onDraftChange={onDraftChange} {...(onOpenPluginMarket === undefined ? {} : { onOpenMarket: onOpenPluginMarket })} onFocus={() => inputRef.current?.focus()} />
         </div><button className="send-button" type="button" aria-label={sending ? '角色处理中' : '发送'} disabled={sending || uploading || employees.length === 0 || (!draft.trim() && attachments.length === 0)} onClick={() => void submit()}>{sending ? <CircleNotch size={19} className="spin" /> : <PaperPlaneRight size={19} weight="fill" />}</button></div>
       </div></div>
     </section>
   )
+}
+
+function PluginPicker({ plugins, draft, onDraftChange, onOpenMarket, onFocus }: { plugins: InstalledPluginCommand[]; draft: string; onDraftChange(value: string): void; onOpenMarket?: () => void; onFocus(): void }) {
+  return (
+    <details className="composer-plugin-picker">
+      <summary aria-label="打开已安装插件"><PuzzlePiece size={17} /><span>插件</span>{plugins.length > 0 ? <b>{plugins.length}</b> : null}<CaretDown size={13} /></summary>
+      <div className="composer-plugin-picker__menu" role="menu" aria-label="已安装插件">
+        <header><strong>已安装插件</strong><span>点击后把指令放入输入框</span></header>
+        {plugins.length === 0 ? <div className="composer-plugin-picker__empty"><PuzzlePiece size={22} /><span>还没有可用插件</span>{onOpenMarket === undefined ? null : <button type="button" onClick={onOpenMarket}>前往插件市场</button>}</div> : plugins.map((plugin) => {
+          const copy = pluginCopy(plugin)
+          const automatic = plugin.automatic || plugin.trigger === 'always'
+          return <button key={`${plugin.packageId}:${plugin.packageVersion}:${plugin.trigger}`} className="composer-plugin-picker__item" type="button" role="menuitem" disabled={automatic} onClick={(event) => { onDraftChange(insertPluginTrigger(draft, plugin.displayTrigger)); event.currentTarget.closest('details')?.removeAttribute('open'); onFocus() }}>
+            <span className="composer-plugin-picker__icon"><PuzzlePiece size={17} weight="duotone" /></span>
+            <span className="composer-plugin-picker__copy"><strong>{copy.name}</strong><small>{copy.description}</small><code>{automatic ? '自动运行' : plugin.displayTrigger}</code></span>
+            <span className="composer-plugin-picker__version">v{plugin.packageVersion}</span>
+          </button>
+        })}
+      </div>
+    </details>
+  )
+}
+
+function insertPluginTrigger(draft: string, trigger: string): string {
+  if (trigger === 'always') return draft
+  const separator = draft.trim().length === 0 ? '' : ' '
+  return `${draft.trimEnd()}${separator}${trigger} `
+}
+
+function pluginCopy(plugin: InstalledPluginCommand): { name: string; description: string } {
+  const localized: Record<string, { name: string; description: string }> = {
+    'official-decision-log': { name: '决策记录', description: '整理背景、决策、取舍与复核事项。' },
+    'official-meeting-notes': { name: '会议纪要助手', description: '整理会议事实、行动项和风险。' },
+    'official-release-check': { name: '发布检查', description: '检查阻断项、证据、风险与回滚。' },
+    'official-research-brief': { name: '研究简报', description: '整理结论、证据、不确定性和下一步。' },
+  }
+  return localized[plugin.packageId] ?? { name: plugin.displayName, description: plugin.description || plugin.summary }
 }
 
 async function uploadWorldAttachment(worldId: string, file: File): Promise<ChatAttachment> {

--- a/packages/web/src/components/PackageMarketDialog.tsx
+++ b/packages/web/src/components/PackageMarketDialog.tsx
@@ -261,12 +261,13 @@ function PluginActivationReview({ item, onUse }: { item: CyberMarketPackage; onU
   </section>
 }
 
-type PackageCardState = 'uninstalled' | 'included' | 'upgrade' | 'installed'
+type PackageCardState = 'uninstalled' | 'included' | 'upgrade' | 'installed' | 'created'
 
 function packageCardState(item: CyberMarketPackage, worlds: World[]): PackageCardState {
-  if (item.installedVersion === item.manifest.version) return 'installed'
-  if (item.installedVersion !== undefined) return 'upgrade'
   const activation = item.activation
+  const hasCreatedWorld = item.market === 'theme' && activation?.kind === 'world-theme' && worlds.some((world) => world.templateId === activation.templateId)
+  if (item.installedVersion === item.manifest.version) return hasCreatedWorld ? 'created' : 'installed'
+  if (item.installedVersion !== undefined) return 'upgrade'
   if (activation?.kind === 'world-theme' && worlds.some((world) => builtInThemeMatches(world.templateId, activation.templateId))) {
     return 'included'
   }
@@ -274,6 +275,7 @@ function packageCardState(item: CyberMarketPackage, worlds: World[]): PackageCar
 }
 
 function packageStateLabel(item: CyberMarketPackage, state: PackageCardState): string {
+  if (state === 'created') return `已安装 v${item.installedVersion} · 已创建`
   if (state === 'installed') {
     const next = item.market === 'theme' ? '可创建' : item.market === 'talent' ? '可招募' : '可使用'
     return `已安装 v${item.installedVersion} · ${next}`
@@ -284,6 +286,7 @@ function packageStateLabel(item: CyberMarketPackage, state: PackageCardState): s
 }
 
 function marketAction(item: CyberMarketPackage, state: PackageCardState, onBind: () => void, onInspect: () => void, onActivate: () => void) {
+  if (item.market === 'theme' && state === 'created') return <button className="market-action--created" type="button" disabled><CheckCircle size={15} />已创建</button>
   if (item.market === 'theme' && state === 'installed') return <button className="market-action--installed" type="button" onClick={onBind}>创建新世界</button>
   if (state === 'installed') return <button className="market-action--installed" type="button" onClick={onActivate}>{item.market === 'talent' ? '招募到世界' : '立即使用'}</button>
   if (state === 'upgrade') return <button className="market-action--upgrade" type="button" onClick={onInspect}>升级到 v{item.manifest.version}</button>

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -402,6 +402,28 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .composer__toolbar { min-height: 38px; display: flex; align-items: center; justify-content: space-between; padding: 3px 6px; }
 .composer__toolbar > div { min-width: 0; display: flex; align-items: center; }
 .composer__hint { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; color: var(--text-muted); font-size: 9px; }
+.composer-plugin-picker { position: relative; margin-left: 4px; }
+.composer-plugin-picker > summary { min-height: 32px; display: inline-flex; align-items: center; gap: 5px; padding: 0 8px; border: 1px solid var(--border); background: var(--surface-0); color: var(--text-soft); cursor: pointer; list-style: none; font-size: 12px; }
+.composer-plugin-picker > summary::-webkit-details-marker { display: none; }
+.composer-plugin-picker > summary:hover, .composer-plugin-picker[open] > summary { border-color: var(--info); color: var(--text); background: color-mix(in srgb, var(--info) 8%, var(--surface-0)); }
+.composer-plugin-picker > summary b { min-width: 17px; height: 17px; display: inline-grid; place-items: center; border-radius: 99px; background: color-mix(in srgb, var(--info) 20%, var(--surface-2)); color: var(--info); font: 11px var(--font-mono); }
+.composer-plugin-picker__menu { position: absolute; z-index: 90; left: 0; bottom: calc(100% + 8px); width: min(400px, calc(100vw - 36px)); overflow: hidden; border: 1px solid var(--border-strong); background: var(--surface-1); box-shadow: 0 18px 46px rgb(0 0 0 / 32%); }
+.composer-plugin-picker__menu > header { display: grid; gap: 2px; padding: 12px 13px 10px; border-bottom: 1px solid var(--border); background: color-mix(in srgb, var(--info) 5%, var(--surface-1)); }
+.composer-plugin-picker__menu > header strong { color: var(--text); font-size: 13px; }
+.composer-plugin-picker__menu > header span { color: var(--text-muted); font-size: 11px; }
+.composer-plugin-picker__item { width: 100%; min-height: 58px; display: grid; grid-template-columns: 30px minmax(0, 1fr) auto; align-items: center; gap: 9px; padding: 9px 12px; border: 0; border-bottom: 1px solid var(--border); background: transparent; color: var(--text-soft); text-align: left; cursor: pointer; }
+.composer-plugin-picker__item:last-child { border-bottom: 0; }
+.composer-plugin-picker__item:hover:not(:disabled), .composer-plugin-picker__item:focus-visible:not(:disabled) { background: color-mix(in srgb, var(--info) 10%, var(--surface-1)); color: var(--text); outline: 0; }
+.composer-plugin-picker__item:disabled { cursor: default; opacity: .72; }
+.composer-plugin-picker__icon { width: 30px; height: 30px; display: grid; place-items: center; border: 1px solid color-mix(in srgb, var(--info) 45%, var(--border)); color: var(--info); background: color-mix(in srgb, var(--info) 8%, var(--surface-0)); }
+.composer-plugin-picker__copy { min-width: 0; display: grid; gap: 2px; }
+.composer-plugin-picker__copy strong { overflow: hidden; color: var(--text); font-size: 13px; text-overflow: ellipsis; white-space: nowrap; }
+.composer-plugin-picker__copy small { overflow: hidden; color: var(--text-muted); font-size: 11px; line-height: 1.35; text-overflow: ellipsis; white-space: nowrap; }
+.composer-plugin-picker__copy code { width: fit-content; padding: 1px 5px; border: 1px solid var(--border); color: var(--info); font: 11px var(--font-mono); }
+.composer-plugin-picker__version { align-self: start; padding-top: 2px; color: var(--text-muted); font: 10px var(--font-mono); }
+.composer-plugin-picker__empty { display: grid; justify-items: center; gap: 8px; padding: 22px 16px; color: var(--text-muted); font-size: 12px; }
+.composer-plugin-picker__empty button { min-height: 32px; padding: 0 10px; border: 1px solid var(--info); background: transparent; color: var(--info); cursor: pointer; font-size: 12px; }
+.composer-plugin-picker__empty button:hover { background: color-mix(in srgb, var(--info) 10%, transparent); }
 .message-attachments { display: grid; gap: 6px; margin-top: 8px; }
 .message-attachment { min-height: 46px; display: grid; grid-template-columns: 20px minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 8px 9px; border: 1px solid var(--border); color: var(--text-soft); background: var(--surface-1); text-decoration: none; }
 .message-attachment:hover { border-color: var(--border-strong); background: var(--surface-2); }
@@ -759,6 +781,7 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .market-card-grid > article { min-height: 210px; display: grid; align-content: start; gap: 12px; padding: 16px; border: 1px solid var(--border); background: var(--surface-1); }
 .market-card-grid > article:hover, .market-card-grid > article.is-selected { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 5%, var(--surface-1)); }
 .market-card-grid > article.is-installed { border-color: color-mix(in srgb, var(--success) 52%, var(--border)); }
+.market-card-grid > article.is-created { border-color: color-mix(in srgb, var(--success) 72%, var(--border)); background: color-mix(in srgb, var(--success) 5%, var(--surface-1)); }
 .market-card-grid > article.is-included { border-color: color-mix(in srgb, var(--success) 32%, var(--border)); background: color-mix(in srgb, var(--success) 3%, var(--surface-1)); }
 .market-card-grid > article.is-upgrade { border-color: color-mix(in srgb, var(--accent) 62%, var(--border)); }
 .market-card-grid article > header { display: grid; grid-template-columns: 32px minmax(0, 1fr) auto; align-items: center; gap: 8px; }
@@ -781,10 +804,11 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .market-card-grid article > footer { display: flex; align-items: center; justify-content: space-between; gap: 8px; padding-top: 9px; border-top: 1px solid var(--border); }
 .market-card-grid article > footer span { color: var(--text-muted); font: 12px var(--font-mono); }
 .market-card-grid article > footer button { min-height: 36px; padding: 0 12px; border: 1px solid var(--accent); color: var(--accent-strong); background: var(--accent-soft); font-size: 13px; }
-.market-card-grid article.is-installed > footer span, .market-card-grid article.is-included > footer span { color: var(--success); }
+.market-card-grid article.is-installed > footer span, .market-card-grid article.is-created > footer span, .market-card-grid article.is-included > footer span { color: var(--success); }
 .market-card-grid article.is-upgrade > footer span { color: var(--accent-strong); }
 .market-card-grid article > footer button.market-action--installed { border-color: var(--success); color: #07140f; background: var(--success); font-weight: 650; }
 .market-card-grid article > footer button.market-action--included { display: inline-flex; align-items: center; justify-content: center; gap: 5px; border-color: color-mix(in srgb, var(--success) 65%, var(--border)); color: var(--success); background: color-mix(in srgb, var(--success) 9%, var(--surface-0)); opacity: 1; cursor: default; }
+.market-card-grid article > footer button.market-action--created { display: inline-flex; align-items: center; justify-content: center; gap: 5px; border-color: var(--success); color: var(--success); background: color-mix(in srgb, var(--success) 10%, var(--surface-0)); opacity: 1; cursor: default; }
 .market-card-grid article > footer button.market-action--upgrade { font-weight: 650; }
 .market-empty { min-height: 220px; display: grid; place-content: center; justify-items: center; gap: 7px; border: 1px dashed var(--border); color: var(--text-muted); text-align: center; }
 .market-empty strong { color: var(--text-soft); font-size: 15px; }

--- a/packages/web/tests/package-market-activation.test.ts
+++ b/packages/web/tests/package-market-activation.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it, vi } from 'vitest'
 
 import type { CyberMarketPackage, World } from '@dsh-cyber/contracts'
 
+import { ChatWorkbench } from '../src/components/ChatWorkbench.js'
 import { PackageMarketDialog } from '../src/components/PackageMarketDialog.js'
 import { RecruitmentDialog } from '../src/components/RecruitmentDialog.js'
 
@@ -38,10 +39,18 @@ describe('package market activation flow', () => {
     expect(included).toContain('已内置 · 当前可用')
     expect(included).toContain('已内置</button>')
 
-    const installed = marketHtml(themeItem('1.0.1'), 'theme')
+    const installed = marketHtml(themeItem('1.0.1'), 'theme', [{ ...world, templateId: 'personal-world' }])
     expect(installed).toContain('is-installed')
     expect(installed).toContain('已安装 v1.0.1 · 可创建')
     expect(installed).toContain('创建新世界')
+  })
+
+  it('shows a created state after an installed theme has produced a world', () => {
+    const created = marketHtml(themeItem('1.0.1'), 'theme', [{ ...world, templateId: 'cyber-company' }])
+    expect(created).toContain('is-created')
+    expect(created).toContain('已安装 v1.0.1 · 已创建')
+    expect(created).toContain('已创建</button>')
+    expect(created).not.toContain('创建新世界')
   })
 
   it('shows an explicit upgrade state when an older theme is installed', () => {
@@ -49,6 +58,38 @@ describe('package market activation flow', () => {
     expect(html).toContain('is-upgrade')
     expect(html).toContain('已安装 v1.0.0 · 有新版 v1.0.1')
     expect(html).toContain('升级到 v1.0.1')
+  })
+
+  it('exposes installed plugin commands in the chat composer with a recognizable icon', () => {
+    const html = renderToStaticMarkup(createElement(ChatWorkbench, {
+      demoMode: true,
+      world,
+      messages: [],
+      employees: [],
+      installedPlugins: [{
+        packageId: 'official-research-brief',
+        packageVersion: '1.0.0',
+        displayName: 'Research Brief',
+        summary: '整理研究内容',
+        trigger: '/research-brief',
+        displayTrigger: '/研究简报',
+        description: '整理结论和证据。',
+        automatic: false,
+      }],
+      sending: false,
+      draft: '',
+      onDraftChange: vi.fn(),
+      onSend: vi.fn(async () => undefined),
+      onUploadAttachment: vi.fn(async () => ({ assetId: 'asset-1', name: 'a.txt', mimeType: 'text/plain', byteLength: 1, url: '/a.txt' })),
+      onOpenDossier: vi.fn(),
+      onOpenArtifact: vi.fn(),
+      onRecruit: vi.fn(),
+      onOpenPluginMarket: vi.fn(),
+    }))
+    expect(html).toContain('已安装插件')
+    expect(html).toContain('研究简报')
+    expect(html).toContain('/研究简报')
+    expect(html).toContain('composer-plugin-picker__icon')
   })
 
   it('opens recruitment on the market-selected blueprint', () => {


### PR DESCRIPTION
## 变更摘要
- 在聊天输入区展示已安装插件命令快捷入口
- 服务端仅暴露安全的插件命令元数据，指令正文继续保留在服务端
- 支持官方插件命令的中文触发词
- 修复 Windows 8.3 路径别名导致的世界目录误判
- 补充插件运行时与市场激活测试

## 合并说明
该分支基于当前 `main`，领先 1 个提交且未落后，合并前由必需 CI 校验。