### PR TITLE
feat(approval):approval-gate-v1

### DIFF
--- a/docs/architecture/approval-gate-v1.md
+++ b/docs/architecture/approval-gate-v1.md
@@ -1,0 +1,51 @@
+# Approval Gate V1
+
+Approval Gate V1 为受信任 Skill Adapter 的外部副作用提供本地、持久且不可绕过的审批边界。当前 Home Assistant 控制动作属于这一边界。
+
+## 执行链
+
+```text
+Skill proposal
+  → durable Skill Action
+  → exact Approval Request or active Policy
+  → current character and Skill Grant check
+  → trusted Skill Adapter
+  → durable result
+```
+
+外部副作用在审批前保存为 `waiting-for-approval`。只有持久化审批已经批准，或存在完全匹配的有效策略，运行时才会调用 Adapter。拒绝和过期会把动作终止为 `rejected`。
+
+执行前会再次确认角色仍存在、未归档、属于当前世界，并且当前 revision 仍持有对应 Skill Grant。撤销授权后，旧审批不能继续驱动动作。
+
+## 精确复用策略
+
+可复用策略只支持角色级和世界级作用域，并绑定以下全部字段：
+
+- Subject Type
+- Skill ID
+- Action
+- Target
+- Risk
+- World
+- Character，适用于角色级策略
+
+目标、动作或风险发生变化时必须重新审批。系统不提供“永久允许整个插件”或“永久允许全部外部动作”的宽泛授权。
+
+## 中断与重试
+
+调用外部 Adapter 前，动作先持久化为 `waiting-for-integration`。应用在该阶段中断时，重启恢复会把动作标记为 `outcome-unknown`。系统不会自动重试可能已经产生副作用的动作。
+
+## 本地 API
+
+- `GET /api/worlds/:worldId/approvals?status=pending`
+- `POST /api/approvals/:approvalId/decision`
+- `GET /api/worlds/:worldId/approval-policies`
+- `DELETE /api/approval-policies/:policyId`
+
+决策请求使用 `decision` 字段，可选值为 `approved` 或 `rejected`。批准时可使用 `scope` 字段选择 `once`、`character` 或 `world`。拒绝始终按单次决策处理。
+
+所有接口沿用世界访问锁。决策主体由本地服务确定，客户端不能提交任意身份冒充审批人。
+
+## 当前范围
+
+Approval Gate V1 覆盖 `external-side-effect` Skill Action。工具调用、文件写入、审批中心界面和远程审批同步尚未实现。

--- a/docs/community/implementation-status.md
+++ b/docs/community/implementation-status.md
@@ -20,7 +20,8 @@
 | 员工蓝图 | schemaVersion、严格字段/长度/唯一性、package id 与能力绑定、不可变 id+version、模板过滤、默认拒绝与逐项能力授权、独立实例/会话、SQLite 恢复 | requested skills 当前展示但不自动授权；模型继续走 ModelProfile/assignment | avatar、memory/skill 文件、蓝图 modelPolicy、compatibility/评测 schema |
 | 插件 | canonical `prompt-transform` 进入真实 conversation runtime prompt；legacy `commands` 明确转换；staged 校验；原始用户消息持久化不被改写 | 仅声明式 JSON；支持 `/command`、`always`、prepend/append/replace、priority 与资源上限；强制无外发 | 可执行代码、skill/tool/event/widget、网络代理与外发审计 |
 | 会话记忆 | 单个 WorkSession 的用户可见聊天历史由本地 SQLite 恢复：跨进程重启、Harness Runtime 重建、权限模式切换和 persisted-log 碰撞轮换都能继续对话；私聊/群聊/世界之间严格隔离；群聊历史保留真实发言人；reasoning、tool-call、tool-result、system、临时气泡与凭据不进入历史 | 预算为「24 条 + 16000 字符」的确定性截断，不使用 tokenizer；超长单条消息截断并标注；每个角色按自身 watermark 增量补齐——新 Session 重播全部，存活 Session 只补它未见过的部分（私聊恒为空，群聊补上一轮晚于自己发言的角色）；同一员工的回合串行、不同员工并行 | Episodic/Semantic/Procedural memory 分类、向量检索、Embedding、自动摘要与记忆整理、跨会话回忆 |
-| 会话执行 | `WorkSession → WorkTurn → AgentRun` 持久模型；私聊一轮一次运行，群聊和角色协作按真实调用顺序记录多次运行；本轮消息关联回合，角色输出、领域事件与 SSE 关联具体运行；服务重启确定性终止遗留执行；提供会话回合和回合详情读取 API | 当前只记录生命周期、错误码和 Runtime Session ID，不持久化原始 prompt、工具输入或工具结果 | 自动重试、通用事件 items 表、远程执行同步、审批模型 |
+| 会话执行 | `WorkSession → WorkTurn → AgentRun` 持久模型；私聊一轮一次运行，群聊和角色协作按真实调用顺序记录多次运行；本轮消息关联回合，角色输出、领域事件与 SSE 关联具体运行；服务重启确定性终止遗留执行；提供会话回合和回合详情读取 API | 当前只记录生命周期、错误码和 Runtime Session ID，不持久化原始 prompt、工具输入或工具结果 | 自动重试、通用事件 items 表、远程执行同步 |
+| 动作审批 | 外部副作用先持久化 Skill Action 与 Approval Request；未批准、已拒绝、已过期或授权已撤销时不会进入受信任 Adapter；支持单次批准、角色级和世界级精确策略，以及策略撤销；服务中断时执行中的外部动作转为结果未知并禁止自动重试 | 当前审批通过本地 HTTP API 提供，复用策略严格绑定 Skill、Action、Target、Risk 与作用域 | 审批中心 UI、工具调用与文件写入审批、远程审批同步 |
 | 模型交互日志 | turn/discovery 双源采集、SQLite 持久化（v11 STRICT 表 + 三索引）、分页/筛选/详情/清空 API、设置面板「日志记录」界面、错误信息密钥清洗（`sk-…`/`Bearer …`/键值对 → `[已隐藏]`） | token 用量字段预留但当前恒为空（DSH worker 未透出单次请求用量）；消息数为近似统计；无自动保留策略 | worker 进程内逐请求采集与 token 透出、日志自动清理/条数上限 |
 | CI | Node 22.19、pnpm 11.7、frozen lockfile、typecheck、test、Chromium、E2E | 仓库工作流名为 `required`；GitHub 分支保护需在仓库设置中另行确认 | 自动发布与包签名流水线 |
 
@@ -36,6 +37,7 @@
 - 员工蓝图解析与实例化：`packages/server/src/employee-blueprint-manifest.ts`、`packages/persistence/src/sqlite-store.ts`
 - prompt transform：`packages/server/src/prompt-transform-parser.ts`、`packages/server/src/routes/conversation-routes.ts`
 - 会话记忆与执行：`packages/orchestration/src/conversation-history.ts`、`packages/orchestration/src/conversation-orchestrator.ts`、`packages/persistence/src/migrations.ts`、`packages/persistence/src/sqlite-store.ts`、`packages/harness-adapter/src/history-prompt.ts`、`packages/harness-adapter/src/adapter.ts`、`packages/orchestration/tests/conversation-history.test.ts`、`packages/orchestration/tests/conversation-memory.test.ts`、`packages/server/tests/conversation-memory-restart.test.ts`
+- 动作审批：`packages/server/src/services/character-skill-runtime.ts`、`packages/server/src/skills/sqlite-skill-action-repository.ts`、`packages/persistence/src/migrations.ts`、`packages/persistence/src/sqlite-store.ts`、`packages/server/tests/character-skill-runtime.test.ts`、[Approval Gate V1](../architecture/approval-gate-v1.md)
 - 模型交互日志：`packages/server/src/services/model-interaction-service.ts`、`packages/server/src/routes/model-interaction-routes.ts`、`packages/persistence/src/migrations.ts`（v11）、[模块说明与观测边界](model-interaction-logs.md)
 - CI：`.github/workflows/ci.yml`
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -25,6 +25,7 @@
 - [x] Complete local `.dshbackup` boundary
 - [x] Controlled Harness update / rollback
 - [x] SQLite-backed conversation continuity across runtime restart
+- [x] Approval Gate V1 for trusted external Skill actions
 - [ ] Finish Creative Workshop project lifecycle
 - [ ] Add Creative Workshop smoke E2E
 - [ ] Define Creative Platform V1 local-data compatibility baseline

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,4 @@
-export const CYBER_SCHEMA_VERSION = 15 as const
+export const CYBER_SCHEMA_VERSION = 16 as const
 
 export type IsoTimestamp = string
 export type JsonPrimitive = boolean | number | string | null
