### PR TITLE
feat: add durable conversation turn and agent run lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,10 +53,12 @@ DSH Cyber 想把这件事做成一个**可视化、可玩、可扩展的本地 A
 - 角色可以参与真实多角色协作，不由一个“总控 Prompt”假装所有人发言。
 - 角色之间的共享经历和关系证据可以持久化。
 
-**Persistent Memory 的当前边界（请按这个理解，不要按 Memory V2 理解）：**
+#### 持久会话与执行记录
 
-- **已实现**：同一个会话的最近聊天历史由本地 SQLite 恢复，可以跨应用重启、跨 Harness Runtime 重建和权限模式切换。SQLite 是会话历史的权威，DSH Session 只是当前进程内的可丢弃运行时缓存。私聊、群聊和不同世界之间不共享历史。
-- **尚未实现**：Semantic Memory、Episodic Memory 分类、向量检索、Embedding、自动摘要与记忆整理。角色不会跨会话回忆，也不会主动提炼长期知识。
+- 同一个会话的最近聊天历史由本地 SQLite 恢复，可以跨应用重启、Harness Runtime 重建和权限模式切换。私聊、群聊和不同世界之间不共享历史。
+- 每次用户交互和每次实际角色运行都有持久状态，可查看私聊、群聊和角色协作的运行顺序与结果。服务重启会安全终止未完成记录，不自动重放可能产生副作用的调用。
+- SQLite 是会话历史与执行状态的权威；DSH Session 和实时事件是可重建的运行时状态。
+- 跨会话语义检索、情景记忆、向量索引、自动摘要与记忆整理尚未实现。角色不会跨会话自动回忆或提炼长期知识。
 
 ### 🌍 Embodied Worlds
 
@@ -348,7 +350,7 @@ Harness 被限制在兼容适配层，不允许世界、角色、Skill 领域代
 - [ ] Creative Platform V1 稳定化
 - [ ] Workshop 项目版本与编辑生命周期
 - [ ] Character Identity / Persona / Embodiment 完全以用户当前设定为准
-- [ ] Persistent Memory V2
+- [ ] 跨会话长期记忆与语义检索
 - [ ] Task / Job / Deliverable / Review 工作系统
 - [ ] GitHub Skill Adapter
 - [ ] Browser Skill Adapter

--- a/docs/architecture/creative-world-platform-v1.md
+++ b/docs/architecture/creative-world-platform-v1.md
@@ -268,6 +268,8 @@ Runtime 事件携带 `workTurnId` 与 `agentRunId`；本轮消息关联 `workTur
 
 当前持久能力覆盖会话历史恢复和回合执行审计。它不提供跨会话语义检索、向量索引、自动摘要、情景记忆整理或程序性记忆。
 
+`WorkTurn` 与 `AgentRun` 只表达 DSH Cyber 当前所需的执行边界，并非对其他 Agent 平台 Thread、Turn、Item 模型的完整复制。消息、工具轨迹和其他执行事实继续由现有领域表承载；当前没有独立的通用 Item 事实表。
+
 ### 回合并发语义
 
 `#turnQueues` 按 `employeeId` 串行，因为一个 Harness worker 一次只能跑一个 run，且 runtime 缓存不能被两个回合同时改写。准确说法是：

--- a/docs/architecture/creative-world-platform-v1.md
+++ b/docs/architecture/creative-world-platform-v1.md
@@ -214,7 +214,7 @@ Persist project.json
 
 会话 UI 偏好存储在独立本地文件中，不修改消息和 Agent 事实源。
 
