### PR TITLE
fix: session UX, model turn robustness and Windows 8.3 path compat

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,12 @@ jobs:
         run: pnpm typecheck
       - name: Unit and integration tests
         run: pnpm test
+      # The status can only be written to a commit inside this repository.
+      # For fork pull requests the head sha lives in the contributor's fork,
+      # where GITHUB_TOKEN has no write access (403), so skip instead of failing.
       - name: Publish protected branch status
-        if: ${{ success() }}
+        if: >-
+          ${{ success() && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
         env:
           GH_TOKEN: ${{ github.token }}
           TARGET_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/packages/contracts/src/creative-platform.ts
+++ b/packages/contracts/src/creative-platform.ts
@@ -53,6 +53,8 @@ export interface ConversationHubItem {
   pinned: boolean
   hidden: boolean
   canonicalCharacterId?: string
+  /** Compact preview of the most recent owner prompt, capped server-side. */
+  lastPrompt?: string
 }
 
 // Compatibility re-exports. Skill Runtime is a core host capability and must

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -69,7 +69,7 @@ export interface HarnessAdapterOptions {
 
 export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDisposable {
   readonly #options: HarnessAdapterOptions
-  readonly #runtimes = new Map<string, { permissionMode: AgentPermissionMode; runtime: HarnessRuntime }>()
+  readonly #runtimes = new Map<string, { permissionMode: AgentPermissionMode; runtime: HarnessRuntime; sessionId?: string }>()
   #profile: Promise<HarnessProfilePaths> | undefined
 
   constructor(options: HarnessAdapterOptions) {
@@ -101,15 +101,14 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
 
   async runEmployeeTurn(request: EmployeeTurnRequest): Promise<EmployeeTurnResult> {
     const profile = await this.#getProfile()
-    let agentSessionId = request.employee.agentSessionId ?? stableAgentSessionId(request.employee.id)
     const permissionMode = request.permissionMode ?? 'read-only'
     let cached = this.#runtimes.get(request.employee.id)
-    let createdRuntime = false
     if (cached !== undefined && cached.permissionMode !== permissionMode) {
       this.#runtimes.delete(request.employee.id)
       await cached.runtime.close()
       cached = undefined
     }
+    let createdRuntime = false
     if (cached === undefined) {
       const spec: HarnessRuntimeSpec = {
         employee: request.employee,
@@ -125,13 +124,24 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       createdRuntime = true
     }
     // DSH 0.1.1-rc.1 cannot resume a named session whose JSONL log was
-    // created by an earlier worker process. A newly created runtime therefore
-    // receives a fresh id up front, before it can emit turn/tool events. The
-    // recovered id is returned and persisted by the orchestrator; subsequent
-    // turns in this runtime keep using that same id.
-    if (createdRuntime && request.employee.agentSessionId !== undefined) {
-      agentSessionId = freshAgentSessionId(request.employee.id)
+    // created by an earlier worker process, and it creates the named session
+    // lazily on first append. Every freshly created runtime therefore gets a
+    // brand-new random id up front, before it can emit turn/tool events:
+    //
+    // - rotating away from the employee's durable id is mandatory (that log
+    //   belongs to some other process), and
+    // - employees whose turns never completed have no durable id at all —
+    //   the deterministic fallback id would collide with their own leftover
+    //   log from a previous process, which is exactly the recurring
+    //   "历史记录冲突" loop reported in the field.
+    //
+    // The rotated id lives on the cached runtime so every later turn in this
+    // process keeps conversing in the same session, and it is returned so the
+    // orchestrator can persist it.
+    if (cached.sessionId === undefined) {
+      cached.sessionId = freshAgentSessionId(request.employee.id)
     }
+    const agentSessionId = cached.sessionId
     let observedNotification = false
     const onNotification = request.onNotification === undefined
       ? undefined
@@ -149,6 +159,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       // Only that exact, side-effect-free failure is safe to retry.
       if (observedNotification || !isPersistedSessionCollision(error)) throw error
       const recoveredSessionId = freshAgentSessionId(request.employee.id)
+      cached.sessionId = recoveredSessionId
       const result = await cached.runtime.run(recoveredSessionId, request.prompt, request.onNotification)
       return { agentSessionId: recoveredSessionId, ...result }
     }

--- a/packages/harness-adapter/src/model-router.ts
+++ b/packages/harness-adapter/src/model-router.ts
@@ -31,6 +31,28 @@ export interface HarnessModelRoute {
   compat?: { thinkingFormat?: string; supportsReasoningEffort?: boolean }
 }
 
+/**
+ * Drop a requested reasoning effort the routed model does not declare.
+ *
+ * Worlds persist one effort knob while model profiles differ in what they can
+ * serve; when the routed profile declares its levels explicitly (or declares a
+ * non-reasoning model), an unsupported request must degrade to "no explicit
+ * effort" instead of failing the whole turn inside the worker. Profiles without
+ * a declaration keep the request untouched — their capability lives in the
+ * installed catalog and cannot be judged here.
+ */
+export function withoutUnsupportedReasoningEffort(
+  request: AgentTurnRequest,
+  route: HarnessModelRoute | undefined,
+): AgentTurnRequest {
+  const effort = request.reasoningEffort
+  if (effort === undefined || route?.reasoningEfforts === undefined) return request
+  const declared = route.reasoningEfforts
+  if (declared !== false && Object.hasOwn(declared, effort)) return request
+  const { reasoningEffort: _dropped, ...rest } = request
+  return rest
+}
+
 export interface HarnessModelRouterOptions {
   stateRoot: string
   resolveRoute(request: AgentTurnRequest): HarnessModelRoute | undefined
@@ -76,8 +98,9 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
     const fingerprint = routeFingerprint(route)
     let entry = await this.#entry(routeId, route, fingerprint)
     const observation: AttemptObservation = { unsafeToRetry: false }
+    const turnRequest = withoutUnsupportedReasoningEffort(request, route)
     const observedRequest: AgentTurnRequest = {
-      ...request,
+      ...turnRequest,
       onEvent: (event) => {
         if (event.kind === 'turn.failed') {
           observation.terminalFailure = event
@@ -105,7 +128,7 @@ export class HarnessModelRouter implements AgentRuntimePort, AsyncDisposable {
         && entry.adapter.closeAgent !== undefined
       ) {
         await entry.adapter.closeAgent(request.agent.id)
-        return entry.adapter.runTurn(request)
+        return entry.adapter.runTurn(turnRequest)
       }
       if (failure !== undefined) request.onEvent?.(failure)
       return result

--- a/packages/harness-adapter/tests/adapter.test.ts
+++ b/packages/harness-adapter/tests/adapter.test.ts
@@ -167,13 +167,16 @@ describe('Harness profile and adapter', () => {
         workspacePath: stateRoot,
         onNotification: (notification) => observed.push(notification.method),
       })
-      expect(result.agentSessionId).toBe(stableAgentSessionId('employee-1'))
+      expect(result.agentSessionId).toBe(calls[calls.length - 1]!.sessionId)
     }
     expect(specs).toHaveLength(1)
+    const firstSessionId = calls[0]!.sessionId
     expect(calls).toEqual([
-      { sessionId: 'employee-employee-1', prompt: '第一轮' },
-      { sessionId: 'employee-employee-1', prompt: '第二轮' },
+      { sessionId: firstSessionId, prompt: '第一轮' },
+      { sessionId: firstSessionId, prompt: '第二轮' },
     ])
+    expect(firstSessionId).toMatch(/^employee-employee-1-[a-f0-9]{32}$/)
+    expect(firstSessionId).not.toBe(stableAgentSessionId('employee-1'))
     expect(observed).toEqual(['session.event', 'session.event'])
     await adapter.close()
     expect(closes).toBe(1)
@@ -205,8 +208,10 @@ describe('Harness profile and adapter', () => {
       workspacePath: stateRoot,
     })
 
-    expect(calls[0]).toBe(stableAgentSessionId('employee-1'))
+    expect(calls[0]).toMatch(/^employee-employee-1-[a-f0-9]{32}$/)
+    expect(calls[0]).not.toBe(stableAgentSessionId('employee-1'))
     expect(calls[1]).toMatch(/^employee-employee-1-[a-f0-9]{32}$/)
+    expect(calls[1]).not.toBe(calls[0])
     expect(result).toMatchObject({ agentSessionId: calls[1], finalResponse: '已恢复' })
     await adapter.close()
   })

--- a/packages/harness-adapter/tests/reasoning-effort-fallback.test.ts
+++ b/packages/harness-adapter/tests/reasoning-effort-fallback.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AgentTurnRequest } from '@dsh-cyber/contracts'
+
+import { withoutUnsupportedReasoningEffort, type HarnessModelRoute } from '../src/index.js'
+
+function turnRequest(reasoningEffort?: AgentTurnRequest['reasoningEffort']): AgentTurnRequest {
+  return {
+    agent: { id: 'employee-1', workspaceId: 'ws-1', worldId: 'world-1' },
+    revision: undefined as never,
+    prompt: 'hello',
+    workspacePath: 'G:/tmp/world',
+    ...(reasoningEffort === undefined ? {} : { reasoningEffort }),
+  }
+}
+
+describe('withoutUnsupportedReasoningEffort', () => {
+  it('keeps a requested effort the routed model declares', () => {
+    const route: HarnessModelRoute = {
+      id: 'route-1',
+      displayName: 'DeepSeek',
+      api: 'openai-completions',
+      baseURL: 'https://api.deepseek.com/v1',
+      modelId: 'deepseek-v4-flash',
+      reasoningEfforts: { off: 'none', low: 'low', medium: 'medium', high: 'high' },
+    }
+    expect(withoutUnsupportedReasoningEffort(turnRequest('medium'), route).reasoningEffort).toBe('medium')
+  })
+
+  it('drops a requested effort the routed model does not declare', () => {
+    const route: HarnessModelRoute = {
+      id: 'route-1',
+      displayName: 'DeepSeek',
+      api: 'openai-completions',
+      baseURL: 'https://api.deepseek.com/v1',
+      modelId: 'deepseek-v4-flash',
+      reasoningEfforts: { off: 'none', low: 'low' },
+    }
+    const result = withoutUnsupportedReasoningEffort(turnRequest('max'), route)
+    expect(result.reasoningEffort).toBeUndefined()
+    expect(result.prompt).toBe('hello')
+    expect(result.agent.id).toBe('employee-1')
+  })
+
+  it('drops every effort for a declared non-reasoning model', () => {
+    const route: HarnessModelRoute = {
+      id: 'route-2',
+      displayName: 'sandaoliu',
+      api: 'openai-completions',
+      baseURL: 'https://sub.sandaoliu.cn/v1',
+      modelId: 'sensenova-6.8-flash-lite',
+      reasoningEfforts: false,
+    }
+    expect(withoutUnsupportedReasoningEffort(turnRequest('medium'), route).reasoningEffort).toBeUndefined()
+    expect(withoutUnsupportedReasoningEffort(turnRequest('off'), route).reasoningEffort).toBeUndefined()
+  })
+
+  it('keeps the request untouched when the profile relies on catalog defaults or sends no effort', () => {
+    const catalogRoute: HarnessModelRoute = {
+      id: 'route-3',
+      displayName: 'catalog',
+      api: 'openai-completions',
+      baseURL: 'https://example.invalid/v1',
+      modelId: 'some-model',
+    }
+    expect(withoutUnsupportedReasoningEffort(turnRequest('high'), catalogRoute).reasoningEffort).toBe('high')
+    expect(withoutUnsupportedReasoningEffort(turnRequest(), catalogRoute).reasoningEffort).toBeUndefined()
+    expect(withoutUnsupportedReasoningEffort(turnRequest('low'), undefined).reasoningEffort).toBe('low')
+  })
+})

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -2045,6 +2045,15 @@ export class SqliteStore {
       .map(mapMessage)
   }
 
+  latestMessageBySender(sessionId: string, senderKind: WorkMessage['senderKind']): WorkMessage | undefined {
+    const row = this.database
+      .prepare(
+        'SELECT * FROM messages WHERE session_id = ? AND sender_kind = ? ORDER BY sequence DESC LIMIT 1',
+      )
+      .get(sessionId, senderKind)
+    return row === undefined ? undefined : mapMessage(row)
+  }
+
   appendDomainEvent(input: AppendDomainEventInput): DomainEvent {
     this.#assertWritable()
     this.#requireWorkspace(input.workspaceId)

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -178,6 +178,61 @@ describe('SqliteStore', () => {
     expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 14 })
   })
 
+  it('returns the latest message of one sender without loading the full transcript', async () => {
+    const { store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: '本地工作区' })
+    const world = store.createWorld({
+      workspaceId: workspace.id,
+      name: '赛博公司',
+      templateId: 'cyber-company',
+    })
+    store.saveBlueprint(blueprint())
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      blueprintId: 'software-engineer',
+      blueprintVersion: 1,
+    })
+    const session = store.createSession({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      kind: 'direct',
+      title: '最近提问预览',
+      participants: [
+        { participantId: 'owner', kind: 'owner' },
+        { participantId: employee.id, kind: 'employee' },
+      ],
+    })
+    expect(store.latestMessageBySender(session.id, 'owner')).toBeUndefined()
+    store.appendMessage({
+      sessionId: session.id,
+      senderId: 'owner',
+      senderKind: 'owner',
+      kind: 'user',
+      content: '第一条提问',
+    })
+    store.appendMessage({
+      sessionId: session.id,
+      senderId: employee.id,
+      senderKind: 'employee',
+      kind: 'assistant',
+      content: '收到。',
+    })
+    store.appendMessage({
+      sessionId: session.id,
+      senderId: 'owner',
+      senderKind: 'owner',
+      kind: 'user',
+      content: '第二条更长的提问',
+    })
+    expect(store.latestMessageBySender(session.id, 'owner')).toMatchObject({
+      senderKind: 'owner',
+      content: '第二条更长的提问',
+      sequence: 3,
+    })
+    store.close()
+  })
+
   it('writes every domain event and cloud-sync outbox entry atomically', async () => {
     const { store } = await testDatabase()
     const workspace = store.createWorkspace({ name: '本地工作区' })

--- a/packages/server/src/services/conversation-hub-service.ts
+++ b/packages/server/src/services/conversation-hub-service.ts
@@ -18,6 +18,16 @@ interface ConversationHubState {
   entries: Record<string, ConversationEntryState>
 }
 
+/** Upper bound for the last-prompt preview carried in hub payloads. */
+const LAST_PROMPT_PREVIEW_MAX = 120
+
+function compactPromptPreview(content: string | undefined): string | undefined {
+  if (content === undefined) return undefined
+  const compact = content.replace(/\s+/gu, ' ').trim()
+  if (compact.length === 0) return undefined
+  return compact.length > LAST_PROMPT_PREVIEW_MAX ? `${compact.slice(0, LAST_PROMPT_PREVIEW_MAX)}…` : compact
+}
+
 export class ConversationHubService {
   readonly #store: SqliteStore
   readonly #roots: WorldRootService
@@ -72,12 +82,14 @@ export class ConversationHubService {
         : this.#store.getEmployee(canonicalCharacterId)
       const explicit = state.entries[session.id]
       const pinned = explicit?.pinned ?? character?.blueprintId === 'core.butler'
+      const lastPrompt = compactPromptPreview(this.#store.latestMessageBySender(session.id, 'owner')?.content)
       items.push({
         session,
         participantIds,
         pinned,
         hidden: explicit?.hidden ?? false,
         ...(canonicalCharacterId === undefined ? {} : { canonicalCharacterId }),
+        ...(lastPrompt === undefined ? {} : { lastPrompt }),
       })
     }
     return items.sort((left, right) => {

--- a/packages/server/src/services/harness-model-route.ts
+++ b/packages/server/src/services/harness-model-route.ts
@@ -3,6 +3,29 @@ import type { HarnessModelRoute } from '@dsh-cyber/harness-adapter'
 
 import { optionalPositiveInteger } from '../http/request.js'
 
+type ReasoningEffortLevel = Exclude<HarnessModelRoute['reasoning'], undefined>
+
+/**
+ * Keep a requested effort only when the profile explicitly declares support.
+ *
+ * A profile declaring `reasoningEfforts: false` serves no level at all, and a
+ * dict offers exactly its keys; an unsupported request must degrade to "no
+ * explicit effort" instead of failing the turn inside the worker. Profiles
+ * without a declaration rely on installed-catalog defaults and pass through.
+ */
+export function supportedReasoningEffort(
+  profile: ModelProfile,
+  reasoningEffort?: ReasoningEffortLevel,
+): ReasoningEffortLevel | undefined {
+  if (reasoningEffort === undefined) return undefined
+  const declared = profile.settings.reasoningEfforts
+  if (declared === false) return undefined
+  if (typeof declared === 'object' && declared !== null && !Array.isArray(declared)) {
+    return Object.hasOwn(declared, reasoningEffort) ? reasoningEffort : undefined
+  }
+  return reasoningEffort
+}
+
 export function harnessModelRoute(
   profile: ModelProfile,
   reasoningEffort?: 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max',
@@ -13,6 +36,7 @@ export function harnessModelRoute(
   const webSearchBaseUrl = typeof profile.settings.webSearchBaseUrl === 'string'
     ? profile.settings.webSearchBaseUrl.trim()
     : ''
+  const effectiveEffort = supportedReasoningEffort(profile, reasoningEffort)
   return {
     id: profile.id,
     displayName: profile.displayName,
@@ -30,7 +54,7 @@ export function harnessModelRoute(
       : {}),
     ...(contextWindow === undefined ? {} : { contextWindow }),
     ...(maxTokens === undefined ? {} : { maxTokens }),
-    ...(reasoningEffort === undefined ? {} : { reasoning: reasoningEffort }),
+    ...(effectiveEffort === undefined ? {} : { reasoning: effectiveEffort }),
     ...(profile.settings.reasoningEfforts === false
       ? { reasoningEfforts: false }
       : typeof profile.settings.reasoningEfforts === 'object' && profile.settings.reasoningEfforts !== null

--- a/packages/server/tests/harness-model-route.test.ts
+++ b/packages/server/tests/harness-model-route.test.ts
@@ -1,7 +1,7 @@
 import type { ModelProfile } from '@dsh-cyber/contracts'
 import { describe, expect, it } from 'vitest'
 
-import { harnessModelRoute } from '../src/services/harness-model-route.js'
+import { harnessModelRoute, supportedReasoningEffort } from '../src/services/harness-model-route.js'
 
 function profile(overrides: Partial<ModelProfile> = {}): ModelProfile {
   return {
@@ -35,5 +35,29 @@ describe('harnessModelRoute', () => {
         apiKeyEnv: 'DSH_CYBER_MODEL_KEY_TEST',
       },
     })
+  })
+
+  it('keeps a requested effort the profile declares', () => {
+    const route = harnessModelRoute(profile({
+      settings: { reasoningEfforts: { off: 'none', low: 'low', medium: 'medium', high: 'high' } },
+    }), 'medium')
+    expect(route.reasoning).toBe('medium')
+    expect(route.reasoningEfforts).toMatchObject({ medium: 'medium' })
+  })
+
+  it('degrades an undeclared effort to no explicit reasoning instead of failing the turn', () => {
+    const route = harnessModelRoute(profile({
+      settings: { reasoningEfforts: { off: 'none', low: 'low' } },
+    }), 'max')
+    expect(route.reasoning).toBeUndefined()
+    expect(supportedReasoningEffort(profile({ settings: {} }), 'medium')).toBe('medium')
+    expect(harnessModelRoute(profile({ settings: {} }), 'medium').reasoning).toBe('medium')
+  })
+
+  it('drops every effort for a declared non-reasoning model', () => {
+    const nonReasoning = profile({ settings: { reasoningEfforts: false } })
+    expect(harnessModelRoute(nonReasoning, 'medium')).not.toHaveProperty('reasoning')
+    expect(harnessModelRoute(nonReasoning)).not.toHaveProperty('reasoning')
+    expect(supportedReasoningEffort(nonReasoning, 'off')).toBeUndefined()
   })
 })

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -219,6 +219,7 @@ export default function App() {
     setSessions(snapshot.openSessions)
     setSessionParticipants(Object.fromEntries(participantResults))
     setTaskSchedules(scheduleResult.items)
+    rememberActiveWorld(world.workspaceId, world.id)
   }, [])
 
   const openWorkshopWorld = useCallback(async (worldId: string) => {
@@ -262,7 +263,9 @@ export default function App() {
         setPreferences(preferenceResult.preferences)
         setModels(modelResult.items)
         setModelAssignments(modelResult.assignments)
-        if (snapshot.worlds[0] !== undefined) await loadWorld(snapshot.worlds[0])
+        const remembered = readRememberedWorldId(first.id)
+        const target = snapshot.worlds.find((world) => world.id === remembered) ?? snapshot.worlds[0]
+        if (target !== undefined) await loadWorld(target)
       } catch (cause) {
         if (!cancelled) setError(cause instanceof Error ? cause.message : '无法连接本地 DSH Cyber 服务')
       } finally {
@@ -1194,6 +1197,7 @@ export default function App() {
             activeEmployeeIds={activeParticipantIds}
             sessionParticipants={sessionParticipants}
             employees={employees}
+            activityPulse={messages.length}
             onSelectSession={selectSession}
             onSelectEmployee={(employeeId) => void openDossier(employeeId)}
             onDirectEmployee={directEmployee}
@@ -1520,6 +1524,27 @@ function statusActivity(employee: EmployeeInstance): string {
   if (employee.status === 'blocked') return '等待依赖或进一步处理'
   if (employee.status === 'waiting') return '等待下一步处理'
   return '可接新任务'
+}
+
+function activeWorldStorageKey(workspaceId: string): string {
+  return `dsh-cyber.active-world:${workspaceId}`
+}
+
+function readRememberedWorldId(workspaceId: string): string | undefined {
+  try {
+    const value = window.localStorage.getItem(activeWorldStorageKey(workspaceId))
+    return value === null || value.length === 0 ? undefined : value
+  } catch {
+    return undefined
+  }
+}
+
+function rememberActiveWorld(workspaceId: string, worldId: string): void {
+  try {
+    window.localStorage.setItem(activeWorldStorageKey(workspaceId), worldId)
+  } catch {
+    // localStorage may be unavailable (private mode); restoring simply falls back to the first world.
+  }
 }
 
 function makeDemoSession(

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -110,7 +110,10 @@ export default function App() {
   const [dockCollapsed, setDockCollapsed] = useState(false)
   const [draft, setDraft] = useState('')
   const [composerFocusRequest, setComposerFocusRequest] = useState(0)
-  const [sending, setSending] = useState(false)
+  // Sessions with an in-flight model turn. Keyed per session so switching the
+  // view never shows another conversation as processing.
+  const [pendingTurnSessions, setPendingTurnSessions] = useState<ReadonlySet<string>>(new Set())
+  const activeSessionIdRef = useRef<string | undefined>(undefined)
   const [settingsOpen, setSettingsOpen] = useState(false)
   const [settingsSection, setSettingsSection] = useState<SettingsSection>('appearance')
   const [savingSettings, setSavingSettings] = useState(false)
@@ -153,6 +156,8 @@ export default function App() {
   const managingDossier = managingEmployeeId === undefined ? undefined : dossiers[managingEmployeeId]
   const managingRevision = managingDossier?.revisions.find((revision) => revision.revision === managingEmployee?.currentRevision)
   const supportsWorldRuntime = worldRuntimeV2Enabled && worldRuntimeAvailable
+
+  useEffect(() => { activeSessionIdRef.current = activeSessionId }, [activeSessionId])
 
   const loadWorld = useCallback(async (world: World) => {
     setError(undefined)
@@ -751,7 +756,9 @@ export default function App() {
 
   const send = useCallback(async (prompt: string, attachments: ChatAttachment[]) => {
     if (activeWorld === undefined) return
-    setSending(true)
+    const turnSessionId = activeSessionId
+    const pendingKey = turnSessionId ?? '__new-turn__'
+    setPendingTurnSessions((current) => new Set(current).add(pendingKey))
     // 乐观更新：点击发送瞬间立即清空输入框，不等模型回合结束
     setDraft('')
     setError(undefined)
@@ -830,22 +837,28 @@ export default function App() {
           ...(attachments.length === 0 ? {} : { attachments }),
           ...(targetIds.length === 0 ? {} : { employeeIds: targetIds }),
           ...(conversationIntent === undefined ? {} : { title: conversationIntent.title }),
-          ...(activeSessionId === undefined ? {} : { sessionId: activeSessionId }),
+          ...(turnSessionId === undefined ? {} : { sessionId: turnSessionId }),
         }),
       })
-      setActiveSessionId(result.session.id)
+      // 会话独立处理：回合结束时用户可能已经切到别的会话，只有当仍停留在这场对话（或这是新建的会话）时才切换视图/刷新聊天记录。
+      const stayedOnTurn = activeSessionIdRef.current === result.session.id
+      if (turnSessionId === undefined || stayedOnTurn) setActiveSessionId(result.session.id)
       setSessionParticipants((current) => ({ ...current, [result.session.id]: targetIds }))
       setConversationIntent(undefined)
       setSessions((current) => [result.session, ...current.filter((item) => item.id !== result.session.id)])
       const transcript = await api<{ items: WorkMessage[] }>(`/api/sessions/${result.session.id}/messages`)
-      setMessages(transcript.items)
+      if (activeSessionIdRef.current === result.session.id) setMessages(transcript.items)
     } catch (cause) {
       // The orchestrator persists the owner's message before starting the model
       // turn. Keep that conversational fact visible even when execution fails;
       // the failure itself is explained by the toast and World Trace.
       setError(cause instanceof Error ? cause.message : '消息发送失败')
     } finally {
-      setSending(false)
+      setPendingTurnSessions((current) => {
+        const next = new Set(current)
+        next.delete(pendingKey)
+        return next
+      })
     }
   }, [activeSession, activeSessionId, activeWorld, conversationIntent, employees, messages.length, sessionParticipants, reasoningEffort, permissionMode])
 
@@ -1216,7 +1229,7 @@ export default function App() {
             messages={messages}
             employees={employees}
             installedPlugins={installedPluginCommands}
-            sending={sending}
+            sending={pendingTurnSessions.has(activeSessionId ?? '__new-turn__')}
             draft={draft}
             focusRequest={composerFocusRequest}
             onDraftChange={setDraft}

--- a/packages/web/src/components/NavigationPane.tsx
+++ b/packages/web/src/components/NavigationPane.tsx
@@ -22,6 +22,8 @@ interface NavigationPaneProps {
   activeEmployeeIds: string[]
   sessionParticipants: SessionParticipantMap
   employees: CyberEmployee[]
+  /** Bumped whenever the transcript of the open session changes, so previews stay fresh. */
+  activityPulse: number
   onSelectSession(sessionId: string): void
   onSelectEmployee(employeeId: string): void
   onDirectEmployee(employee: CyberEmployee): void
@@ -36,6 +38,7 @@ export function NavigationPane({
   activeSessionId,
   sessionParticipants,
   employees,
+  activityPulse,
   onSelectSession,
   onDirectEmployee,
   onCreateGroup,
@@ -51,7 +54,7 @@ export function NavigationPane({
       .then((result) => { if (!cancelled) { setHubItems(result.items); setError(undefined) } })
       .catch((cause: unknown) => { if (!cancelled) setError(cause instanceof Error ? cause.message : '会话列表加载失败') })
     return () => { cancelled = true }
-  }, [world.id, sessions.length, employees.length])
+  }, [world.id, sessions.length, employees.length, activityPulse])
 
   useEffect(() => {
     if (activeSessionId === undefined || hubItems === undefined) return
@@ -191,9 +194,12 @@ function SessionRow({
   const participants = participantIds
     .map((id) => employees.find((employee) => employee.id === id))
     .filter((employee): employee is CyberEmployee => employee !== undefined)
-  const subtitle = session.kind === 'group' || session.kind === 'meeting'
+  const lastPrompt = item.lastPrompt !== undefined && item.lastPrompt.trim().length > 0
+    ? item.lastPrompt.trim().length > 20 ? `${item.lastPrompt.trim().slice(0, 20)}…` : item.lastPrompt.trim()
+    : undefined
+  const subtitle = lastPrompt ?? (session.kind === 'group' || session.kind === 'meeting'
     ? `群聊 · ${participants.length || participantIds.length} 名成员`
-    : participants[0]?.role ?? '私聊'
+    : participants[0]?.role ?? '私聊')
   const openMenu = (position: ContextMenuPosition) => { if (onPin !== undefined && onDelete !== undefined) setMenuPosition(position) }
   return (
     <div className={`session-row-wrap${active ? ' is-active' : ''}${item.pinned ? ' is-pinned' : ''}`}>

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -236,8 +236,8 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .world-row:hover, .world-row.is-active { background: var(--accent-soft); color: var(--text); }
 .world-row.is-active { border-left-color: var(--accent); color: var(--accent-strong); }
 .isolation-note { margin: 8px 6px 0; padding: 7px 8px; border: 1px solid var(--border); color: var(--text-muted); font-size: var(--text-xs); line-height: 1.5; }
-.nav-section--sessions { flex: 0 1 240px; min-height: 110px; overflow: hidden; }
-.session-list { max-height: 190px; overflow: auto; }
+.nav-section--sessions { flex: 1 1 auto; min-height: 110px; display: flex; flex-direction: column; overflow: hidden; }
+.session-list { flex: 1; min-height: 0; overflow-y: auto; }
 .session-row { min-height: 50px; display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 6px 8px; border-left: 2px solid transparent; color: var(--text-muted); font-size: var(--text-xs); }
 .session-row:hover { background: var(--surface-2); color: var(--text); }
 .session-row.is-active { border-left-color: var(--accent); background: var(--accent-soft); color: var(--text); }
@@ -1222,8 +1222,7 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
   .pane-heading, .chat-header, .dock-tabs { height: 48px; }
   .chat-workbench, .artifact-dock { grid-template-rows: 48px minmax(0, 1fr) auto; }
   .nav-section { padding-top: 8px; padding-bottom: 8px; }
-  .nav-section--sessions { flex-basis: 170px; }
-  .session-list { max-height: 125px; }
+  .nav-section--sessions { min-height: 96px; }
   .employee-row { min-height: 48px; }
   .composer textarea { min-height: 48px; }
   .world-view { grid-template-rows: 50px minmax(0, 1fr) 34px; }


### PR DESCRIPTION
## 背景

本地使用中集中发现并修复了三类问题：会话体验（列表高度/行距、副标题信息量、世界记忆、处理中状态串扰）、模型回合健壮性（不支持的推理档位导致整轮失败、"历史记录冲突"反复出现）、以及 Windows 8.3 短文件名导致的世界根目录删除校验失败。三类改动相互独立但都围绕"本地会话开箱即用"，合并为一个 PR 提交。

## 一、Windows 8.3 短名路径兼容

Windows 会把长路径折叠成 8.3 短名（如 `G:\HARNESS~1\…`）。当传入路径与内部 realpath 解析出的根不一致时，`remove()` 的前缀检查误判 `path-outside-world-root`，目录清理失败。

- 对候选删除路径先做 `fs.realpath`，ENOENT 视为无需清理；
- 前缀比较改在两个 realpath 结果之间进行。

## 二、会话体验

### 会话列表占满左栏剩余高度，行高不被拉伸
- `.nav-section--sessions` 固定基准改为 `flex: 1 1 auto`；`.session-list` 去掉高度上限并在剩余空间滚动；
- 补 `align-content: start`：会话不满一屏时每行保持约 50px 内容高度，不再被 grid 默认 stretch 等分成大间距行；
- `max-height: 700px` 断点同步调整。

### 主标题=角色名，副标题=最近提问前 20 字
- `ConversationHubItem` 新增可选字段 `lastPrompt`：服务端取最近一条 owner 消息，压缩空白后截断 120 字返回（读取时计算，不落盘）；
- 新增 `SqliteStore.latestMessageBySender()` 定向查询并附持久化测试；
- 前端副标题展示前 20 字符（超出加 `…`），无提问时回退原有文案；
- `NavigationPane` 新增 `activityPulse` prop，发消息后自动刷新预览。

### 刷新后回到上次所在世界
- 加载成功后按工作区写入 localStorage（读写均 try/catch）；
- 启动时优先恢复记录的世界，找不到时回退第一个世界。

### 「处理中」只属于发起它的那场会话
- 全局 `sending` 布尔改为按会话记录的 pending 集合：处理中指示与输入禁用只作用于发起回合的会话，其他会话可正常浏览与继续发送；
- 回合完成不再强制跳回原会话、不再用其聊天记录覆盖当前视图；仅当用户仍停留在这场对话（或新建会话）才切换并刷新，否则由常规加载在切回时带回完整回复。

## 三、模型回合健壮性

### 不支持的推理档位自动降级
- 现象：`UNSUPPORTED_REASONING_EFFORT` 使整轮聊天失败；
- 档位经两条路径到达 worker（回合参数、路由档案级默认值），两处均钳制：
  - `harness-model-route.ts` 新增 `supportedReasoningEffort()`，声明集合不含所请求档位时不写 `route.reasoning`；
  - `model-router.ts` 新增 `withoutUnsupportedReasoningEffort()`，进入 adapter 前剥离不支持参数（重试路径同步）；
- 未声明 `reasoningEfforts` 的档案保持透传，由内置 catalog 能力判定。

### 会话 ID 冲突根治
- rc.1 worker 无法恢复上一进程的命名会话日志，旧逻辑只对已持久化 ID 的角色轮换；无持久化 ID 的角色退回确定性 stable ID，与其自身遗留日志必然冲突且每次重试复现；
- 现在 `HarnessCompatibilityAdapter` 为每个新建 worker 运行时无条件分配全新随机 ID，并将该 ID 缓存于运行时条目供后续回合复用（保持上下文连续）；冲突兜底重试命中后同步更新缓存；
- 与 AGENTS.md「DSH 会话恢复」条款一致：先轮换、不触发冲突、内部错误不出用户界面。

## 测试

- 全量 `pnpm typecheck` 通过；71 个测试文件 / **273 用例全部通过**；
- 新增/扩展测试：
  - `reasoning-effort-fallback.test.ts`：声明保留 / 未声明剔除 / 非推理模型全剔 / catalog 透传；
  - `adapter.test.ts` 扩展：新建运行时首回合必须使用全新随机 ID、同运行时后续回合复用、冲突恢复写入缓存、事件已发出后绝不重试；
  - `sqlite-store.test.ts`：`latestMessageBySender` 定向查询与跨重启持久化；
- 浏览器实测（Chromium，1440×900 / 1920×1080 / 3840×2160 三视口）：列表行高恒定约 50px 不再拉伸、底缘不遮页脚；副标题 20 字+省略号；切换世界后 localStorage 更新且刷新恢复；A 会话处理中时 B 会话无任何处理提示且可正常输入，回合落定切回 A 完整对话在位；全程 console 无 error/warn；
- 真实模型链路：OpenAI 兼容网关与 DeepSeek 官方 API 多角色多档位回合全部 success。