@@ -13,6 +13,47 @@ export type {
 
 export type ReasoningEffort = 'auto' | 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max'
 export type AgentPermissionMode = 'read-only' | 'workspace-write' | 'danger-full-access'
+
+export type ApprovalSubjectType = 'skill-action' | 'tool-call' | 'file-write' | 'external-action'
+export type ApprovalRisk = 'read' | 'write-local' | 'external-side-effect' | 'high-risk'
+export type ApprovalStatus = 'pending' | 'approved' | 'rejected' | 'expired'
+export type ApprovalScope = 'once' | 'character' | 'world'
+
+export interface ApprovalRequest {
+  id: string
+  workspaceId: string
+  worldId: string
+  sessionId?: string
+  workTurnId?: string
+  agentRunId?: string
+  characterId?: string
+  subjectType: ApprovalSubjectType
+  subjectId: string
+  risk: ApprovalRisk
+  summary: string
+  status: ApprovalStatus
+  scope: ApprovalScope
+  createdAt: IsoTimestamp
+  expiresAt: IsoTimestamp
+  decidedAt?: IsoTimestamp
+  decidedBy?: string
+}
+
+export interface ApprovalPolicy {
+  id: string
+  workspaceId: string
+  worldId: string
+  characterId?: string
+  subjectType: ApprovalSubjectType
+  skillId?: string
+  action: string
+  target: string
+  risk: ApprovalRisk
+  scope: Exclude<ApprovalScope, 'once'>
+  sourceApprovalId: string
+  createdAt: IsoTimestamp
+  revokedAt?: IsoTimestamp
+}
 
 export type TaskScheduleKind = 'once' | 'interval'
 export type TaskScheduleStatus = 'active' | 'paused' | 'completed'
@@ -870,6 +911,9 @@ export interface DatabaseDoctorReport {
     modelInteractionLogs: number
     taskSchedules: number
     taskScheduleRuns: number
+    approvalRequests: number
+    approvalPolicies: number
+    skillActions: number
     events: number
     outbox: number
   }

--- a/packages/contracts/src/skill-runtime.ts
+++ b/packages/contracts/src/skill-runtime.ts
@@ -2,10 +2,12 @@ import type { IsoTimestamp, JsonObject } from './index.js'
 
 export type SkillActionStatus =
   | 'scheduled'
+  | 'waiting-for-approval'
   | 'executed'
   | 'waiting-for-integration'
   | 'failed'
   | 'outcome-unknown'
+  | 'rejected'
 
 export type SkillActionRisk = 'read' | 'write-local' | 'external-side-effect'
 
@@ -36,6 +38,9 @@ export interface CharacterSkillAction {
   authorization: SkillActionAuthorization
   parameters: JsonObject
   scheduledFor?: IsoTimestamp
+  approvalRequestId?: string
+  workTurnId?: string
+  agentRunId?: string
   status: SkillActionStatus
   detail: string
   createdAt: IsoTimestamp

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -658,6 +658,78 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX agent_runs_employee_status_created_idx ON agent_runs(employee_id, status, created_at DESC, id);
     `,
   },
+  {
+    version: 16,
+    name: 'approval-gate-v1',
+    sql: `
+      CREATE TABLE skill_actions (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        world_id TEXT NOT NULL REFERENCES worlds(id) ON DELETE CASCADE,
+        character_id TEXT NOT NULL REFERENCES employee_instances(id) ON DELETE CASCADE,
+        skill_id TEXT NOT NULL,
+        adapter_id TEXT NOT NULL,
+        action TEXT NOT NULL,
+        target TEXT NOT NULL,
+        label TEXT NOT NULL,
+        risk TEXT NOT NULL CHECK (risk IN ('read', 'write-local', 'external-side-effect')),
+        authorization TEXT NOT NULL CHECK (authorization IN ('explicit-user-request', 'preapproved-policy')),
+        parameters_json TEXT NOT NULL,
+        scheduled_for TEXT,
+        approval_request_id TEXT REFERENCES approval_requests(id) ON DELETE SET NULL,
+        work_turn_id TEXT REFERENCES work_turns(id) ON DELETE SET NULL,
+        agent_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL,
+        status TEXT NOT NULL CHECK (status IN ('scheduled', 'waiting-for-approval', 'executed', 'waiting-for-integration', 'failed', 'outcome-unknown', 'rejected')),
+        detail TEXT NOT NULL,
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+      ) STRICT;
+      CREATE INDEX skill_actions_world_created_idx ON skill_actions(world_id, created_at DESC, id);
+      CREATE INDEX skill_actions_due_idx ON skill_actions(status, scheduled_for) WHERE scheduled_for IS NOT NULL;
+      CREATE INDEX skill_actions_subject_idx ON skill_actions(world_id, character_id, skill_id, action, target, created_at DESC);
+
+      CREATE TABLE approval_requests (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        world_id TEXT NOT NULL REFERENCES worlds(id) ON DELETE CASCADE,
+        session_id TEXT REFERENCES work_sessions(id) ON DELETE SET NULL,
+        work_turn_id TEXT REFERENCES work_turns(id) ON DELETE SET NULL,
+        agent_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL,
+        character_id TEXT REFERENCES employee_instances(id) ON DELETE SET NULL,
+        subject_type TEXT NOT NULL CHECK (subject_type IN ('skill-action', 'tool-call', 'file-write', 'external-action')),
+        subject_id TEXT NOT NULL,
+        risk TEXT NOT NULL CHECK (risk IN ('read', 'write-local', 'external-side-effect', 'high-risk')),
+        summary TEXT NOT NULL,
+        status TEXT NOT NULL CHECK (status IN ('pending', 'approved', 'rejected', 'expired')),
+        scope TEXT NOT NULL CHECK (scope IN ('once', 'character', 'world')),
+        created_at TEXT NOT NULL,
+        expires_at TEXT NOT NULL,
+        decided_at TEXT,
+        decided_by TEXT,
+        UNIQUE(subject_type, subject_id)
+      ) STRICT;
+      CREATE INDEX approval_requests_world_status_created_idx ON approval_requests(world_id, status, created_at DESC, id);
+      CREATE INDEX approval_requests_turn_idx ON approval_requests(work_turn_id, created_at DESC) WHERE work_turn_id IS NOT NULL;
+
+      CREATE TABLE approval_policies (
+        id TEXT PRIMARY KEY,
+        workspace_id TEXT NOT NULL REFERENCES workspaces(id) ON DELETE CASCADE,
+        world_id TEXT NOT NULL REFERENCES worlds(id) ON DELETE CASCADE,
+        character_id TEXT REFERENCES employee_instances(id) ON DELETE CASCADE,
+        subject_type TEXT NOT NULL CHECK (subject_type IN ('skill-action', 'tool-call', 'file-write', 'external-action')),
+        skill_id TEXT,
+        action TEXT NOT NULL,
+        target TEXT NOT NULL,
+        risk TEXT NOT NULL CHECK (risk IN ('read', 'write-local', 'external-side-effect', 'high-risk')),
+        scope TEXT NOT NULL CHECK (scope IN ('character', 'world')),
+        source_approval_id TEXT NOT NULL REFERENCES approval_requests(id) ON DELETE CASCADE,
+        created_at TEXT NOT NULL,
+        revoked_at TEXT,
+        CHECK ((scope = 'character' AND character_id IS NOT NULL) OR (scope = 'world' AND character_id IS NULL))
+      ) STRICT;
+      CREATE INDEX approval_policies_match_idx ON approval_policies(world_id, subject_type, skill_id, action, target, risk, revoked_at);
+    `,
+  },
 ]
 
 export function migrate(database: DatabaseSync, now: () => string): void {

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -46,6 +46,12 @@ import {
   type SkillEvidenceKind,
   type SkillEvidenceOutcome,
   type AgentRun,
+  type ApprovalPolicy,
+  type ApprovalRequest,
+  type ApprovalRisk,
+  type ApprovalScope,
+  type ApprovalStatus,
+  type ApprovalSubjectType,
   type WorkTurn,
   type WorkTurnInteractionKind,
   type WorkMessage,
@@ -63,6 +69,7 @@ import {
   type WorkspacePreferences,
   type WorkspaceSnapshot,
 } from '@dsh-cyber/contracts'
+import type { CharacterSkillAction } from '@dsh-cyber/contracts/skill-runtime'
 
 import { DatabaseCorruptError, EntityNotFoundError, PersistenceError } from './errors.js'
 import { migrate, readUserVersion } from './migrations.js'
@@ -261,6 +268,34 @@ export interface ConversationRuntimeRecoveryReport {
   runsFailed: number
 }
 
+export interface CreateApprovalRequestInput {
+  workspaceId: string
+  worldId: string
+  sessionId?: string
+  workTurnId?: string
+  agentRunId?: string
+  characterId?: string
+  subjectType: ApprovalSubjectType
+  subjectId: string
+  risk: ApprovalRisk
+  summary: string
+  createdAt?: string
+  expiresAt: string
+}
+
+export interface CreateApprovalPolicyInput {
+  workspaceId: string
+  worldId: string
+  characterId?: string
+  subjectType: ApprovalSubjectType
+  skillId?: string
+  action: string
+  target: string
+  risk: ApprovalRisk
+  scope: Exclude<ApprovalScope, 'once'>
+  sourceApprovalId: string
+}
+
 export interface AppendMessageInput {
   sessionId: string
   senderId: string
@@ -375,6 +410,9 @@ const KNOWN_TABLES = [
   'work_sessions',
   'work_turns',
   'agent_runs',
+  'skill_actions',
+  'approval_requests',
+  'approval_policies',
   'work_session_participants',
   'messages',
   'installed_packages',
@@ -2140,6 +2178,265 @@ export class SqliteStore {
     })
   }
 
+  reserveSkillAction(action: CharacterSkillAction, duplicateWindowMs: number): { action: CharacterSkillAction; created: boolean } {
+    this.#assertWritable()
+    if (!Number.isSafeInteger(duplicateWindowMs) || duplicateWindowMs < 0) throw new PersistenceError('Skill duplicate window is invalid')
+    const world = this.#requireWorld(action.worldId)
+    const employee = this.#requireEmployee(action.characterId)
+    if (employee.worldId !== world.id || employee.workspaceId !== world.workspaceId) throw new PersistenceError('Skill action scope is invalid')
+    return this.#transaction(() => {
+      const existingId = this.getSkillAction(action.id)
+      if (existingId !== undefined) return { action: existingId, created: false }
+      const cutoff = new Date(Date.parse(action.createdAt) - duplicateWindowMs).toISOString()
+      const duplicate = this.database.prepare(
+        `SELECT * FROM skill_actions
+         WHERE world_id = ? AND character_id = ? AND skill_id = ? AND adapter_id = ?
+           AND action = ? AND target = ? AND scheduled_for IS ? AND created_at > ?
+         ORDER BY created_at DESC LIMIT 1`,
+      ).get(action.worldId, action.characterId, action.skillId, action.adapterId, action.action,
+        action.target, action.scheduledFor ?? null, cutoff)
+      if (duplicate !== undefined) return { action: mapSkillAction(duplicate), created: false }
+      this.database.prepare(
+        `INSERT INTO skill_actions
+         (id, workspace_id, world_id, character_id, skill_id, adapter_id, action, target, label,
+          risk, authorization, parameters_json, scheduled_for, approval_request_id, work_turn_id,
+          agent_run_id, status, detail, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      ).run(action.id, world.workspaceId, action.worldId, action.characterId, action.skillId,
+        action.adapterId, action.action, action.target, action.label, action.risk, action.authorization,
+        stringifyJson(action.parameters), action.scheduledFor ?? null, action.approvalRequestId ?? null,
+        action.workTurnId ?? null, action.agentRunId ?? null, action.status, action.detail,
+        action.createdAt, action.updatedAt)
+      return { action: structuredClone(action), created: true }
+    })
+  }
+
+  saveSkillAction(action: CharacterSkillAction): void {
+    this.#assertWritable()
+    const result = this.database.prepare(
+      `UPDATE skill_actions SET status = ?, detail = ?, authorization = ?, approval_request_id = ?, work_turn_id = ?,
+       agent_run_id = ?, updated_at = ? WHERE id = ?`,
+    ).run(action.status, action.detail, action.authorization, action.approvalRequestId ?? null, action.workTurnId ?? null,
+      action.agentRunId ?? null, action.updatedAt, action.id)
+    if (Number(result.changes) !== 1) throw new EntityNotFoundError(`Skill action not found: ${action.id}`)
+  }
+
+  getSkillAction(actionId: string): CharacterSkillAction | undefined {
+    const row = this.database.prepare('SELECT * FROM skill_actions WHERE id = ?').get(actionId)
+    return row === undefined ? undefined : mapSkillAction(row)
+  }
+
+  listWorldSkillActions(worldId: string): CharacterSkillAction[] {
+    this.#requireWorld(worldId)
+    return this.database.prepare(
+      'SELECT * FROM skill_actions WHERE world_id = ? ORDER BY created_at DESC, id DESC',
+    ).all(worldId).map(mapSkillAction)
+  }
+
+  listDueSkillActions(now: Date): CharacterSkillAction[] {
+    return this.database.prepare(
+      `SELECT * FROM skill_actions WHERE status = 'scheduled' AND scheduled_for <= ? ORDER BY scheduled_for, id`,
+    ).all(now.toISOString()).map(mapSkillAction)
+  }
+
+  listSkillActionsWaitingForApproval(): CharacterSkillAction[] {
+    return this.database.prepare(
+      `SELECT * FROM skill_actions WHERE status = 'waiting-for-approval' ORDER BY created_at, id`,
+    ).all().map(mapSkillAction)
+  }
+
+  createApprovalRequest(input: CreateApprovalRequestInput): ApprovalRequest {
+    this.#assertWritable()
+    const world = this.#requireWorld(input.worldId)
+    if (world.workspaceId !== input.workspaceId) throw new PersistenceError('Approval workspace does not match world')
+    if (input.characterId !== undefined) {
+      const employee = this.#requireEmployee(input.characterId)
+      if (employee.worldId !== world.id) throw new PersistenceError('Approval character does not match world')
+    }
+    if (input.sessionId !== undefined) {
+      const session = this.getSession(input.sessionId)
+      if (session === undefined || session.worldId !== world.id) throw new PersistenceError('Approval session does not match world')
+    }
+    if (input.workTurnId !== undefined) {
+      const turn = this.getWorkTurn(input.workTurnId)
+      if (turn === undefined || turn.worldId !== world.id || (input.sessionId !== undefined && turn.sessionId !== input.sessionId)) {
+        throw new PersistenceError('Approval turn does not match scope')
+      }
+    }
+    if (input.agentRunId !== undefined) {
+      const run = this.getAgentRun(input.agentRunId)
+      if (run === undefined || run.worldId !== world.id || (input.workTurnId !== undefined && run.turnId !== input.workTurnId)) {
+        throw new PersistenceError('Approval run does not match scope')
+      }
+    }
+    const existing = this.getApprovalRequestBySubject(input.subjectType, input.subjectId)
+    if (existing !== undefined) {
+      if (existing.workspaceId !== input.workspaceId || existing.worldId !== input.worldId
+        || existing.characterId !== input.characterId || existing.risk !== input.risk) {
+        throw new PersistenceError('Approval subject is already bound to another scope')
+      }
+      return existing
+    }
+    const createdAt = input.createdAt ?? this.#clock()
+    if (!Number.isFinite(Date.parse(createdAt))) throw new PersistenceError('Approval creation time is invalid')
+    if (!Number.isFinite(Date.parse(input.expiresAt)) || Date.parse(input.expiresAt) <= Date.parse(createdAt)) {
+      throw new PersistenceError('Approval expiry is invalid')
+    }
+    const request: ApprovalRequest = {
+      id: this.#idFactory(), workspaceId: input.workspaceId, worldId: input.worldId,
+      subjectType: input.subjectType, subjectId: input.subjectId, risk: input.risk,
+      summary: input.summary.trim(), status: 'pending', scope: 'once', createdAt, expiresAt: input.expiresAt,
+      ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
+      ...(input.workTurnId === undefined ? {} : { workTurnId: input.workTurnId }),
+      ...(input.agentRunId === undefined ? {} : { agentRunId: input.agentRunId }),
+      ...(input.characterId === undefined ? {} : { characterId: input.characterId }),
+    }
+    if (!request.summary) throw new PersistenceError('Approval summary cannot be empty')
+    this.database.prepare(
+      `INSERT INTO approval_requests
+       (id, workspace_id, world_id, session_id, work_turn_id, agent_run_id, character_id,
+        subject_type, subject_id, risk, summary, status, scope, created_at, expires_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(request.id, request.workspaceId, request.worldId, request.sessionId ?? null,
+      request.workTurnId ?? null, request.agentRunId ?? null, request.characterId ?? null,
+      request.subjectType, request.subjectId, request.risk, request.summary, request.status,
+      request.scope, request.createdAt, request.expiresAt)
+    return request
+  }
+
+  getApprovalRequest(approvalId: string): ApprovalRequest | undefined {
+    const row = this.database.prepare('SELECT * FROM approval_requests WHERE id = ?').get(approvalId)
+    return row === undefined ? undefined : mapApprovalRequest(row)
+  }
+
+  getApprovalRequestBySubject(subjectType: ApprovalSubjectType, subjectId: string): ApprovalRequest | undefined {
+    const row = this.database.prepare(
+      'SELECT * FROM approval_requests WHERE subject_type = ? AND subject_id = ?',
+    ).get(subjectType, subjectId)
+    return row === undefined ? undefined : mapApprovalRequest(row)
+  }
+
+  listWorldApprovalRequests(worldId: string, status?: ApprovalStatus): ApprovalRequest[] {
+    this.#requireWorld(worldId)
+    const rows = status === undefined
+      ? this.database.prepare('SELECT * FROM approval_requests WHERE world_id = ? ORDER BY created_at DESC, id DESC').all(worldId)
+      : this.database.prepare('SELECT * FROM approval_requests WHERE world_id = ? AND status = ? ORDER BY created_at DESC, id DESC').all(worldId, status)
+    return rows.map(mapApprovalRequest)
+  }
+
+  decideApprovalRequest(approvalId: string, decision: 'approved' | 'rejected', scope: ApprovalScope, actorId: string, now = this.#clock()): ApprovalRequest {
+    this.#assertWritable()
+    if (!['once', 'character', 'world'].includes(scope)) throw new PersistenceError('Approval scope is invalid')
+    if (!actorId.trim()) throw new PersistenceError('Approval actor is required')
+    return this.#transaction(() => {
+      const request = this.getApprovalRequest(approvalId)
+      if (request === undefined) throw new EntityNotFoundError(`Approval request not found: ${approvalId}`)
+      if (request.status !== 'pending') throw new PersistenceError(`Approval request is already ${request.status}`)
+      if (Date.parse(request.expiresAt) <= Date.parse(now)) {
+        this.database.prepare(
+          `UPDATE approval_requests SET status = 'expired', decided_at = ?, decided_by = ? WHERE id = ? AND status = 'pending'`,
+        ).run(now, 'system', approvalId)
+        return this.getApprovalRequest(approvalId)!
+      }
+      this.database.prepare(
+        `UPDATE approval_requests SET status = ?, scope = ?, decided_at = ?, decided_by = ?
+         WHERE id = ? AND status = 'pending'`,
+      ).run(decision, decision === 'rejected' ? 'once' : scope, now, actorId, approvalId)
+      if (this.getApprovalRequest(approvalId)?.status !== decision) throw new PersistenceError('Approval decision lost a concurrent race')
+      return this.getApprovalRequest(approvalId)!
+    })
+  }
+
+  expirePendingApprovals(now = this.#clock()): number {
+    this.#assertWritable()
+    return Number(this.database.prepare(
+      `UPDATE approval_requests SET status = 'expired', decided_at = ?, decided_by = 'system'
+       WHERE status = 'pending' AND expires_at <= ?`,
+    ).run(now, now).changes)
+  }
+
+  createApprovalPolicy(input: CreateApprovalPolicyInput): ApprovalPolicy {
+    this.#assertWritable()
+    const approval = this.getApprovalRequest(input.sourceApprovalId)
+    if (approval === undefined || approval.status !== 'approved') throw new PersistenceError('Approval policy requires an approved request')
+    if (approval.workspaceId !== input.workspaceId || approval.worldId !== input.worldId
+      || approval.subjectType !== input.subjectType || approval.risk !== input.risk || approval.scope !== input.scope) {
+      throw new PersistenceError('Approval policy does not match its source approval')
+    }
+    if (input.scope === 'character' && !input.characterId) throw new PersistenceError('Character approval policy requires a character')
+    if (input.scope === 'character' && approval.characterId !== input.characterId) throw new PersistenceError('Approval policy character does not match')
+    if (input.subjectType === 'skill-action') {
+      const action = this.getSkillAction(approval.subjectId)
+      if (action === undefined || action.worldId !== input.worldId || action.characterId !== approval.characterId
+        || action.skillId !== input.skillId || action.action !== input.action || action.target !== input.target || action.risk !== input.risk) {
+        throw new PersistenceError('Approval policy must exactly match the approved skill action')
+      }
+    }
+    const policy: ApprovalPolicy = {
+      id: this.#idFactory(), workspaceId: input.workspaceId, worldId: input.worldId,
+      subjectType: input.subjectType, action: input.action.trim(), target: input.target.trim(),
+      risk: input.risk, scope: input.scope, sourceApprovalId: input.sourceApprovalId,
+      createdAt: this.#clock(),
+      ...(input.characterId === undefined ? {} : { characterId: input.characterId }),
+      ...(input.skillId === undefined ? {} : { skillId: input.skillId }),
+    }
+    if (!policy.action || !policy.target) throw new PersistenceError('Approval policy action and target are required')
+    this.database.prepare(
+      `INSERT INTO approval_policies
+       (id, workspace_id, world_id, character_id, subject_type, skill_id, action, target, risk,
+        scope, source_approval_id, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    ).run(policy.id, policy.workspaceId, policy.worldId, policy.characterId ?? null,
+      policy.subjectType, policy.skillId ?? null, policy.action, policy.target, policy.risk,
+      policy.scope, policy.sourceApprovalId, policy.createdAt)
+    return policy
+  }
+
+  findApprovalPolicy(input: Omit<CreateApprovalPolicyInput, 'scope' | 'sourceApprovalId'>): ApprovalPolicy | undefined {
+    const world = this.#requireWorld(input.worldId)
+    if (world.workspaceId !== input.workspaceId) throw new PersistenceError('Approval policy workspace does not match world')
+    const row = this.database.prepare(
+      `SELECT * FROM approval_policies
+       WHERE world_id = ? AND subject_type = ? AND skill_id IS ? AND action = ? AND target = ?
+         AND risk = ? AND revoked_at IS NULL
+         AND ((scope = 'character' AND character_id = ?) OR scope = 'world')
+       ORDER BY CASE scope WHEN 'character' THEN 0 ELSE 1 END, created_at DESC LIMIT 1`,
+    ).get(input.worldId, input.subjectType, input.skillId ?? null, input.action, input.target,
+      input.risk, input.characterId ?? null)
+    return row === undefined ? undefined : mapApprovalPolicy(row)
+  }
+
+  listWorldApprovalPolicies(worldId: string): ApprovalPolicy[] {
+    this.#requireWorld(worldId)
+    return this.database.prepare(
+      'SELECT * FROM approval_policies WHERE world_id = ? ORDER BY created_at DESC, id DESC',
+    ).all(worldId).map(mapApprovalPolicy)
+  }
+
+  getApprovalPolicy(policyId: string): ApprovalPolicy | undefined {
+    const row = this.database.prepare('SELECT * FROM approval_policies WHERE id = ?').get(policyId)
+    return row === undefined ? undefined : mapApprovalPolicy(row)
+  }
+
+  revokeApprovalPolicy(policyId: string, now = this.#clock()): ApprovalPolicy {
+    this.#assertWritable()
+    const result = this.database.prepare(
+      'UPDATE approval_policies SET revoked_at = ? WHERE id = ? AND revoked_at IS NULL',
+    ).run(now, policyId)
+    if (Number(result.changes) !== 1) throw new PersistenceError('Approval policy is unavailable')
+    const row = this.database.prepare('SELECT * FROM approval_policies WHERE id = ?').get(policyId)
+    return mapApprovalPolicy(row!)
+  }
+
+  recoverSkillActionsAfterRestart(now = this.#clock()): number {
+    this.#assertWritable()
+    return Number(this.database.prepare(
+      `UPDATE skill_actions SET status = 'outcome-unknown',
+       detail = '应用在外部动作执行期间中断，结果未知；不得自动重试', updated_at = ?
+       WHERE status = 'waiting-for-integration'`,
+    ).run(now).changes)
+  }
+
   listParticipants(sessionId: string): WorkSessionParticipant[] {
     return this.database
       .prepare('SELECT * FROM work_session_participants WHERE session_id = ? ORDER BY joined_at, participant_id')
@@ -3035,6 +3332,9 @@ export class SqliteStore {
         modelInteractionLogs: countRows(this.database, 'model_interaction_logs'),
         taskSchedules: countRows(this.database, 'task_schedules'),
         taskScheduleRuns: countRows(this.database, 'task_schedule_runs'),
+        approvalRequests: countRows(this.database, 'approval_requests'),
+        approvalPolicies: countRows(this.database, 'approval_policies'),
+        skillActions: countRows(this.database, 'skill_actions'),
         events: countRows(this.database, 'domain_events'),
         outbox: countRows(this.database, 'sync_outbox'),
       },
@@ -3964,6 +4264,65 @@ function mapAgentRun(row: object): AgentRun {
   if (typeof value.started_at === 'string') run.startedAt = value.started_at
   if (typeof value.completed_at === 'string') run.completedAt = value.completed_at
   return run
+}
+
+function mapSkillAction(row: object): CharacterSkillAction {
+  const value = row as Record<string, unknown>
+  const action: CharacterSkillAction = {
+    id: String(value.id),
+    worldId: String(value.world_id),
+    characterId: String(value.character_id),
+    skillId: String(value.skill_id),
+    adapterId: String(value.adapter_id),
+    action: String(value.action),
+    target: String(value.target),
+    label: String(value.label),
+    risk: value.risk as CharacterSkillAction['risk'],
+    authorization: value.authorization as CharacterSkillAction['authorization'],
+    parameters: parseJson<CharacterSkillAction['parameters']>(value.parameters_json),
+    status: value.status as CharacterSkillAction['status'],
+    detail: String(value.detail),
+    createdAt: String(value.created_at),
+    updatedAt: String(value.updated_at),
+  }
+  if (typeof value.scheduled_for === 'string') action.scheduledFor = value.scheduled_for
+  if (typeof value.approval_request_id === 'string') action.approvalRequestId = value.approval_request_id
+  if (typeof value.work_turn_id === 'string') action.workTurnId = value.work_turn_id
+  if (typeof value.agent_run_id === 'string') action.agentRunId = value.agent_run_id
+  return action
+}
+
+function mapApprovalRequest(row: object): ApprovalRequest {
+  const value = row as Record<string, unknown>
+  const request: ApprovalRequest = {
+    id: String(value.id), workspaceId: String(value.workspace_id), worldId: String(value.world_id),
+    subjectType: value.subject_type as ApprovalSubjectType, subjectId: String(value.subject_id),
+    risk: value.risk as ApprovalRisk, summary: String(value.summary),
+    status: value.status as ApprovalStatus, scope: value.scope as ApprovalScope,
+    createdAt: String(value.created_at), expiresAt: String(value.expires_at),
+  }
+  if (typeof value.session_id === 'string') request.sessionId = value.session_id
+  if (typeof value.work_turn_id === 'string') request.workTurnId = value.work_turn_id
+  if (typeof value.agent_run_id === 'string') request.agentRunId = value.agent_run_id
+  if (typeof value.character_id === 'string') request.characterId = value.character_id
+  if (typeof value.decided_at === 'string') request.decidedAt = value.decided_at
+  if (typeof value.decided_by === 'string') request.decidedBy = value.decided_by
+  return request
+}
+
+function mapApprovalPolicy(row: object): ApprovalPolicy {
+  const value = row as Record<string, unknown>
+  const policy: ApprovalPolicy = {
+    id: String(value.id), workspaceId: String(value.workspace_id), worldId: String(value.world_id),
+    subjectType: value.subject_type as ApprovalSubjectType, action: String(value.action),
+    target: String(value.target), risk: value.risk as ApprovalRisk,
+    scope: value.scope as ApprovalPolicy['scope'], sourceApprovalId: String(value.source_approval_id),
+    createdAt: String(value.created_at),
+  }
+  if (typeof value.character_id === 'string') policy.characterId = value.character_id
+  if (typeof value.skill_id === 'string') policy.skillId = value.skill_id
+  if (typeof value.revoked_at === 'string') policy.revokedAt = value.revoked_at
+  return policy
 }
 
 function mapParticipant(row: object): WorkSessionParticipant {

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -175,7 +175,7 @@ describe('SqliteStore', () => {
       '收到，我先建立基线。',
     ])
     expect(reopened.getEmployee(employee.id)?.agentSessionId).toBe('harness-session-1')
-    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 15 })
+    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 16 })
   })
 
   it('returns the latest message of one sender without loading the full transcript', async () => {
@@ -361,7 +361,7 @@ describe('SqliteStore', () => {
     expect(backupStore.getWorkspace(workspace.id)?.name).toBe('赛博公司')
     const exported = JSON.parse(await readFile(exportPath, 'utf8')) as any
     expect(exported.format).toBe('dsh-cyber-export')
-    expect(exported.schemaVersion).toBe(15)
+    expect(exported.schemaVersion).toBe(16)
     expect(exported.workspaces[0].worlds[0].world.id).toBe(world.id)
     expect(exported.workspaces[0].worlds[0].employees[0].employee.id).toBe(employee.id)
     expect(exported.workspaces[0].worlds[0].sessions[0].messages[0].content).toBe('世界内记录')
@@ -676,6 +676,9 @@ describe('SqliteStore', () => {
       DROP TABLE model_interaction_logs;
       DROP TABLE task_schedule_runs;
       DROP TABLE task_schedules;
+      DROP TABLE approval_policies;
+      DROP TABLE skill_actions;
+      DROP TABLE approval_requests;
       DROP TABLE agent_runs;
       DROP TABLE work_turns;
       ALTER TABLE employee_blueprints DROP COLUMN embodiment_json;
@@ -689,7 +692,7 @@ describe('SqliteStore', () => {
     expect(migrated.listWorkspaces()[0]?.name).toBe('迁移前工作区')
     expect(migrated.doctor()).toMatchObject({
       ok: true,
-      schemaVersion: 15,
+      schemaVersion: 16,
       counts: {
         installedPackages: 0,
         packageTransactions: 0,

--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -184,6 +184,47 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     writeJson(response, 200, { items: await skillRuntime.list(worldId) })
   })
 
+  router.get(/^\/api\/worlds\/([^/]+)\/approvals$/, async ({ request, response, params, url }) => {
+    const worldId = params[0]!
+    if (store.getWorld(worldId) === undefined) throw new HttpError(404, 'world_not_found', 'World not found')
+    await worldAccess.assertUnlocked(worldId, request)
+    const rawStatus = url.searchParams.get('status')
+    const status = rawStatus === null ? undefined : rawStatus
+    if (status !== undefined && !['pending', 'approved', 'rejected', 'expired'].includes(status)) {
+      throw new HttpError(422, 'invalid_approval_status', '不支持的审批状态')
+    }
+    writeJson(response, 200, {
+      items: skillRuntime.listApprovalRequests(worldId, status as 'pending' | 'approved' | 'rejected' | 'expired' | undefined),
+    })
+  })
+
+  router.post(/^\/api\/approvals\/([^/]+)\/decision$/, async ({ request, response, params }) => {
+    const approval = store.getApprovalRequest(params[0]!)
+    if (approval === undefined) throw new HttpError(404, 'approval_not_found', '审批请求不存在')
+    await worldAccess.assertUnlocked(approval.worldId, request)
+    if (approval.status !== 'pending') throw new HttpError(409, 'approval_already_decided', '审批请求已经处理')
+    const body = await readJson(request)
+    const decision = requiredEnum(body, 'decision', ['approved', 'rejected'])
+    const scope = body.scope === undefined ? 'once' : requiredEnum(body, 'scope', ['once', 'character', 'world'])
+    const result = await skillRuntime.decideApproval(approval.id, decision, scope, 'local-user')
+    writeJson(response, 200, result)
+  })
+
+  router.get(/^\/api\/worlds\/([^/]+)\/approval-policies$/, async ({ request, response, params }) => {
+    const worldId = params[0]!
+    if (store.getWorld(worldId) === undefined) throw new HttpError(404, 'world_not_found', 'World not found')
+    await worldAccess.assertUnlocked(worldId, request)
+    writeJson(response, 200, { items: skillRuntime.listApprovalPolicies(worldId) })
+  })
+
+  router.delete(/^\/api\/approval-policies\/([^/]+)$/, async ({ request, response, params }) => {
+    const policy = skillRuntime.getApprovalPolicy(params[0]!)
+    if (policy === undefined) throw new HttpError(404, 'approval_policy_not_found', '授权策略不存在')
+    await worldAccess.assertUnlocked(policy.worldId, request)
+    if (policy.revokedAt !== undefined) throw new HttpError(409, 'approval_policy_revoked', '授权策略已经撤销')
+    writeJson(response, 200, { policy: skillRuntime.revokeApprovalPolicy(policy.id) })
+  })
+
   router.post(/^\/api\/worlds\/([^/]+)\/peer-conversations$/, async ({ request, response, params }) => {
     const world = store.getWorld(params[0]!)
     if (world === undefined) throw new HttpError(404, 'world_not_found', 'World not found')

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -64,6 +64,7 @@ import { WorldTraceService } from './services/world-trace-service.js'
 import { WorldMarketplaceService } from './services/world-marketplace-service.js'
 import { createBuiltinSkillRegistry } from './skills/builtin-skill-registry.js'
 import { LocalSkillActionRepository } from './skills/local-skill-action-repository.js'
+import { SqliteSkillActionRepository } from './skills/sqlite-skill-action-repository.js'
 import type { CharacterSkillActionRepository } from './skills/skill-action-repository.js'
 import type { CharacterSkillAdapterRegistry } from './skills/skill-adapter.js'
 import { RuntimeStreamHub } from './streams/runtime-stream-hub.js'
@@ -192,8 +193,20 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
     service: ambientLifeRuntime,
   })
   const skillRegistry = options.skillRegistry ?? createBuiltinSkillRegistry()
-  const skillActions = options.skillActionRepository
-    ?? new LocalSkillActionRepository(join(stateRoot, 'skills', 'actions.json'))
+  let skillActions = options.skillActionRepository
+  if (skillActions === undefined) {
+    const sqliteActions = new SqliteSkillActionRepository(store)
+    const legacyActions = new LocalSkillActionRepository(join(stateRoot, 'skills', 'actions.json'))
+    for (const workspace of store.listWorkspaces()) {
+      for (const world of store.listWorlds(workspace.id, true)) {
+        for (const action of await legacyActions.listByWorld(world.id)) {
+          await sqliteActions.reserve(action, 0)
+        }
+      }
+    }
+    store.recoverSkillActionsAfterRestart()
+    skillActions = sqliteActions
+  }
   const skillRuntime = new CharacterSkillRuntime(store, {
     registry: skillRegistry,
     actions: skillActions,

--- a/packages/server/src/services/character-skill-runtime.ts
+++ b/packages/server/src/services/character-skill-runtime.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 
+import type { ApprovalPolicy, ApprovalRequest, ApprovalScope } from '@dsh-cyber/contracts'
 import type {
   CharacterSkillAction,
   CharacterSkillDescriptor,
@@ -9,9 +10,11 @@ import type { SqliteStore } from '@dsh-cyber/persistence'
 
 import type { CharacterSkillActionRepository } from '../skills/skill-action-repository.js'
 import type { CharacterSkillAdapterRegistry } from '../skills/skill-adapter.js'
+import { ServiceError } from './service-error.js'
 
 const TICK_MS = 30_000
 const DUPLICATE_WINDOW_MS = 60_000
+const APPROVAL_TTL_MS = 10 * 60_000
 
 export interface CharacterSkillRuntimeOptions {
   registry: CharacterSkillAdapterRegistry
@@ -90,8 +93,12 @@ export class CharacterSkillRuntime {
         authorization: proposal.authorization,
         parameters: proposal.parameters ?? {},
         ...(proposal.scheduledFor === undefined ? {} : { scheduledFor: proposal.scheduledFor }),
-        status: proposal.scheduledFor === undefined ? 'waiting-for-integration' : 'scheduled',
-        detail: proposal.scheduledFor === undefined
+        status: proposal.risk === 'external-side-effect'
+          ? 'waiting-for-approval'
+          : proposal.scheduledFor === undefined ? 'waiting-for-integration' : 'scheduled',
+        detail: proposal.risk === 'external-side-effect'
+          ? '外部动作已安全预留，等待用户审批'
+          : proposal.scheduledFor === undefined
           ? '已预留真实动作，正在通过受信任技能适配器执行'
           : `已创建本地计划，将在 ${localTimeLabel(proposal.scheduledFor)} 尝试执行`,
         createdAt: now.toISOString(),
@@ -103,6 +110,12 @@ export class CharacterSkillRuntime {
       const reservation = await this.#actions.reserve(candidate, DUPLICATE_WINDOW_MS)
       const action = reservation.action
       if (!reservation.created) {
+        actions.push(action)
+        continue
+      }
+
+      if (!this.#authorize(action, now)) {
+        await this.#actions.save(action)
         actions.push(action)
         continue
       }
@@ -128,10 +141,96 @@ export class CharacterSkillRuntime {
     return this.#actions.listByWorld(worldId)
   }
 
+  listApprovalRequests(worldId: string, status?: ApprovalRequest['status']): ApprovalRequest[] {
+    return this.#store.listWorldApprovalRequests(worldId, status)
+  }
+
+  listApprovalPolicies(worldId: string): ApprovalPolicy[] {
+    return this.#store.listWorldApprovalPolicies(worldId)
+  }
+
+  getApprovalPolicy(policyId: string): ApprovalPolicy | undefined {
+    return this.#store.getApprovalPolicy(policyId)
+  }
+
+  revokeApprovalPolicy(policyId: string): ApprovalPolicy {
+    return this.#store.revokeApprovalPolicy(policyId)
+  }
+
+  async decideApproval(
+    approvalId: string,
+    decision: 'approved' | 'rejected',
+    scope: ApprovalScope,
+    actorId: string,
+    now = new Date(),
+  ): Promise<{ request: ApprovalRequest; action: CharacterSkillAction }> {
+    const pending = this.#store.getApprovalRequest(approvalId)
+    if (pending === undefined) throw new Error(`Approval request not found: ${approvalId}`)
+    if (pending.subjectType !== 'skill-action' || this.#actions.get === undefined) {
+      throw new Error('Approval request is not backed by a skill action')
+    }
+    const action = await this.#actions.get(pending.subjectId)
+    if (action === undefined || action.worldId !== pending.worldId || action.approvalRequestId !== pending.id) {
+      throw new Error('Approval request and skill action do not match')
+    }
+    if (this.#store.getApprovalRequest(approvalId)?.status !== 'pending') {
+      throw new ServiceError('conflict', 'approval_already_decided', '审批请求已经处理')
+    }
+    const request = this.#store.decideApprovalRequest(approvalId, decision, scope, actorId, now.toISOString())
+    if (request.status !== 'approved') {
+      action.status = 'rejected'
+      action.detail = request.status === 'expired' ? '审批请求已过期，外部动作未执行' : '用户已拒绝此外部动作'
+      action.updatedAt = now.toISOString()
+      await this.#actions.save(action)
+      return { request, action }
+    }
+    if (request.scope !== 'once') {
+      this.#store.createApprovalPolicy({
+        workspaceId: request.workspaceId,
+        worldId: request.worldId,
+        ...(request.scope === 'character' ? { characterId: action.characterId } : {}),
+        subjectType: 'skill-action',
+        skillId: action.skillId,
+        action: action.action,
+        target: action.target,
+        risk: action.risk,
+        scope: request.scope,
+        sourceApprovalId: request.id,
+      })
+    }
+    if (action.scheduledFor !== undefined && Date.parse(action.scheduledFor) > now.getTime()) {
+      action.status = 'scheduled'
+      action.detail = `已获批准，将在 ${localTimeLabel(action.scheduledFor)} 尝试执行`
+    } else {
+      action.status = 'waiting-for-integration'
+      action.detail = '审批已通过，正在通过受信任技能适配器执行'
+      await this.#actions.save(action)
+      await this.#execute(action, now)
+    }
+    action.updatedAt = now.toISOString()
+    await this.#actions.save(action)
+    return { request, action }
+  }
+
   async tick(now = new Date()): Promise<void> {
     if (this.#ticking) return
     this.#ticking = true
     try {
+      this.#store.expirePendingApprovals(now.toISOString())
+      const waiting = this.#actions.listWaitingForApproval === undefined
+        ? (await Promise.all(this.#store.listWorkspaces().flatMap((workspace) =>
+          this.#store.listWorlds(workspace.id, true).map((world) => this.#actions.listByWorld(world.id)),
+        ))).flat().filter((action) => action.status === 'waiting-for-approval')
+        : await this.#actions.listWaitingForApproval()
+      for (const action of waiting) {
+        if (action.approvalRequestId === undefined) continue
+        const request = this.#store.getApprovalRequest(action.approvalRequestId)
+        if (request?.status !== 'expired') continue
+        action.status = 'rejected'
+        action.detail = '审批请求已过期，外部动作未执行'
+        action.updatedAt = now.toISOString()
+        await this.#actions.save(action)
+      }
       for (const action of await this.#actions.listDue(now)) {
         const employee = this.#store.getEmployee(action.characterId)
         const revision = employee === undefined ? undefined : this.#store.getEmployeeRevision(employee.id, employee.currentRevision)
@@ -157,6 +256,30 @@ export class CharacterSkillRuntime {
   }
 
   async #execute(action: CharacterSkillAction, now: Date): Promise<void> {
+    if (!this.#isGrantActive(action)) {
+      action.status = 'failed'
+      action.detail = '执行前角色已不可用或技能授权已撤销'
+      action.updatedAt = now.toISOString()
+      return
+    }
+    if (!this.#isApproved(action)) {
+      action.status = 'waiting-for-approval'
+      action.detail = '外部动作缺少有效审批，已阻止执行'
+      action.updatedAt = now.toISOString()
+      return
+    }
+    if (action.risk === 'external-side-effect' && action.status !== 'waiting-for-integration') {
+      action.status = 'waiting-for-integration'
+      action.detail = '审批有效，正在通过受信任技能适配器执行'
+      action.updatedAt = now.toISOString()
+      await this.#actions.save(action)
+    }
+    if (!this.#isApproved(action)) {
+      action.status = 'waiting-for-approval'
+      action.detail = '审批在执行前已失效，外部动作未执行'
+      action.updatedAt = now.toISOString()
+      return
+    }
     const adapter = this.#registry.adapterById(action.adapterId) ?? this.#registry.adapterForSkill(action.skillId)
     if (adapter === undefined) {
       action.status = 'failed'
@@ -176,6 +299,70 @@ export class CharacterSkillRuntime {
       action.detail = '技能适配器执行过程异常，外部动作结果未知；不得自动重试'
     }
     action.updatedAt = now.toISOString()
+  }
+
+  #authorize(action: CharacterSkillAction, now: Date): boolean {
+    if (action.risk !== 'external-side-effect') return true
+    const policy = this.#matchingPolicy(action)
+    if (policy !== undefined) {
+      action.authorization = 'preapproved-policy'
+      action.status = action.scheduledFor === undefined ? 'waiting-for-integration' : 'scheduled'
+      action.detail = action.scheduledFor === undefined
+        ? '精确授权策略已匹配，正在通过受信任技能适配器执行'
+        : `精确授权策略已匹配，将在 ${localTimeLabel(action.scheduledFor)} 尝试执行`
+      return true
+    }
+    const world = this.#store.getWorld(action.worldId)
+    if (world === undefined) return false
+    const request = this.#store.createApprovalRequest({
+      workspaceId: world.workspaceId,
+      worldId: action.worldId,
+      characterId: action.characterId,
+      subjectType: 'skill-action',
+      subjectId: action.id,
+      risk: action.risk,
+      summary: `${action.label} · ${action.target}`,
+      createdAt: now.toISOString(),
+      expiresAt: new Date(now.getTime() + APPROVAL_TTL_MS).toISOString(),
+    })
+    action.approvalRequestId = request.id
+    action.status = 'waiting-for-approval'
+    action.detail = '外部动作已安全预留，等待用户审批'
+    return false
+  }
+
+  #isApproved(action: CharacterSkillAction): boolean {
+    if (action.risk !== 'external-side-effect') return true
+    if (this.#matchingPolicy(action) !== undefined) return true
+    if (action.approvalRequestId === undefined) return false
+    const request = this.#store.getApprovalRequest(action.approvalRequestId)
+    return request?.status === 'approved'
+      && request.subjectType === 'skill-action'
+      && request.subjectId === action.id
+      && request.worldId === action.worldId
+      && request.characterId === action.characterId
+  }
+
+  #isGrantActive(action: CharacterSkillAction): boolean {
+    const employee = this.#store.getEmployee(action.characterId)
+    if (employee === undefined || employee.status === 'archived' || employee.worldId !== action.worldId) return false
+    const revision = this.#store.getEmployeeRevision(employee.id, employee.currentRevision)
+    return revision !== undefined && revision.skillGrants.includes(action.skillId)
+  }
+
+  #matchingPolicy(action: CharacterSkillAction): ApprovalPolicy | undefined {
+    const world = this.#store.getWorld(action.worldId)
+    if (world === undefined) return undefined
+    return this.#store.findApprovalPolicy({
+      workspaceId: world.workspaceId,
+      worldId: action.worldId,
+      characterId: action.characterId,
+      subjectType: 'skill-action',
+      skillId: action.skillId,
+      action: action.action,
+      target: action.target,
+      risk: action.risk,
+    })
   }
 }
 

--- a/packages/server/src/skills/local-skill-action-repository.ts
+++ b/packages/server/src/skills/local-skill-action-repository.ts
@@ -38,10 +38,12 @@ const RISKS = new Set<SkillActionRisk>(['read', 'write-local', 'external-side-ef
 const AUTHORIZATIONS = new Set<SkillActionAuthorization>(['explicit-user-request', 'preapproved-policy'])
 const STATUSES = new Set<SkillActionStatus>([
   'scheduled',
+  'waiting-for-approval',
   'executed',
   'waiting-for-integration',
   'failed',
   'outcome-unknown',
+  'rejected',
 ])
 
 /**
@@ -94,6 +96,13 @@ export class LocalSkillActionRepository implements CharacterSkillActionRepositor
     })
   }
 
+  get(actionId: string): Promise<CharacterSkillAction | undefined> {
+    return this.#serial(async () => {
+      const action = (await this.#readUnlocked()).actions.find((item) => item.id === actionId)
+      return action === undefined ? undefined : clone(action)
+    })
+  }
+
   listByWorld(worldId: string): Promise<CharacterSkillAction[]> {
     return this.#serial(async () => {
       const file = await this.#readUnlocked()
@@ -115,6 +124,12 @@ export class LocalSkillActionRepository implements CharacterSkillActionRepositor
         )
         .map(clone)
     })
+  }
+
+  listWaitingForApproval(): Promise<CharacterSkillAction[]> {
+    return this.#serial(async () => (await this.#readUnlocked()).actions
+      .filter((item) => item.status === 'waiting-for-approval')
+      .map(clone))
   }
 
   #serial<T>(operation: () => Promise<T>): Promise<T> {
@@ -170,6 +185,9 @@ function parseAction(value: unknown, path: string): CharacterSkillAction {
   if (!AUTHORIZATIONS.has(authorization)) throw new Error(`Invalid ${path}.authorization`)
   const parameters = jsonObject(input.parameters, `${path}.parameters`)
   const scheduledFor = optionalString(input.scheduledFor, `${path}.scheduledFor`)
+  const approvalRequestId = optionalString(input.approvalRequestId, `${path}.approvalRequestId`)
+  const workTurnId = optionalString(input.workTurnId, `${path}.workTurnId`)
+  const agentRunId = optionalString(input.agentRunId, `${path}.agentRunId`)
   const action: CharacterSkillAction = {
     id: string(input.id, `${path}.id`),
     worldId: string(input.worldId, `${path}.worldId`),
@@ -188,6 +206,9 @@ function parseAction(value: unknown, path: string): CharacterSkillAction {
     updatedAt: iso(input.updatedAt, `${path}.updatedAt`),
   }
   if (scheduledFor !== undefined) action.scheduledFor = iso(scheduledFor, `${path}.scheduledFor`)
+  if (approvalRequestId !== undefined) action.approvalRequestId = approvalRequestId
+  if (workTurnId !== undefined) action.workTurnId = workTurnId
+  if (agentRunId !== undefined) action.agentRunId = agentRunId
   return action
 }
 

--- a/packages/server/src/skills/skill-action-repository.ts
+++ b/packages/server/src/skills/skill-action-repository.ts
@@ -16,6 +16,8 @@ export interface CharacterSkillActionReservation {
 export interface CharacterSkillActionRepository {
   reserve(action: CharacterSkillAction, duplicateWindowMs: number): Promise<CharacterSkillActionReservation>
   save(action: CharacterSkillAction): Promise<void>
+  get?(actionId: string): Promise<CharacterSkillAction | undefined>
   listByWorld(worldId: string): Promise<CharacterSkillAction[]>
   listDue(now: Date): Promise<CharacterSkillAction[]>
+  listWaitingForApproval?(): Promise<CharacterSkillAction[]>
 }

--- a/packages/server/src/skills/sqlite-skill-action-repository.ts
+++ b/packages/server/src/skills/sqlite-skill-action-repository.ts
@@ -1,0 +1,36 @@
+import type { CharacterSkillAction } from '@dsh-cyber/contracts/skill-runtime'
+import type { SqliteStore } from '@dsh-cyber/persistence'
+
+import type { CharacterSkillActionRepository, CharacterSkillActionReservation } from './skill-action-repository.js'
+
+export class SqliteSkillActionRepository implements CharacterSkillActionRepository {
+  readonly #store: SqliteStore
+
+  constructor(store: SqliteStore) {
+    this.#store = store
+  }
+
+  async reserve(action: CharacterSkillAction, duplicateWindowMs: number): Promise<CharacterSkillActionReservation> {
+    return this.#store.reserveSkillAction(action, duplicateWindowMs)
+  }
+
+  async save(action: CharacterSkillAction): Promise<void> {
+    this.#store.saveSkillAction(action)
+  }
+
+  async get(actionId: string): Promise<CharacterSkillAction | undefined> {
+    return this.#store.getSkillAction(actionId)
+  }
+
+  async listByWorld(worldId: string): Promise<CharacterSkillAction[]> {
+    return this.#store.listWorldSkillActions(worldId)
+  }
+
+  async listDue(now: Date): Promise<CharacterSkillAction[]> {
+    return this.#store.listDueSkillActions(now)
+  }
+
+  async listWaitingForApproval(): Promise<CharacterSkillAction[]> {
+    return this.#store.listSkillActionsWaitingForApproval()
+  }
+}

--- a/packages/server/src/world-trace/skill-action-trace-adapter.ts
+++ b/packages/server/src/world-trace/skill-action-trace-adapter.ts
@@ -29,6 +29,6 @@ function skillStatus(status: SkillActionStatus): WorldTraceStatus {
   if (status === 'scheduled') return 'pending'
   if (status === 'executed') return 'success'
   if (status === 'waiting-for-integration') return 'waiting'
-  if (status === 'failed') return 'failed'
+  if (status === 'failed' || status === 'rejected') return 'failed'
   return 'waiting'
 }

--- a/packages/server/tests/character-skill-runtime.test.ts
+++ b/packages/server/tests/character-skill-runtime.test.ts
@@ -9,7 +9,7 @@ import type { CharacterSkillAction, CharacterSkillDescriptor } from '@dsh-cyber/
 import { SqliteStore } from '@dsh-cyber/persistence'
 
 import { CharacterSkillRuntime } from '../src/services/character-skill-runtime.js'
-import { LocalSkillActionRepository } from '../src/skills/local-skill-action-repository.js'
+import { SqliteSkillActionRepository } from '../src/skills/sqlite-skill-action-repository.js'
 import {
   CharacterSkillAdapterRegistry,
   type CharacterSkillAdapter,
@@ -138,6 +138,64 @@ describe('CharacterSkillRuntime', () => {
     })
     expect((await runtime.list(worldId))[0]).toMatchObject({ status: 'outcome-unknown' })
   })
+
+  it('never reaches an external adapter before an explicit approval is durable', async () => {
+    const { store, root, worldId, employeeId } = await setup(['test.external'])
+    const adapter = new ExternalAdapter()
+    const registry = new CharacterSkillAdapterRegistry()
+    registry.register(adapter)
+    const runtime = makeRuntime(store, root, registry)
+
+    const prepared = await runtime.prepare(worldId, employeeId, '请执行 external', new Date('2026-08-23T08:00:00.000Z'))
+
+    expect(prepared.actions[0]).toMatchObject({ status: 'waiting-for-approval', risk: 'external-side-effect' })
+    expect(adapter.executed).toBe(0)
+    const request = runtime.listApprovalRequests(worldId, 'pending')[0]!
+    expect(request).toMatchObject({ subjectType: 'skill-action', subjectId: prepared.actions[0]!.id, scope: 'once' })
+
+    const decided = await runtime.decideApproval(request.id, 'approved', 'once', 'owner', new Date('2026-08-23T08:01:00.000Z'))
+    expect(decided.action.status).toBe('executed')
+    expect(adapter.executed).toBe(1)
+  })
+
+  it('does not execute an external action when approval arrives after expiry', async () => {
+    const { store, root, worldId, employeeId } = await setup(['test.external'])
+    const adapter = new ExternalAdapter()
+    const registry = new CharacterSkillAdapterRegistry()
+    registry.register(adapter)
+    const runtime = makeRuntime(store, root, registry)
+
+    const prepared = await runtime.prepare(worldId, employeeId, '请执行 external', new Date('2026-08-23T08:00:00.000Z'))
+    const result = await runtime.decideApproval(
+      prepared.actions[0]!.approvalRequestId!, 'approved', 'once', 'owner', new Date('2026-08-23T08:11:00.000Z'),
+    )
+
+    expect(result.request.status).toBe('expired')
+    expect(result.action.status).toBe('rejected')
+    expect(adapter.executed).toBe(0)
+  })
+
+  it('reuses only an exact character policy and never broadens it to another target', async () => {
+    const { store, root, worldId, employeeId } = await setup(['test.external'])
+    const adapter = new ExternalAdapter()
+    const registry = new CharacterSkillAdapterRegistry()
+    registry.register(adapter)
+    const runtime = makeRuntime(store, root, registry)
+
+    const first = await runtime.prepare(worldId, employeeId, '请执行 external', new Date('2026-08-23T08:00:00.000Z'))
+    await runtime.decideApproval(first.actions[0]!.approvalRequestId!, 'approved', 'character', 'owner', new Date('2026-08-23T08:01:00.000Z'))
+    const sameTarget = await runtime.prepare(worldId, employeeId, '请执行 external', new Date('2026-08-23T08:02:01.000Z'))
+    const otherTarget = await runtime.prepare(worldId, employeeId, '请执行 external other', new Date('2026-08-23T08:04:02.000Z'))
+
+    expect(sameTarget.actions[0]).toMatchObject({ status: 'executed', authorization: 'preapproved-policy' })
+    expect(otherTarget.actions[0]).toMatchObject({ status: 'waiting-for-approval', target: 'other-system' })
+    expect(adapter.executed).toBe(2)
+    const policy = runtime.listApprovalPolicies(worldId)[0]!
+    runtime.revokeApprovalPolicy(policy.id)
+    const afterRevocation = await runtime.prepare(worldId, employeeId, '请执行 external', new Date('2026-08-23T08:06:03.000Z'))
+    expect(afterRevocation.actions[0]?.status).toBe('waiting-for-approval')
+    expect(adapter.executed).toBe(2)
+  })
 })
 
 class TestAdapter implements CharacterSkillAdapter {
@@ -173,6 +231,30 @@ class ThrowingAdapter implements CharacterSkillAdapter {
   }
 }
 
+class ExternalAdapter implements CharacterSkillAdapter {
+  readonly id = 'test-external-adapter'
+  readonly descriptors: readonly CharacterSkillDescriptor[] = [{
+    id: 'test.external', displayName: '外部测试技能', summary: '验证审批硬门。',
+    adapterId: this.id, risks: ['external-side-effect'], supportsScheduling: false,
+  }]
+  executed = 0
+
+  propose(context: CharacterSkillMatchContext) {
+    if (!context.prompt.includes('external')) return []
+    return [{
+      skillId: 'test.external', adapterId: this.id, action: 'external.run',
+      target: context.prompt.includes('other') ? 'other-system' : 'primary-system',
+      label: '执行外部测试动作', risk: 'external-side-effect' as const,
+      authorization: 'explicit-user-request' as const, parameters: {},
+    }]
+  }
+
+  async execute() {
+    this.executed += 1
+    return { status: 'executed' as const, detail: '外部测试动作已执行' }
+  }
+}
+
 function descriptor(adapterId: string): readonly CharacterSkillDescriptor[] {
   return [{
     id: 'test.echo',
@@ -205,7 +287,7 @@ function makeRuntime(
 ): CharacterSkillRuntime {
   return new CharacterSkillRuntime(store, {
     registry,
-    actions: new LocalSkillActionRepository(join(root, 'skills', 'actions.json')),
+    actions: new SqliteSkillActionRepository(store),
   })
 }
 
@@ -225,7 +307,7 @@ async function setup(skillGrants: string[]) {
     role: '测试员',
     summary: '用于 Skill Runtime 测试。',
     persona: '执行受控测试技能。',
-    requestedSkills: ['test.echo'],
+    requestedSkills: ['test.echo', 'test.external'],
     requestedCapabilities: [],
     createdAt: '2026-08-23T00:00:00.000Z',
   }


### PR DESCRIPTION
## Summary

- persist Skill Action, Approval Request, and exact reusable Approval Policy records in SQLite schema v16
- prevent external-side-effect adapters from executing before durable approval or an exact active policy
- recheck character availability and Skill Grant at execution time, expire/reject pending actions, and mark interrupted dispatches outcome-unknown without retry
- migrate the legacy local action ledger idempotently, expose local approval APIs, and document the current public boundary

## Verification

- `pnpm typecheck`
- `pnpm test`
- 76 test files passed, 325 tests passed
- production web build passed