-### 会话历史权威（Conversation Memory V1）
+### 持久会话历史
 
 ```text
 SQLite WorkSession / WorkMessage   = 会话历史权威
@@ -249,6 +249,24 @@ observedThroughSequence = 该角色在本会话中最后一条自己的消息的
 `unseenHistory()` 做这个选择，`formatRecoveredHistoryPrompt()` 负责渲染，为空时原样返回 prompt。历史块被明确标注为「恢复上下文」，不得覆盖角色 Persona、世界设定、权限和当前用户请求。
 
 已知边界：如果角色上一次发言已经掉出「24 条 / 16000 字符」预算窗口，watermark 仍然精确（它来自原始 messages，不是预算后的历史），所以不会漏；但窗口本身仍会限制能补多少。
+
+### 会话执行生命周期
+
+每次用户交互创建一个持久化 `WorkTurn`，每次实际调用角色 Runtime 创建一个 `AgentRun`：
+
+```text
+WorkSession
+  └─ WorkTurn
+       ├─ AgentRun 1
+       ├─ AgentRun 2
+       └─ AgentRun N
+```
+
+私聊每轮包含一个 `AgentRun`；群聊按角色顺序包含多个 `AgentRun`；角色协作按轮次和角色记录每次实际执行。SQLite 保存 `queued → running → completed/failed` 状态、角色、顺序和 Runtime Session ID，服务启动时把遗留的 `queued`、`running` 状态确定性标记为 `failed: service-restarted`，不自动重放可能已经产生副作用的调用。
+
+Runtime 事件携带 `workTurnId` 与 `agentRunId`；本轮消息关联 `workTurnId`，角色运行生成的消息和领域事件同时关联 `agentRunId`。兼容字段 `traceTurnId` 与 `agentRunId` 使用同一个值，不再生成另一套随机标识。读取接口提供会话回合列表以及单个回合的完整运行列表；SQLite 记录是执行状态的权威，SSE 只负责实时投影。
+
+当前持久能力覆盖会话历史恢复和回合执行审计。它不提供跨会话语义检索、向量索引、自动摘要、情景记忆整理或程序性记忆。
 
 ### 回合并发语义
 

--- a/docs/community/implementation-status.md
+++ b/docs/community/implementation-status.md
@@ -6,7 +6,7 @@
 
 世界主题、本地包、员工蓝图和 prompt-transform 已收敛到严格声明式边界；现有领域模型更安全的部分继续保留。远程市场、发布 CLI、密码学签名、依赖解析、任意插件代码和外发监控仍未实现，不能通过文档字段假装存在。
 
-会话连续性已经实现到「同一会话跨重启可恢复」这一层，权威在本地 SQLite；这不是 Memory V2，Semantic / Episodic memory、向量检索和记忆整理仍然未实现。
+会话连续性支持同一会话跨重启恢复，回合与角色执行生命周期也已持久化到本地 SQLite。当前能力不包含跨会话语义检索、情景记忆、向量检索和自动记忆整理。
 
 | 领域 | 已实现 | 部分实现/约定补强 | 未实现（ROADMAP） |
 | --- | --- | --- | --- |
@@ -20,6 +20,7 @@
 | 员工蓝图 | schemaVersion、严格字段/长度/唯一性、package id 与能力绑定、不可变 id+version、模板过滤、默认拒绝与逐项能力授权、独立实例/会话、SQLite 恢复 | requested skills 当前展示但不自动授权；模型继续走 ModelProfile/assignment | avatar、memory/skill 文件、蓝图 modelPolicy、compatibility/评测 schema |
 | 插件 | canonical `prompt-transform` 进入真实 conversation runtime prompt；legacy `commands` 明确转换；staged 校验；原始用户消息持久化不被改写 | 仅声明式 JSON；支持 `/command`、`always`、prepend/append/replace、priority 与资源上限；强制无外发 | 可执行代码、skill/tool/event/widget、网络代理与外发审计 |
 | 会话记忆 | 单个 WorkSession 的用户可见聊天历史由本地 SQLite 恢复：跨进程重启、Harness Runtime 重建、权限模式切换和 persisted-log 碰撞轮换都能继续对话；私聊/群聊/世界之间严格隔离；群聊历史保留真实发言人；reasoning、tool-call、tool-result、system、临时气泡与凭据不进入历史 | 预算为「24 条 + 16000 字符」的确定性截断，不使用 tokenizer；超长单条消息截断并标注；每个角色按自身 watermark 增量补齐——新 Session 重播全部，存活 Session 只补它未见过的部分（私聊恒为空，群聊补上一轮晚于自己发言的角色）；同一员工的回合串行、不同员工并行 | Episodic/Semantic/Procedural memory 分类、向量检索、Embedding、自动摘要与记忆整理、跨会话回忆 |
+| 会话执行 | `WorkSession → WorkTurn → AgentRun` 持久模型；私聊一轮一次运行，群聊和角色协作按真实调用顺序记录多次运行；本轮消息关联回合，角色输出、领域事件与 SSE 关联具体运行；服务重启确定性终止遗留执行；提供会话回合和回合详情读取 API | 当前只记录生命周期、错误码和 Runtime Session ID，不持久化原始 prompt、工具输入或工具结果 | 自动重试、通用事件 items 表、远程执行同步、审批模型 |
 | 模型交互日志 | turn/discovery 双源采集、SQLite 持久化（v11 STRICT 表 + 三索引）、分页/筛选/详情/清空 API、设置面板「日志记录」界面、错误信息密钥清洗（`sk-…`/`Bearer …`/键值对 → `[已隐藏]`） | token 用量字段预留但当前恒为空（DSH worker 未透出单次请求用量）；消息数为近似统计；无自动保留策略 | worker 进程内逐请求采集与 token 透出、日志自动清理/条数上限 |
 | CI | Node 22.19、pnpm 11.7、frozen lockfile、typecheck、test、Chromium、E2E | 仓库工作流名为 `required`；GitHub 分支保护需在仓库设置中另行确认 | 自动发布与包签名流水线 |
 
@@ -34,7 +35,7 @@
 - renderer 与动画：`packages/web/src/features/world/renderer`、`packages/web/tests`
 - 员工蓝图解析与实例化：`packages/server/src/employee-blueprint-manifest.ts`、`packages/persistence/src/sqlite-store.ts`
 - prompt transform：`packages/server/src/prompt-transform-parser.ts`、`packages/server/src/routes/conversation-routes.ts`
-- 会话记忆：`packages/orchestration/src/conversation-history.ts`、`packages/orchestration/src/conversation-orchestrator.ts`、`packages/harness-adapter/src/history-prompt.ts`、`packages/harness-adapter/src/adapter.ts`、`packages/orchestration/tests/conversation-history.test.ts`、`packages/orchestration/tests/conversation-memory.test.ts`、`packages/server/tests/conversation-memory-restart.test.ts`
+- 会话记忆与执行：`packages/orchestration/src/conversation-history.ts`、`packages/orchestration/src/conversation-orchestrator.ts`、`packages/persistence/src/migrations.ts`、`packages/persistence/src/sqlite-store.ts`、`packages/harness-adapter/src/history-prompt.ts`、`packages/harness-adapter/src/adapter.ts`、`packages/orchestration/tests/conversation-history.test.ts`、`packages/orchestration/tests/conversation-memory.test.ts`、`packages/server/tests/conversation-memory-restart.test.ts`
 - 模型交互日志：`packages/server/src/services/model-interaction-service.ts`、`packages/server/src/routes/model-interaction-routes.ts`、`packages/persistence/src/migrations.ts`（v11）、[模块说明与观测边界](model-interaction-logs.md)
 - CI：`.github/workflows/ci.yml`
 

--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -49,6 +49,11 @@ test('onboards, recruits from dossier, talks, browses dossiers and keeps file su
   await createRoleFromDossier(page, /开发工程师 v1/, '阿帆')
   await expect(composer).toBeEnabled()
   await expect(page.getByRole('button', { name: '与阿帆私聊' })).toBeVisible()
+  const sessionRowTops = await page.locator('.session-list .session-row').evaluateAll((rows) =>
+    rows.slice(0, 2).map((row) => row.getBoundingClientRect().top),
+  )
+  expect(sessionRowTops).toHaveLength(2)
+  expect(sessionRowTops[1]! - sessionRowTops[0]!).toBeLessThanOrEqual(56)
 
   const dock = page.getByRole('region', { name: '世界与角色档案侧边栏' })
   await dock.getByRole('button', { name: '档案', exact: true }).click()

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,4 @@
-export const CYBER_SCHEMA_VERSION = 14 as const
+export const CYBER_SCHEMA_VERSION = 15 as const
 
 export type IsoTimestamp = string
 export type JsonPrimitive = boolean | number | string | null
@@ -602,6 +602,41 @@ export interface WorkSession {
   status: WorkSessionStatus
   createdAt: IsoTimestamp
   updatedAt: IsoTimestamp
+}
+
+export type WorkTurnInteractionKind = 'chat' | 'task' | 'meeting' | 'peer'
+export type WorkTurnStatus = 'queued' | 'running' | 'completed' | 'failed' | 'interrupted'
+
+export interface WorkTurn {
+  id: string
+  workspaceId: string
+  worldId: string
+  sessionId: string
+  clientTurnId?: string
+  interactionKind: WorkTurnInteractionKind
+  status: WorkTurnStatus
+  errorCode?: string
+  createdAt: string
+  startedAt?: string
+  completedAt?: string
+}
+
+export type AgentRunStatus = WorkTurnStatus
+
+export interface AgentRun {
+  id: string
+  workspaceId: string
+  worldId: string
+  turnId: string
+  sessionId: string
+  employeeId: string
+  ordinal: number
+  status: AgentRunStatus
+  runtimeSessionId?: string
+  errorCode?: string
+  createdAt: string
+  startedAt?: string
+  completedAt?: string
 }
 
 export type ParticipantKind = 'owner' | 'employee' | 'system'

--- a/packages/orchestration/src/conversation-orchestrator.ts
+++ b/packages/orchestration/src/conversation-orchestrator.ts
@@ -1,8 +1,7 @@
-import { randomUUID } from 'node:crypto'
-
 import type {
   AgentRuntimeEvent,
   AgentRuntimePort,
+  AgentRun,
   AgentPermissionMode,
   ConversationHistoryEntry,
   DomainEvent,
@@ -14,6 +13,8 @@ import type {
   ReasoningEffort,
   WorkMessage,
   WorkSession,
+  WorkTurn,
+  WorkTurnInteractionKind,
   WorkSessionParticipant,
   World,
 } from '@dsh-cyber/contracts'
@@ -77,6 +78,14 @@ export interface ConversationStorePort {
     actorId: string,
   ): EmployeeInstance
   bindEmployeeAgentSession(employeeId: string, agentSessionId: string): EmployeeInstance
+  createWorkTurn(input: { workspaceId: string; worldId: string; sessionId: string; clientTurnId?: string; interactionKind: WorkTurnInteractionKind }): WorkTurn
+  startWorkTurn(turnId: string): WorkTurn
+  completeWorkTurn(turnId: string): WorkTurn
+  failWorkTurn(turnId: string, errorCode: string): WorkTurn
+  createAgentRun(input: { workspaceId: string; worldId: string; turnId: string; sessionId: string; employeeId: string; ordinal: number }): AgentRun
+  startAgentRun(runId: string): AgentRun
+  completeAgentRun(runId: string, runtimeSessionId?: string): AgentRun
+  failAgentRun(runId: string, errorCode: string, runtimeSessionId?: string): AgentRun
 }
 
 export interface ConversationRealtimeEnvelope {
@@ -84,6 +93,8 @@ export interface ConversationRealtimeEnvelope {
   worldId: string
   sessionId: string
   agentId: string
+  workTurnId: string
+  agentRunId: string
   event: AgentRuntimeEvent
 }
 
@@ -225,27 +236,40 @@ export class ConversationOrchestrator implements AsyncDisposable {
     // the current prompt is appended, otherwise this turn's prompt would reach
     // the model twice: once as recovered history and once as the live request.
     const recovered = this.#recoverConversation(session)
+    const clientTurnId = clientTurnIdFrom(input.metadata)
+    const workTurn = this.#store.createWorkTurn({
+      workspaceId: input.workspaceId,
+      worldId: input.worldId,
+      sessionId: session.id,
+      interactionKind: interactionKindFrom(input.metadata, 'chat'),
+      ...(clientTurnId === undefined ? {} : { clientTurnId }),
+    })
     this.#store.appendMessage({
       sessionId: session.id,
       senderId: 'owner',
       senderKind: 'owner',
       kind: 'user',
       content: prompt,
-      ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+      metadata: { ...input.metadata, workTurnId: workTurn.id },
       correlationId: session.id,
     })
-    const clientTurnId = clientTurnIdFrom(input.metadata)
-    const reply = await this.#runAgent({
-      session,
-      employee,
-      prompt: input.runtimePrompt?.trim() || prompt,
-      history: recovered.history,
-      observedThroughSequence: lastAuthoredSequence(recovered.messages, employee.id),
-      ...(input.reasoningEffort === undefined ? {} : { reasoningEffort: input.reasoningEffort }),
-      ...(input.permissionMode === undefined ? {} : { permissionMode: input.permissionMode }),
-      ...(clientTurnId === undefined ? {} : { clientTurnId }),
-    })
-    return { session, replies: [reply] }
+    this.#store.startWorkTurn(workTurn.id)
+    try {
+      const reply = await this.#runAgent({
+        session, workTurn, ordinal: 1, employee,
+        prompt: input.runtimePrompt?.trim() || prompt,
+        history: recovered.history,
+        observedThroughSequence: lastAuthoredSequence(recovered.messages, employee.id),
+        ...(input.reasoningEffort === undefined ? {} : { reasoningEffort: input.reasoningEffort }),
+        ...(input.permissionMode === undefined ? {} : { permissionMode: input.permissionMode }),
+        ...(clientTurnId === undefined ? {} : { clientTurnId }),
+      })
+      this.#store.completeWorkTurn(workTurn.id)
+      return { session, replies: [reply] }
+    } catch (error) {
+      this.#store.failWorkTurn(workTurn.id, lifecycleErrorCode(error))
+      throw error
+    }
   }
 
   async group(input: GroupConversationInput): Promise<ConversationResult> {
@@ -276,16 +300,23 @@ export class ConversationOrchestrator implements AsyncDisposable {
     // current round are supplied separately by groupPrompt(), so they must not
     // be part of the recovered history as well.
     const recovered = this.#recoverConversation(session)
+    const clientTurnId = clientTurnIdFrom(input.metadata)
+    const workTurn = this.#store.createWorkTurn({
+      workspaceId: input.workspaceId, worldId: input.worldId, sessionId: session.id,
+      interactionKind: interactionKindFrom(input.metadata, 'meeting'),
+      ...(clientTurnId === undefined ? {} : { clientTurnId }),
+    })
     this.#store.appendMessage({
       sessionId: session.id,
       senderId: 'owner',
       senderKind: 'owner',
       kind: 'user',
       content: prompt,
-      ...(input.metadata === undefined ? {} : { metadata: input.metadata }),
+      metadata: { ...input.metadata, workTurnId: workTurn.id },
       correlationId: session.id,
     })
-    const meetingRunId = randomUUID()
+    this.#store.startWorkTurn(workTurn.id)
+    const meetingRunId = workTurn.id
     this.#store.appendDomainEvent({
       workspaceId: input.workspaceId,
       worldId: input.worldId,
@@ -294,16 +325,15 @@ export class ConversationOrchestrator implements AsyncDisposable {
       actorId: 'owner',
       actorKind: 'owner',
       correlationId: session.id,
-      payload: { participantIds: employeeIds, promptMessageSequence: 1, meetingRunId },
+      payload: { participantIds: employeeIds, promptMessageSequence: 1, meetingRunId, workTurnId: workTurn.id },
     })
 
     const replies: AgentReply[] = []
     try {
-      const clientTurnId = clientTurnIdFrom(input.metadata)
-      for (const employee of employees) {
+      for (const [index, employee] of employees.entries()) {
         const collaborationPrompt = groupPrompt(input.runtimePrompt?.trim() || prompt, replies)
         replies.push(await this.#runAgent({
-          session,
+          session, workTurn, ordinal: index + 1,
           employee,
           prompt: collaborationPrompt,
           history: recovered.history,
@@ -324,8 +354,9 @@ export class ConversationOrchestrator implements AsyncDisposable {
         actorId: 'system',
         actorKind: 'system',
         correlationId: session.id,
-        payload: { participantIds: employeeIds, status: 'completed', replyCount: replies.length, meetingRunId },
+        payload: { participantIds: employeeIds, status: 'completed', replyCount: replies.length, meetingRunId, workTurnId: workTurn.id },
       })
+      this.#store.completeWorkTurn(workTurn.id)
       return { session, replies }
     } catch (error) {
       this.#store.appendDomainEvent({
@@ -336,8 +367,9 @@ export class ConversationOrchestrator implements AsyncDisposable {
         actorId: 'system',
         actorKind: 'system',
         correlationId: session.id,
-        payload: { participantIds: employeeIds, status: 'blocked', replyCount: replies.length, meetingRunId },
+        payload: { participantIds: employeeIds, status: 'blocked', replyCount: replies.length, meetingRunId, workTurnId: workTurn.id },
       })
+      this.#store.failWorkTurn(workTurn.id, lifecycleErrorCode(error))
       throw error
     }
   }
@@ -377,6 +409,12 @@ export class ConversationOrchestrator implements AsyncDisposable {
     })),
     actorId: initiator.id,
   })
+  const workTurn = this.#store.createWorkTurn({
+    workspaceId: input.workspaceId,
+    worldId: input.worldId,
+    sessionId: session.id,
+    interactionKind: 'peer',
+  })
   this.#store.appendMessage({
     sessionId: session.id,
     senderId: 'system',
@@ -390,10 +428,12 @@ export class ConversationOrchestrator implements AsyncDisposable {
       participantIds,
       purpose,
       maxRounds,
+      workTurnId: workTurn.id,
     },
     correlationId: session.id,
   })
-  const meetingRunId = randomUUID()
+  this.#store.startWorkTurn(workTurn.id)
+  const meetingRunId = workTurn.id
   this.#store.appendDomainEvent({
     workspaceId: input.workspaceId,
     worldId: input.worldId,
@@ -410,15 +450,18 @@ export class ConversationOrchestrator implements AsyncDisposable {
       purpose,
       maxRounds,
       meetingRunId,
+      workTurnId: workTurn.id,
     },
   })
 
   const replies: AgentReply[] = []
+  let ordinal = 0
   try {
     for (let round = 1; round <= maxRounds; round += 1) {
       for (const employee of orderedEmployees) {
+        ordinal += 1
         replies.push(await this.#runAgent({
-          session,
+          session, workTurn, ordinal,
           employee,
           prompt: peerPrompt({
             basePrompt: input.runtimePrompt?.trim() || purpose,
@@ -454,8 +497,10 @@ export class ConversationOrchestrator implements AsyncDisposable {
         replyCount: replies.length,
         rounds: maxRounds,
         meetingRunId,
+        workTurnId: workTurn.id,
       },
     })
+    this.#store.completeWorkTurn(workTurn.id)
     return {
       session,
       replies,
@@ -481,8 +526,10 @@ export class ConversationOrchestrator implements AsyncDisposable {
         replyCount: replies.length,
         rounds: maxRounds,
         meetingRunId,
+        workTurnId: workTurn.id,
       },
     })
+    this.#store.failWorkTurn(workTurn.id, lifecycleErrorCode(error))
     throw error
   }
 }
@@ -524,6 +571,8 @@ export class ConversationOrchestrator implements AsyncDisposable {
 
   async #runAgent(input: {
     session: WorkSession
+    workTurn: WorkTurn
+    ordinal: number
     employee: EmployeeInstance
     prompt: string
     history: ConversationHistoryEntry[]
@@ -534,6 +583,8 @@ export class ConversationOrchestrator implements AsyncDisposable {
   }): Promise<AgentReply> {
     const {
       session,
+      workTurn,
+      ordinal,
       employee,
       prompt,
       history,
@@ -546,23 +597,31 @@ export class ConversationOrchestrator implements AsyncDisposable {
     if (revision === undefined) {
       throw new ConversationOrchestrationError(`Missing agent revision: ${employee.id}`)
     }
-    const traceTurnId = randomUUID()
-    this.#store.setEmployeeStatus(employee.id, 'working', 'system')
-    this.#store.appendDomainEvent({
+    const agentRun = this.#store.createAgentRun({
       workspaceId: session.workspaceId,
       worldId: session.worldId,
+      turnId: workTurn.id,
       sessionId: session.id,
-      type: 'task.started',
-      actorId: employee.id,
-      actorKind: 'employee',
-      correlationId: session.id,
-      payload: { employeeId: employee.id, role: employee.role, traceTurnId },
+      employeeId: employee.id,
+      ordinal,
     })
-
+    this.#store.startAgentRun(agentRun.id)
+    const traceTurnId = agentRun.id
     let responsePersisted = false
     let failedTurn = false
     let failedTurnKind: AgentTurnFailureKind = 'unknown'
     try {
+      this.#store.setEmployeeStatus(employee.id, 'working', 'system')
+      this.#store.appendDomainEvent({
+        workspaceId: session.workspaceId,
+        worldId: session.worldId,
+        sessionId: session.id,
+        type: 'task.started',
+        actorId: employee.id,
+        actorKind: 'employee',
+        correlationId: session.id,
+        payload: { employeeId: employee.id, role: employee.role, traceTurnId, agentRunId: agentRun.id, workTurnId: workTurn.id },
+      })
       const workspacePath = this.#resolveWorldRoot === undefined ? this.#workspacePath! : await this.#resolveWorldRoot(session.worldId)
       const result = await this.#runtime.runTurn({
         agent: employee,
@@ -580,6 +639,8 @@ export class ConversationOrchestrator implements AsyncDisposable {
             metadata: {
               ...event.metadata,
               traceTurnId,
+              agentRunId: agentRun.id,
+              workTurnId: workTurn.id,
               ...(clientTurnId === undefined ? {} : { clientTurnId }),
             },
           }
@@ -596,13 +657,16 @@ export class ConversationOrchestrator implements AsyncDisposable {
             worldId: session.worldId,
             sessionId: session.id,
             agentId: employee.id,
+            agentRunId: agentRun.id,
+            workTurnId: workTurn.id,
             event: tracedEvent,
           })
         },
       })
       this.#store.bindEmployeeAgentSession(employee.id, result.agentSessionId)
       if (failedTurn) {
-        this.#blockAgent(session, employee, 'runtime-turn-failed', traceTurnId)
+        this.#blockAgent(session, employee, 'runtime-turn-failed', workTurn.id, agentRun.id)
+        this.#store.failAgentRun(agentRun.id, `runtime-${failedTurnKind}`, result.agentSessionId)
         throw new AgentTurnFailedError(employee.id, failedTurnKind)
       }
       const content = result.finalResponse.trim()
@@ -617,6 +681,8 @@ export class ConversationOrchestrator implements AsyncDisposable {
             source: 'runtime-final-response',
             agentSessionId: result.agentSessionId,
             traceTurnId,
+            agentRunId: agentRun.id,
+            workTurnId: workTurn.id,
             ...(clientTurnId === undefined ? {} : { clientTurnId }),
           },
           correlationId: session.id,
@@ -631,8 +697,9 @@ export class ConversationOrchestrator implements AsyncDisposable {
         actorId: employee.id,
         actorKind: 'employee',
         correlationId: session.id,
-        payload: { employeeId: employee.id, agentSessionId: result.agentSessionId, traceTurnId },
+        payload: { employeeId: employee.id, agentSessionId: result.agentSessionId, traceTurnId, agentRunId: agentRun.id, workTurnId: workTurn.id },
       })
+      this.#store.completeAgentRun(agentRun.id, result.agentSessionId)
       return {
         employeeId: employee.id,
         displayName: employee.displayName,
@@ -641,6 +708,7 @@ export class ConversationOrchestrator implements AsyncDisposable {
       }
     } catch (error) {
       if (!(error instanceof AgentTurnFailedError)) {
+        this.#store.failAgentRun(agentRun.id, lifecycleErrorCode(error))
         this.#store.appendDomainEvent({
           workspaceId: session.workspaceId,
           worldId: session.worldId,
@@ -649,9 +717,9 @@ export class ConversationOrchestrator implements AsyncDisposable {
           actorId: employee.id,
           actorKind: 'employee',
           correlationId: session.id,
-          payload: { employeeId: employee.id, failure: 'runtime-error', traceTurnId },
+          payload: { employeeId: employee.id, failure: 'runtime-error', traceTurnId, agentRunId: agentRun.id, workTurnId: workTurn.id },
         })
-        this.#blockAgent(session, employee, 'runtime-error', traceTurnId)
+        this.#blockAgent(session, employee, 'runtime-error', workTurn.id, agentRun.id)
       }
       throw error instanceof AgentTurnFailedError
         ? error
@@ -753,7 +821,7 @@ export class ConversationOrchestrator implements AsyncDisposable {
     })
   }
 
-  #blockAgent(session: WorkSession, employee: EmployeeInstance, reason: string, traceTurnId: string): void {
+  #blockAgent(session: WorkSession, employee: EmployeeInstance, reason: string, workTurnId: string, agentRunId: string): void {
     this.#store.setEmployeeStatus(employee.id, 'blocked', 'system')
     this.#store.appendDomainEvent({
       workspaceId: session.workspaceId,
@@ -763,7 +831,7 @@ export class ConversationOrchestrator implements AsyncDisposable {
       actorId: employee.id,
       actorKind: 'employee',
       correlationId: session.id,
-      payload: { employeeId: employee.id, reason, traceTurnId },
+      payload: { employeeId: employee.id, reason, traceTurnId: agentRunId, agentRunId, workTurnId },
     })
   }
 
@@ -933,6 +1001,15 @@ function runtimeMetadata(event: AgentRuntimeEvent): JsonObject {
 function clientTurnIdFrom(metadata?: JsonObject): string | undefined {
   const value = metadata?.clientTurnId
   return typeof value === 'string' && value.trim().length > 0 ? value : undefined
+}
+
+function interactionKindFrom(metadata: JsonObject | undefined, fallback: WorkTurnInteractionKind): WorkTurnInteractionKind {
+  const value = metadata?.interactionKind
+  return value === 'chat' || value === 'task' || value === 'meeting' || value === 'peer' ? value : fallback
+}
+
+function lifecycleErrorCode(error: unknown): string {
+  return error instanceof AgentTurnFailedError ? `runtime-${error.failureKind}` : 'runtime-error'
 }
 
 function requiredText(value: string, label: string): string {

--- a/packages/orchestration/tests/conversation-orchestrator.test.ts
+++ b/packages/orchestration/tests/conversation-orchestrator.test.ts
@@ -155,9 +155,11 @@ describe('ConversationOrchestrator', () => {
     const orchestrator = new ConversationOrchestrator({ store, runtime, workspacePath: directory })
     orchestrators.push(orchestrator)
     const realtime: AgentRuntimeEvent[] = []
+    const realtimeIds: Array<{ workTurnId: string; agentRunId: string; traceTurnId: unknown }> = []
     const durableAtEmit: Array<{ kind: AgentRuntimeEvent['kind']; persisted: boolean }> = []
     orchestrator.subscribe((event) => {
       realtime.push(event.event)
+      realtimeIds.push({ workTurnId: event.workTurnId, agentRunId: event.agentRunId, traceTurnId: event.event.metadata.traceTurnId })
       const eventTypes = store.listWorldDomainEvents(company.id).map((item) => item.type)
       const messages = store.listMessages(event.sessionId)
       const persisted = event.event.kind === 'turn.started'
@@ -203,6 +205,12 @@ describe('ConversationOrchestrator', () => {
     ).toHaveLength(2)
     expect(store.listWorldDomainEvents(company.id).at(-1)?.type).toBe('task.completed')
     expect(store.getEmployee(employee.id)?.status).toBe('available')
+    const directTurns = store.listSessionTurns(first.session.id)
+    expect(directTurns).toHaveLength(2)
+    expect(directTurns.every((turn) => turn.status === 'completed')).toBe(true)
+    expect(store.listTurnAgentRuns(directTurns[0]!.id)).toHaveLength(1)
+    expect(realtimeIds.every((item) => item.agentRunId === item.traceTurnId && item.workTurnId.length > 0)).toBe(true)
+    expect(store.listMessages(first.session.id).every((message) => message.metadata.workTurnId !== undefined)).toBe(true)
   })
 
   it('runs two independent agents in sequence and gives the second the first real statement', async () => {
@@ -248,6 +256,12 @@ describe('ConversationOrchestrator', () => {
     const eventTypes = store.listWorldDomainEvents(company.id).map((event) => event.type)
     expect(eventTypes).toContain('meeting.started')
     expect(eventTypes).toContain('meeting.finished')
+    const [turn] = store.listSessionTurns(result.session.id)
+    expect(turn).toMatchObject({ status: 'completed', interactionKind: 'meeting' })
+    expect(store.listTurnAgentRuns(turn!.id)).toEqual([
+      expect.objectContaining({ employeeId: lead.id, ordinal: 1, status: 'completed' }),
+      expect.objectContaining({ employeeId: engineer.id, ordinal: 2, status: 'completed' }),
+    ])
   })
 
   it('continues an existing group history without creating a duplicate session', async () => {
@@ -289,6 +303,38 @@ describe('ConversationOrchestrator', () => {
     expect(store.listSessions(company.id).filter((session) => session.kind === 'group')).toHaveLength(1)
     expect(store.listMessages(first.session.id).filter((message) => message.kind === 'user')).toHaveLength(2)
     expect(store.listWorldDomainEvents(company.id).filter((event) => event.type === 'meeting.started')).toHaveLength(2)
+  })
+
+  it('preserves completed runs when a later group agent fails', async () => {
+    const { directory, store, workspace, company } = await setup()
+    store.saveBlueprint(blueprint('lead-partial', '老王', '技术经理'))
+    store.saveBlueprint(blueprint('engineer-partial', '小刘', '软件工程师'))
+    const lead = store.recruitEmployee({ workspaceId: workspace.id, worldId: company.id, blueprintId: 'lead-partial', blueprintVersion: 1 })
+    const engineer = store.recruitEmployee({ workspaceId: workspace.id, worldId: company.id, blueprintId: 'engineer-partial', blueprintVersion: 1 })
+    let calls = 0
+    const runtime: AgentRuntimePort = {
+      async runTurn(request) {
+        calls += 1
+        if (calls === 2) throw new Error('runtime unavailable')
+        request.onEvent?.({ kind: 'assistant.message', source: 'partial-test', sourceSessionId: 'first-run', content: '第一位已完成。', metadata: {} })
+        return { agentSessionId: 'first-run', finalResponse: '第一位已完成。', eventCount: 1 }
+      },
+      async close() {},
+    }
+    const orchestrator = new ConversationOrchestrator({ store, runtime, workspacePath: directory })
+    orchestrators.push(orchestrator)
+
+    await expect(orchestrator.group({
+      workspaceId: workspace.id, worldId: company.id, employeeIds: [lead.id, engineer.id], prompt: '执行两步检查',
+    })).rejects.toThrow('Agent model turn failed')
+
+    const [session] = store.listSessions(company.id)
+    const [turn] = store.listSessionTurns(session!.id)
+    expect(turn).toMatchObject({ status: 'failed', errorCode: 'runtime-unknown' })
+    expect(store.listTurnAgentRuns(turn!.id)).toEqual([
+      expect.objectContaining({ employeeId: lead.id, status: 'completed', ordinal: 1 }),
+      expect.objectContaining({ employeeId: engineer.id, status: 'failed', ordinal: 2 }),
+    ])
   })
 
   it('rejects cross-world role mixing before a runtime starts', async () => {

--- a/packages/orchestration/tests/peer-conversation.test.ts
+++ b/packages/orchestration/tests/peer-conversation.test.ts
@@ -114,6 +114,9 @@ describe('peer conversations', () => {
     expect(participants.every((participant) => participant.kind === 'employee')).toBe(true)
     expect(participants.some((participant) => participant.participantId === 'owner')).toBe(false)
     expect(store.listMessages(result.session.id).filter((message) => message.kind === 'assistant')).toHaveLength(4)
+    const [turn] = store.listSessionTurns(result.session.id)
+    expect(turn).toMatchObject({ interactionKind: 'peer', status: 'completed' })
+    expect(store.listTurnAgentRuns(turn!.id).map((run) => run.ordinal)).toEqual([1, 2, 3, 4])
 
     const events = store.listWorldDomainEvents(company.id).filter((event) => event.sessionId === result.session.id)
     expect(events.find((event) => event.type === 'meeting.started')?.payload).toMatchObject({

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -612,6 +612,52 @@ const MIGRATIONS: readonly Migration[] = [
         ON task_schedule_runs(schedule_id, started_at DESC);
     `,
   },
+  {
+    version: 15,
+    name: 'conversation-runtime-lifecycle',
+    sql: `
+      CREATE TABLE work_turns (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        world_id TEXT NOT NULL REFERENCES worlds(id) ON DELETE CASCADE,
+        session_id TEXT NOT NULL REFERENCES work_sessions(id) ON DELETE CASCADE,
+        client_turn_id TEXT,
+        interaction_kind TEXT NOT NULL CHECK (interaction_kind IN ('chat', 'task', 'meeting', 'peer')),
+        status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'interrupted')),
+        error_code TEXT,
+        created_at TEXT NOT NULL,
+        started_at TEXT,
+        completed_at TEXT
+      ) STRICT;
+
+      CREATE INDEX work_turns_session_created_idx ON work_turns(session_id, created_at DESC, id);
+      CREATE INDEX work_turns_world_status_created_idx ON work_turns(world_id, status, created_at DESC, id);
+      CREATE INDEX work_turns_client_turn_idx ON work_turns(client_turn_id) WHERE client_turn_id IS NOT NULL;
+      CREATE INDEX work_turns_session_client_turn_idx
+        ON work_turns(session_id, client_turn_id) WHERE client_turn_id IS NOT NULL;
+
+      CREATE TABLE agent_runs (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        world_id TEXT NOT NULL REFERENCES worlds(id) ON DELETE CASCADE,
+        turn_id TEXT NOT NULL REFERENCES work_turns(id) ON DELETE CASCADE,
+        session_id TEXT NOT NULL REFERENCES work_sessions(id) ON DELETE CASCADE,
+        employee_id TEXT NOT NULL REFERENCES employee_instances(id) ON DELETE CASCADE,
+        ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+        status TEXT NOT NULL CHECK (status IN ('queued', 'running', 'completed', 'failed', 'interrupted')),
+        runtime_session_id TEXT,
+        error_code TEXT,
+        created_at TEXT NOT NULL,
+        started_at TEXT,
+        completed_at TEXT,
+        UNIQUE(turn_id, ordinal)
+      ) STRICT;
+
+      CREATE INDEX agent_runs_turn_ordinal_idx ON agent_runs(turn_id, ordinal);
+      CREATE INDEX agent_runs_session_created_idx ON agent_runs(session_id, created_at DESC, id);
+      CREATE INDEX agent_runs_employee_status_created_idx ON agent_runs(employee_id, status, created_at DESC, id);
+    `,
+  },
 ]
 
 export function migrate(database: DatabaseSync, now: () => string): void {

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -45,6 +45,9 @@ import {
   type SkillEvidence,
   type SkillEvidenceKind,
   type SkillEvidenceOutcome,
+  type AgentRun,
+  type WorkTurn,
+  type WorkTurnInteractionKind,
   type WorkMessage,
   type WorkSession,
   type WorkSessionKind,
@@ -236,6 +239,28 @@ export interface CreateSessionInput {
   actorId?: string
 }
 
+export interface CreateWorkTurnInput {
+  workspaceId: string
+  worldId: string
+  sessionId: string
+  clientTurnId?: string
+  interactionKind: WorkTurnInteractionKind
+}
+
+export interface CreateAgentRunInput {
+  workspaceId: string
+  worldId: string
+  turnId: string
+  sessionId: string
+  employeeId: string
+  ordinal: number
+}
+
+export interface ConversationRuntimeRecoveryReport {
+  turnsFailed: number
+  runsFailed: number
+}
+
 export interface AppendMessageInput {
   sessionId: string
   senderId: string
@@ -321,6 +346,8 @@ const KNOWN_TABLES = [
   'model_assignments',
   'local_assets',
   'work_sessions',
+  'work_turns',
+  'agent_runs',
   'work_session_participants',
   'messages',
   'installed_packages',
@@ -1968,6 +1995,124 @@ export class SqliteStore {
     return rows.map(mapSession)
   }
 
+  createWorkTurn(input: CreateWorkTurnInput): WorkTurn {
+    this.#assertWritable()
+    const session = this.#requireSession(input.sessionId)
+    if (session.workspaceId !== input.workspaceId || session.worldId !== input.worldId) {
+      throw new PersistenceError('Work turn scope does not match session')
+    }
+    const clientTurnId = input.clientTurnId?.trim()
+    if (clientTurnId !== undefined && (clientTurnId.length === 0 || clientTurnId.length > 128)) {
+      throw new PersistenceError('Work turn client id is invalid')
+    }
+    const turn: WorkTurn = {
+      id: this.#idFactory(), workspaceId: input.workspaceId, worldId: input.worldId,
+      sessionId: input.sessionId, interactionKind: input.interactionKind,
+      status: 'queued', createdAt: this.#clock(),
+      ...(clientTurnId === undefined ? {} : { clientTurnId }),
+    }
+    this.database.prepare(
+      `INSERT INTO work_turns
+       (id, workspace_id, world_id, session_id, client_turn_id, interaction_kind, status, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(turn.id, turn.workspaceId, turn.worldId, turn.sessionId, turn.clientTurnId ?? null,
+      turn.interactionKind, turn.status, turn.createdAt)
+    return turn
+  }
+
+  getWorkTurn(turnId: string): WorkTurn | undefined {
+    const row = this.database.prepare('SELECT * FROM work_turns WHERE id = ?').get(turnId)
+    return row === undefined ? undefined : mapWorkTurn(row)
+  }
+
+  listSessionTurns(sessionId: string): WorkTurn[] {
+    this.#requireSession(sessionId)
+    return this.database.prepare(
+      'SELECT * FROM work_turns WHERE session_id = ? ORDER BY created_at DESC, id DESC',
+    ).all(sessionId).map(mapWorkTurn)
+  }
+
+  startWorkTurn(turnId: string): WorkTurn {
+    return this.#transitionWorkTurn(turnId, ['queued'], 'running')
+  }
+
+  completeWorkTurn(turnId: string): WorkTurn {
+    return this.#transitionWorkTurn(turnId, ['running'], 'completed')
+  }
+
+  failWorkTurn(turnId: string, errorCode: string): WorkTurn {
+    return this.#transitionWorkTurn(turnId, ['running'], 'failed', errorCode)
+  }
+
+  interruptWorkTurn(turnId: string, errorCode = 'interrupted'): WorkTurn {
+    return this.#transitionWorkTurn(turnId, ['queued', 'running'], 'interrupted', errorCode)
+  }
+
+  createAgentRun(input: CreateAgentRunInput): AgentRun {
+    this.#assertWritable()
+    const turn = this.getWorkTurn(input.turnId)
+    const employee = this.#requireEmployee(input.employeeId)
+    if (turn === undefined || turn.workspaceId !== input.workspaceId || turn.worldId !== input.worldId ||
+      turn.sessionId !== input.sessionId || employee.workspaceId !== input.workspaceId || employee.worldId !== input.worldId) {
+      throw new PersistenceError('Agent run scope does not match turn or employee')
+    }
+    if (!Number.isInteger(input.ordinal) || input.ordinal < 1) throw new PersistenceError('Agent run ordinal is invalid')
+    const run: AgentRun = {
+      id: this.#idFactory(), workspaceId: input.workspaceId, worldId: input.worldId,
+      turnId: input.turnId, sessionId: input.sessionId, employeeId: input.employeeId,
+      ordinal: input.ordinal, status: 'queued', createdAt: this.#clock(),
+    }
+    this.database.prepare(
+      `INSERT INTO agent_runs
+       (id, workspace_id, world_id, turn_id, session_id, employee_id, ordinal, status, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(run.id, run.workspaceId, run.worldId, run.turnId, run.sessionId, run.employeeId,
+      run.ordinal, run.status, run.createdAt)
+    return run
+  }
+
+  getAgentRun(runId: string): AgentRun | undefined {
+    const row = this.database.prepare('SELECT * FROM agent_runs WHERE id = ?').get(runId)
+    return row === undefined ? undefined : mapAgentRun(row)
+  }
+
+  listTurnAgentRuns(turnId: string): AgentRun[] {
+    if (this.getWorkTurn(turnId) === undefined) throw new EntityNotFoundError(`Work turn not found: ${turnId}`)
+    return this.database.prepare('SELECT * FROM agent_runs WHERE turn_id = ? ORDER BY ordinal').all(turnId).map(mapAgentRun)
+  }
+
+  startAgentRun(runId: string): AgentRun {
+    return this.#transitionAgentRun(runId, ['queued'], 'running')
+  }
+
+  completeAgentRun(runId: string, runtimeSessionId?: string): AgentRun {
+    return this.#transitionAgentRun(runId, ['running'], 'completed', undefined, runtimeSessionId)
+  }
+
+  failAgentRun(runId: string, errorCode: string, runtimeSessionId?: string): AgentRun {
+    return this.#transitionAgentRun(runId, ['running'], 'failed', errorCode, runtimeSessionId)
+  }
+
+  interruptAgentRun(runId: string, errorCode = 'interrupted'): AgentRun {
+    return this.#transitionAgentRun(runId, ['queued', 'running'], 'interrupted', errorCode)
+  }
+
+  recoverConversationRuntimeAfterRestart(): ConversationRuntimeRecoveryReport {
+    this.#assertWritable()
+    const now = this.#clock()
+    return this.#transaction(() => {
+      const runs = this.database.prepare(
+        `UPDATE agent_runs SET status = 'failed', error_code = 'service-restarted', completed_at = ?
+         WHERE status IN ('queued', 'running')`,
+      ).run(now)
+      const turns = this.database.prepare(
+        `UPDATE work_turns SET status = 'failed', error_code = 'service-restarted', completed_at = ?
+         WHERE status IN ('queued', 'running')`,
+      ).run(now)
+      return { turnsFailed: Number(turns.changes), runsFailed: Number(runs.changes) }
+    })
+  }
+
   listParticipants(sessionId: string): WorkSessionParticipant[] {
     return this.database
       .prepare('SELECT * FROM work_session_participants WHERE session_id = ? ORDER BY joined_at, participant_id')
@@ -3073,6 +3218,51 @@ export class SqliteStore {
     return mapEmployeeRelationship(row)
   }
 
+  #transitionWorkTurn(
+    turnId: string,
+    from: WorkTurn['status'][],
+    to: WorkTurn['status'],
+    errorCode?: string,
+  ): WorkTurn {
+    this.#assertWritable()
+    const turn = this.getWorkTurn(turnId)
+    if (turn === undefined) throw new EntityNotFoundError(`Work turn not found: ${turnId}`)
+    if (!from.includes(turn.status)) throw new PersistenceError(`Illegal work turn transition: ${turn.status} -> ${to}`)
+    const now = this.#clock()
+    const normalizedError = errorCode?.trim()
+    if ((to === 'failed' || to === 'interrupted') && !normalizedError) throw new PersistenceError('Terminal work turn requires an error code')
+    this.database.prepare(
+      `UPDATE work_turns SET status = ?, error_code = ?,
+       started_at = CASE WHEN ? = 'running' THEN ? ELSE started_at END,
+       completed_at = CASE WHEN ? IN ('completed', 'failed', 'interrupted') THEN ? ELSE completed_at END
+       WHERE id = ?`,
+    ).run(to, normalizedError ?? null, to, now, to, now, turnId)
+    return this.getWorkTurn(turnId)!
+  }
+
+  #transitionAgentRun(
+    runId: string,
+    from: AgentRun['status'][],
+    to: AgentRun['status'],
+    errorCode?: string,
+    runtimeSessionId?: string,
+  ): AgentRun {
+    this.#assertWritable()
+    const run = this.getAgentRun(runId)
+    if (run === undefined) throw new EntityNotFoundError(`Agent run not found: ${runId}`)
+    if (!from.includes(run.status)) throw new PersistenceError(`Illegal agent run transition: ${run.status} -> ${to}`)
+    const now = this.#clock()
+    const normalizedError = errorCode?.trim()
+    if ((to === 'failed' || to === 'interrupted') && !normalizedError) throw new PersistenceError('Terminal agent run requires an error code')
+    this.database.prepare(
+      `UPDATE agent_runs SET status = ?, error_code = ?, runtime_session_id = COALESCE(?, runtime_session_id),
+       started_at = CASE WHEN ? = 'running' THEN ? ELSE started_at END,
+       completed_at = CASE WHEN ? IN ('completed', 'failed', 'interrupted') THEN ? ELSE completed_at END
+       WHERE id = ?`,
+    ).run(to, normalizedError ?? null, runtimeSessionId?.trim() || null, to, now, to, now, runId)
+    return this.getAgentRun(runId)!
+  }
+
   #requireWorkspace(workspaceId: string): Workspace {
     const workspace = this.getWorkspace(workspaceId)
     if (!workspace) throw new EntityNotFoundError(`Workspace not found: ${workspaceId}`)
@@ -3635,6 +3825,34 @@ function mapSession(row: object): WorkSession {
     createdAt: String(value.created_at),
     updatedAt: String(value.updated_at),
   }
+}
+
+function mapWorkTurn(row: object): WorkTurn {
+  const value = row as Record<string, unknown>
+  const turn: WorkTurn = {
+    id: String(value.id), workspaceId: String(value.workspace_id), worldId: String(value.world_id),
+    sessionId: String(value.session_id), interactionKind: value.interaction_kind as WorkTurn['interactionKind'],
+    status: value.status as WorkTurn['status'], createdAt: String(value.created_at),
+  }
+  if (typeof value.client_turn_id === 'string') turn.clientTurnId = value.client_turn_id
+  if (typeof value.error_code === 'string') turn.errorCode = value.error_code
+  if (typeof value.started_at === 'string') turn.startedAt = value.started_at
+  if (typeof value.completed_at === 'string') turn.completedAt = value.completed_at
+  return turn
+}
+
+function mapAgentRun(row: object): AgentRun {
+  const value = row as Record<string, unknown>
+  const run: AgentRun = {
+    id: String(value.id), workspaceId: String(value.workspace_id), worldId: String(value.world_id),
+    turnId: String(value.turn_id), sessionId: String(value.session_id), employeeId: String(value.employee_id),
+    ordinal: Number(value.ordinal), status: value.status as AgentRun['status'], createdAt: String(value.created_at),
+  }
+  if (typeof value.runtime_session_id === 'string') run.runtimeSessionId = value.runtime_session_id
+  if (typeof value.error_code === 'string') run.errorCode = value.error_code
+  if (typeof value.started_at === 'string') run.startedAt = value.started_at
+  if (typeof value.completed_at === 'string') run.completedAt = value.completed_at
+  return run
 }
 
 function mapParticipant(row: object): WorkSessionParticipant {

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -175,7 +175,7 @@ describe('SqliteStore', () => {
       '收到，我先建立基线。',
     ])
     expect(reopened.getEmployee(employee.id)?.agentSessionId).toBe('harness-session-1')
-    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 14 })
+    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 15 })
   })
 
   it('returns the latest message of one sender without loading the full transcript', async () => {
@@ -315,7 +315,7 @@ describe('SqliteStore', () => {
     expect(backupStore.getWorkspace(workspace.id)?.name).toBe('赛博公司')
     const exported = JSON.parse(await readFile(exportPath, 'utf8')) as any
     expect(exported.format).toBe('dsh-cyber-export')
-    expect(exported.schemaVersion).toBe(14)
+    expect(exported.schemaVersion).toBe(15)
     expect(exported.workspaces[0].worlds[0].world.id).toBe(world.id)
     expect(exported.workspaces[0].worlds[0].employees[0].employee.id).toBe(employee.id)
     expect(exported.workspaces[0].worlds[0].sessions[0].messages[0].content).toBe('世界内记录')
@@ -630,6 +630,8 @@ describe('SqliteStore', () => {
       DROP TABLE model_interaction_logs;
       DROP TABLE task_schedule_runs;
       DROP TABLE task_schedules;
+      DROP TABLE agent_runs;
+      DROP TABLE work_turns;
       ALTER TABLE employee_blueprints DROP COLUMN embodiment_json;
       DELETE FROM schema_migrations WHERE version > 2;
       PRAGMA user_version = 2;
@@ -641,7 +643,7 @@ describe('SqliteStore', () => {
     expect(migrated.listWorkspaces()[0]?.name).toBe('迁移前工作区')
     expect(migrated.doctor()).toMatchObject({
       ok: true,
-      schemaVersion: 14,
+      schemaVersion: 15,
       counts: {
         installedPackages: 0,
         packageTransactions: 0,
@@ -867,5 +869,58 @@ describe('SqliteStore', () => {
       durationMs: 5,
       tokensTotal: -2,
     })).toThrow('tokens total must be a non-negative integer')
+  })
+
+  it('persists strict conversation runtime lifecycles and recovers stale work after restart', async () => {
+    const { path, store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: 'Runtime lifecycle' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: 'Company', templateId: 'cyber-company' })
+    store.saveBlueprint(blueprint())
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id, worldId: world.id, blueprintId: 'software-engineer', blueprintVersion: 1,
+    })
+    const session = store.createSession({ workspaceId: workspace.id, worldId: world.id, kind: 'direct', title: 'Lifecycle' })
+    const completedTurn = store.createWorkTurn({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id,
+      interactionKind: 'chat', clientTurnId: 'client-1',
+    })
+    expect(() => store.completeWorkTurn(completedTurn.id)).toThrow('Illegal work turn transition')
+    store.startWorkTurn(completedTurn.id)
+    const completedRun = store.createAgentRun({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id,
+      turnId: completedTurn.id, employeeId: employee.id, ordinal: 1,
+    })
+    store.startAgentRun(completedRun.id)
+    store.completeAgentRun(completedRun.id, 'runtime-session-1')
+    store.completeWorkTurn(completedTurn.id)
+
+    const staleTurn = store.createWorkTurn({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id, interactionKind: 'task',
+    })
+    store.startWorkTurn(staleTurn.id)
+    const staleRun = store.createAgentRun({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id,
+      turnId: staleTurn.id, employeeId: employee.id, ordinal: 1,
+    })
+    store.startAgentRun(staleRun.id)
+    const queuedTurn = store.createWorkTurn({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id, interactionKind: 'chat',
+    })
+    const queuedRun = store.createAgentRun({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id,
+      turnId: queuedTurn.id, employeeId: employee.id, ordinal: 1,
+    })
+    store.close()
+    stores.splice(stores.indexOf(store), 1)
+
+    const reopened = await SqliteStore.open(path)
+    stores.push(reopened)
+    expect(reopened.getAgentRun(completedRun.id)).toMatchObject({ status: 'completed', runtimeSessionId: 'runtime-session-1' })
+    expect(reopened.recoverConversationRuntimeAfterRestart()).toEqual({ turnsFailed: 2, runsFailed: 2 })
+    expect(reopened.getWorkTurn(staleTurn.id)).toMatchObject({ status: 'failed', errorCode: 'service-restarted' })
+    expect(reopened.getAgentRun(staleRun.id)).toMatchObject({ status: 'failed', errorCode: 'service-restarted' })
+    expect(reopened.getWorkTurn(queuedTurn.id)).toMatchObject({ status: 'failed', errorCode: 'service-restarted' })
+    expect(reopened.getAgentRun(queuedRun.id)).toMatchObject({ status: 'failed', errorCode: 'service-restarted' })
+    expect(reopened.recoverConversationRuntimeAfterRestart()).toEqual({ turnsFailed: 0, runsFailed: 0 })
   })
 })

--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -235,6 +235,20 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     writeJson(response, 200, { items: store.listMessages(session.id, nonNegativeInteger(url.searchParams.get('after'))) })
   })
 
+  router.get(/^\/api\/sessions\/([^/]+)\/turns$/, async ({ request, response, params }) => {
+    const session = store.getSession(params[0]!)
+    if (session === undefined) throw new HttpError(404, 'session_not_found', 'Session not found')
+    await worldAccess.assertUnlocked(session.worldId, request)
+    writeJson(response, 200, { items: store.listSessionTurns(session.id) })
+  })
+
+  router.get(/^\/api\/turns\/([^/]+)$/, async ({ request, response, params }) => {
+    const turn = store.getWorkTurn(params[0]!)
+    if (turn === undefined) throw new HttpError(404, 'turn_not_found', 'Turn not found')
+    await worldAccess.assertUnlocked(turn.worldId, request)
+    writeJson(response, 200, { turn, runs: store.listTurnAgentRuns(turn.id) })
+  })
+
   router.get(/^\/api\/sessions\/([^/]+)\/participants$/, async ({ request, response, params }) => {
     const session = store.getSession(params[0]!)
     if (session === undefined) throw new HttpError(404, 'session_not_found', 'Session not found')

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -114,6 +114,7 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
   if (!compatibility.ok) throw new Error(`Harness compatibility check failed: ${compatibility.errors.join('; ')}`)
 
   const store = await SqliteStore.open(join(stateRoot, 'data', 'dsh-cyber.sqlite'))
+  store.recoverConversationRuntimeAfterRestart()
   for (const blueprint of BUILTIN_BLUEPRINTS) store.saveBlueprint(blueprint)
   if (options.bootstrapDefaultWorld === true && store.listWorkspaces().length === 0) {
     const local = store.createWorkspace({ name: '本地实例' })

--- a/packages/server/tests/server.test.ts
+++ b/packages/server/tests/server.test.ts
@@ -348,11 +348,35 @@ describe('Cyber local server', () => {
       'turn.started', 'assistant.reasoning', 'tool.started', 'tool.completed', 'assistant.message', 'turn.completed',
     ])
     expect(runtimeEvents.every((item) => item.event.metadata.clientTurnId === 'client-turn-group')).toBe(true)
+    expect(runtimeEvents.every((item) => item.agentRunId === item.event.metadata.traceTurnId)).toBe(true)
+    expect(runtimeEvents.every((item) => item.workTurnId === item.event.metadata.workTurnId)).toBe(true)
+
+    const turns = await json(first.origin, `/api/sessions/${sessionId}/turns`)
+    expect(turns.response.status).toBe(200)
+    expect(turns.body.items).toHaveLength(1)
+    const turnId = turns.body.items[0].id as string
+    const turnDetail = await json(first.origin, `/api/turns/${turnId}`)
+    expect(turnDetail.body.turn).toMatchObject({ id: turnId, status: 'completed', interactionKind: 'chat' })
+    expect(turnDetail.body.runs).toEqual([
+      expect.objectContaining({ employeeId: engineer.id, ordinal: 1, status: 'completed' }),
+      expect.objectContaining({ employeeId: archivist.id, ordinal: 2, status: 'completed' }),
+    ])
+    const staleTurn = first.server.store.createWorkTurn({
+      workspaceId: workspace.id, worldId: world.id, sessionId, interactionKind: 'task',
+    })
+    first.server.store.startWorkTurn(staleTurn.id)
+    const staleRun = first.server.store.createAgentRun({
+      workspaceId: workspace.id, worldId: world.id, sessionId, turnId: staleTurn.id,
+      employeeId: engineer.id, ordinal: 1,
+    })
+    first.server.store.startAgentRun(staleRun.id)
 
     await first.server.close()
     servers.splice(servers.indexOf(first.server), 1)
 
     const second = await start(stateRoot, new FakeRuntime())
+    expect(second.server.store.getWorkTurn(staleTurn.id)).toMatchObject({ status: 'failed', errorCode: 'service-restarted' })
+    expect(second.server.store.getAgentRun(staleRun.id)).toMatchObject({ status: 'failed', errorCode: 'service-restarted' })
     const workspaceSnapshot = await json(second.origin, `/api/workspaces/${workspace.id}/snapshot`)
     const worldSnapshot = await json(second.origin, `/api/worlds/${world.id}/snapshot`)
     const messages = await json(second.origin, `/api/sessions/${sessionId}/messages`)

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -95,6 +95,8 @@ interface RuntimeEnvelope {
   worldId: string
   sessionId: string
   agentId: string
+  workTurnId: string
+  agentRunId: string
   event: AgentRuntimeEvent
 }
 
@@ -343,7 +345,7 @@ export default function App() {
     if (activeWorldRef.current?.id !== session.worldId) return
     setSessions((current) => [session, ...current.filter((item) => item.id !== session.id)])
     setSessionParticipants((current) => ({ ...current, [session.id]: employeeIds }))
-    if (activeConversationKeyRef.current === queueKey) {
+    if (activeConversationKeyRef.current === queueKey || activeConversationKeyRef.current === undefined) {
       setActiveSessionId(session.id)
       setConversationIntent(undefined)
     }
@@ -408,7 +410,7 @@ export default function App() {
         }
 
         const clientTurnId = metadataText(envelope.event.metadata.clientTurnId)
-        const traceTurnId = metadataText(envelope.event.metadata.traceTurnId)
+        const traceTurnId = envelope.agentRunId
         if (clientTurnId === undefined || traceTurnId === undefined) return
         const pending = pendingTurnsRef.current.find((turn) => turn.id === clientTurnId)
         const queueKey = pending?.queueKey
@@ -448,6 +450,8 @@ export default function App() {
                 employeeId: envelope.agentId,
                 clientTurnId,
                 traceTurnId,
+                workTurnId: envelope.workTurnId,
+                agentRunId: envelope.agentRunId,
                 content: replaceContent ? content : `${previous?.content ?? ''}${content}`,
                 createdAt,
               },

--- a/packages/web/src/chat-realtime.ts
+++ b/packages/web/src/chat-realtime.ts
@@ -22,6 +22,8 @@ export interface StreamingChatReply {
   employeeId: string
   clientTurnId: string
   traceTurnId: string
+  workTurnId: string
+  agentRunId: string
   content: string
   createdAt: string
 }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -237,7 +237,7 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .world-row.is-active { border-left-color: var(--accent); color: var(--accent-strong); }
 .isolation-note { margin: 8px 6px 0; padding: 7px 8px; border: 1px solid var(--border); color: var(--text-muted); font-size: var(--text-xs); line-height: 1.5; }
 .nav-section--sessions { flex: 1 1 auto; min-height: 110px; display: flex; flex-direction: column; overflow: hidden; }
-.session-list { flex: 1; min-height: 0; overflow-y: auto; }
+.session-list { flex: 1; min-height: 0; align-content: start; grid-auto-rows: max-content; overflow-y: auto; }
 .session-row { min-height: 50px; display: grid; grid-template-columns: 36px minmax(0, 1fr) auto; align-items: center; gap: 8px; padding: 6px 8px; border-left: 2px solid transparent; color: var(--text-muted); font-size: var(--text-xs); }
 .session-row:hover { background: var(--surface-2); color: var(--text); }
 .session-row.is-active { border-left-color: var(--accent); background: var(--accent-soft); color: var(--text); }


### PR DESCRIPTION
## Summary
- add durable WorkTurn and AgentRun contracts, SQLite migration, strict lifecycle transitions, and restart recovery
- integrate direct, group, and peer execution with stable workTurnId/agentRunId correlation across messages, domain events, and SSE
- add turn read APIs, regression coverage, and public-facing documentation for the current persistence boundary

## Verification
- pnpm typecheck
- pnpm test (76 files, 318 tests)
- pnpm test:e2e (14 Chromium tests)