### PR TITLE
Trace-Intelligence-V1

### DIFF
--- a/docs/architecture/world-trace-center-v1.md
+++ b/docs/architecture/world-trace-center-v1.md
@@ -1,149 +1,90 @@
-# World Trace Center V1
+# 世界轨迹中心
 
-## Status
+## 当前能力
 
-World Trace Center V1 is the execution-observability boundary for a world. It separates conversational results from operational evidence without introducing a second source of truth.
+世界轨迹中心是每个世界的执行观测入口。聊天只展示用户消息、最终回复、附件和明确的产品通知；轨迹展示角色如何形成可公开的判断摘要、调度了哪些工具、执行是否成功、耗时多少，以及模型实际返回的 Token 用量。
 
-The product rule is:
+轨迹不保存第二套业务事实。页面内容由 SQLite 中的 `AgentRun`、`WorkMessage`、`ModelInteractionLog`、`DomainEvent` 和 `CharacterSkillAction` 投影得到，刷新和重启后都能从权威数据恢复。
 
-> Chat surfaces final conversational results. Execution details belong to Trace.
+## 角色运行轨迹
 
-## Information architecture
+每次 `AgentRun` 对应一条主轨迹。一次运行内的开始、判断摘要、工具调用、工具结果和结束状态会合并到同一个稳定 ID，不再为每个生命周期事件生成独立卡片。
 
-The workbench has three distinct concerns:
+主轨迹可以包含：
 
-```text
-Left                Center                Right Dock
-Conversations       Chat                  World
-                                           Trace
-                                           Dossier
-```
+- 角色、会话和工作回合归属；
+- 可公开的中文判断摘要；
+- 结构化工具步骤及成功、失败、执行中状态；
+- 整轮耗时、模型 ID 和模型服务；
+- Harness 实际返回的输入、输出和合计 Token；
+- 失败时可理解的中文说明。
 
-Chat contains user messages, final assistant messages, attachments and explicit product notices. It does not render reasoning summaries, token deltas, tool calls, tool results or live turn diagnostics.
+普通用户消息、最终回复、角色日记、成长里程碑、关系变化、设置更新和重复的任务生命周期不会作为独立轨迹出现。它们分别属于聊天、角色档案或系统设置。
 
-Trace contains meaningful execution facts. It does not contain render ticks, heartbeat messages, snapshot refreshes, polling records or coordinate-by-coordinate movement.
-
-## Contract
-
-`WorldTraceEntry` is provider-, renderer- and UI-neutral. Its stable fields are:
-
-```text
-id
-worldId
-category: agent | tool | skill | task | collaboration | world | schedule | system
-status: pending | running | waiting | success | failed | cancelled | info
-summary / optional safe detail
-optional actor/session/task/skill/schedule/run references
-sourceKind / sourceId / optional sourceSequence
-createdAt / updatedAt
-```
-
-The `schedule` category and `scheduleId` / `runId` references are reserved now so a future scheduler can register an adapter without changing the core trace contract.
-
-## Read-model flow
+## 数据流
 
 ```mermaid
 flowchart LR
     H[Harness Runtime] --> O[ConversationOrchestrator]
-    O -->|persist first| M[(WorkMessage)]
-    O -->|persist first| D[(DomainEvent)]
-    S[CharacterSkillRuntime] --> A[(CharacterSkillAction)]
-    M --> C[ConversationTraceAdapter]
-    D --> E[DomainEventTraceAdapter]
-    A --> K[SkillActionTraceAdapter]
-    O --> R[RuntimeEventTraceAdapter]
-    C --> G[WorldTraceAdapterRegistry]
-    E --> G
-    K --> G
-    R --> G
+    O --> R[(AgentRun)]
+    O --> M[(WorkMessage)]
+    H --> U[真实 Token 用量]
+    U --> L[(ModelInteractionLog)]
+    R --> A[AgentRunTraceAdapter]
+    M --> A
+    L --> A
+    D[(DomainEvent)] --> B[DomainEventTraceAdapter]
+    S[(CharacterSkillAction)] --> C[SkillActionTraceAdapter]
+    A --> G[WorldTraceAdapterRegistry]
+    B --> G
+    C --> G
     G --> Z[TraceSanitizer]
-    Z --> API[History API]
-    Z --> LIVE[Existing world live transport]
-    API --> UI[useWorldTrace]
+    Z --> API[历史查询]
+    Z --> LIVE[世界 Live SSE]
+    API --> UI[轨迹面板]
     LIVE --> UI
 ```
 
-The Orchestrator persists the corresponding WorkMessage or DomainEvent before notifying subscribers. Therefore a live trace notification never becomes the canonical fact. Refresh and restart recovery always rebuild from durable sources.
+实时运行和持久化历史使用相同的 `AgentRun` 稳定 ID。实时事件先聚合成运行卡片，持久化完成后由权威投影接管，不会产生重复条目。
 
-## Adapter registry
-
-Core Trace knows how to register adapters, normalize entries, sanitize, merge by stable ID, sort, filter and paginate. It does not contain provider-specific branches.
-
-V1 registers:
-
-- `DomainEventTraceAdapter` for semantic domain lifecycle and world events;
-- `RuntimeEventTraceAdapter` for current Harness runtime events;
-- `SkillActionTraceAdapter` for durable Skill actions;
-- `ConversationTraceAdapter` for message-backed user requests, provider reasoning summaries and final responses;
-- `ScheduleTraceAdapter` as a provider-neutral future scheduler boundary.
-
-Future GitHub, browser, Feishu or scheduler sources must enter through a new adapter. They must not add `if (provider === ...)` branches to `WorldTraceService`.
-
-## Stable identity and lifecycle updates
-
-Started/completed pairs use one logical trace ID:
-
-- every orchestrated turn receives a random `traceTurnId`; turn start/completion/failure use that ID;
-- a tool action is keyed by `traceTurnId` and call ID;
-- a task is keyed by the same `traceTurnId` as its runtime turn;
-- every submitted collaboration receives a `meetingRunId`; meeting start/finish use that ID;
-- a Skill action is keyed by its durable action ID.
-
-The later fact replaces the visual status while preserving the original `createdAt`. Reusing a Harness agent session across multiple user turns does not collapse their history because `traceTurnId` is unique per orchestration. Live and historical adapters derive the same IDs from persisted runtime metadata, so reconnect recovery updates rather than duplicates entries. At the end of each conversation request, new durable conversation, domain and Skill projections are flushed to the existing world stream so `task.completed`, `task.blocked` and `meeting.finished` never wait for a manual refresh.
-
-## History API and recovery
+## 查询
 
 ```http
 GET /api/worlds/:worldId/trace
-  ?after=<opaque-trace-cursor>
+  ?after=<opaque-cursor>
   &limit=1..200
   &category=<category>
   &status=<status>
-  &actorId=<actor-id>
+  &actorId=<employee-id>
+  &date=YYYY-MM-DD
+  &search=<keyword>
 ```
 
-Response:
+结果按最新时间倒序返回。日期按运行应用的本地日历解释，关键词可匹配轨迹摘要、判断摘要、角色名、工具名称、模型和服务。游标用于继续读取更早的轨迹。
 
-```json
-{
-  "items": [],
-  "nextCursor": "optional opaque cursor"
-}
-```
+前端默认读取最新 50 条，支持加载更早记录。筛选在服务端执行，实时条目也使用相同条件。面板按角色汇总当前结果中的实际 Token，用量缺失时明确显示模型尚未返回，而不是进行估算。
 
-The trace cursor is independent from World Runtime snapshot sequence and SSE `Last-Event-ID`. The UI re-reads history whenever the existing `/api/worlds/:worldId/live` transport reconnects, then merges by stable ID. No third SSE endpoint is introduced.
+## 安全边界
 
-## Security boundary
+所有历史和实时条目都经过 `TraceSanitizer`。轨迹禁止展示：
 
-All entries pass through `TraceSanitizer`, including entries emitted live. Adapters expose semantic summaries instead of raw payloads.
+- 隐藏思维链；
+- 完整 Prompt 和用户未要求公开的内部指令；
+- 原始工具参数、原始工具结果和文件内容；
+- API key、Authorization、Cookie、密码、Token 和其他凭据；
+- 未经验证的模型自然语言声明。
 
-Never expose:
+判断摘要必须是提供方明确输出的可公开摘要。增量推理片段不会进入历史和界面。工具只展示可理解的调度名称与结果状态。
 
-- API keys, authorization headers, cookies, passwords, tokens or credentials;
-- full user/runtime prompts;
-- raw tool inputs or raw tool results;
-- file contents or arbitrary provider metadata;
-- hidden chain-of-thought.
+## 验证范围
 
-`assistant.reasoning` is projected only when the provider emitted an actual summary. Token-level `reasoning.delta` and `text.delta` events are excluded from Trace history and UI.
+自动化验证覆盖：
 
-## UI behavior
-
-Trace UI lives under `components/world-trace/` and is not embedded in `App.tsx` or `ArtifactDock` logic. The panel provides category, status and actor filters, stable lifecycle updates, safe details and a refresh action.
-
-The timeline auto-scrolls only while the user is already near the bottom. Otherwise it preserves reading position and shows a new-entry indicator. Large timelines use `content-visibility` to avoid rendering every off-screen card eagerly.
-
-## Verification
-
-V1 tests cover:
-
-- registry and future scheduler fixture;
-- normalizing and lifecycle deduplication;
-- centralized credential sanitization;
-- stable live/history identity;
-- stable updates within one turn and distinct identities across repeated turns;
-- category/status/actor filtering and cursor pagination;
-- live reconnect and restart recovery;
-- Chat final-result projection;
-- exact `世界 | 轨迹 | 档案` Dock structure;
-- live visual-entry update instead of duplicate append.
+- 一个角色运行只生成一个稳定轨迹 ID；
+- 多次运行不会因复用 Harness Session 而合并；
+- 判断摘要与工具步骤从持久化事实恢复；
+- 实时、刷新和重启使用同一轨迹身份；
+- 角色、日期、关键词、状态、内容类型和游标分页；
+- 实际 Token 与 `AgentRun`、角色和世界正确关联；
+- Prompt、凭据、原始工具输入和结果不会泄露；
+- 聊天界面不展示推理与工具明细。

--- a/docs/community/implementation-status.md
+++ b/docs/community/implementation-status.md
@@ -21,8 +21,9 @@
 | 插件 | canonical `prompt-transform` 进入真实 conversation runtime prompt；legacy `commands` 明确转换；staged 校验；原始用户消息持久化不被改写 | 仅声明式 JSON；支持 `/command`、`always`、prepend/append/replace、priority 与资源上限；强制无外发 | 可执行代码、skill/tool/event/widget、网络代理与外发审计 |
 | 会话记忆 | 单个 WorkSession 的用户可见聊天历史由本地 SQLite 恢复：跨进程重启、Harness Runtime 重建、权限模式切换和 persisted-log 碰撞轮换都能继续对话；私聊/群聊/世界之间严格隔离；群聊历史保留真实发言人；reasoning、tool-call、tool-result、system、临时气泡与凭据不进入历史 | 预算为「24 条 + 16000 字符」的确定性截断，不使用 tokenizer；超长单条消息截断并标注；每个角色按自身 watermark 增量补齐——新 Session 重播全部，存活 Session 只补它未见过的部分（私聊恒为空，群聊补上一轮晚于自己发言的角色）；同一员工的回合串行、不同员工并行 | Episodic/Semantic/Procedural memory 分类、向量检索、Embedding、自动摘要与记忆整理、跨会话回忆 |
 | 会话执行 | `WorkSession → WorkTurn → AgentRun` 持久模型；私聊一轮一次运行，群聊和角色协作按真实调用顺序记录多次运行；本轮消息关联回合，角色输出、领域事件与 SSE 关联具体运行；服务重启确定性终止遗留执行；提供会话回合和回合详情读取 API | 当前只记录生命周期、错误码和 Runtime Session ID，不持久化原始 prompt、工具输入或工具结果 | 自动重试、通用事件 items 表、远程执行同步 |
+| 世界轨迹 | 每个 AgentRun 投影为一条稳定主轨迹；中文判断摘要、结构化工具调度、状态、耗时、模型和真实 Token 归入同一次运行；按角色汇总 Token；支持角色、日期、关键词、内容和状态筛选以及游标分页；实时与重启恢复使用同一身份；全链路脱敏 | Token 只在 Harness 明确返回时展示，不进行估算；旧运行没有 Token 时保持为空 | 跨设备轨迹同步、用户配置的轨迹保留策略 |
 | 动作审批 | 外部副作用先持久化 Skill Action 与 Approval Request；未批准、已拒绝、已过期或授权已撤销时不会进入受信任 Adapter；支持单次批准、角色级和世界级精确策略，以及策略撤销；服务中断时执行中的外部动作转为结果未知并禁止自动重试 | 当前审批通过本地 HTTP API 提供，复用策略严格绑定 Skill、Action、Target、Risk 与作用域 | 审批中心 UI、工具调用与文件写入审批、远程审批同步 |
-| 模型交互日志 | turn/discovery 双源采集、SQLite 持久化（v11 STRICT 表 + 三索引）、分页/筛选/详情/清空 API、设置面板「日志记录」界面、错误信息密钥清洗（`sk-…`/`Bearer …`/键值对 → `[已隐藏]`） | token 用量字段预留但当前恒为空（DSH worker 未透出单次请求用量）；消息数为近似统计；无自动保留策略 | worker 进程内逐请求采集与 token 透出、日志自动清理/条数上限 |
+| 模型交互日志 | turn/discovery 双源采集、SQLite 持久化、分页/筛选/详情/清空 API、设置面板日志界面、错误信息密钥清洗；v17 将 turn 日志绑定到 WorkTurn 与 AgentRun，并保存 Harness 返回的真实 Token | 一条 turn 日志表示整轮角色运行，不拆分 worker 内部的多次模型请求；消息数为近似统计；无自动保留策略 | worker 内逐请求明细、日志自动清理和条数上限 |
 | CI | Node 22.19、pnpm 11.7、frozen lockfile、typecheck、test、Chromium、E2E | 仓库工作流名为 `required`；GitHub 分支保护需在仓库设置中另行确认 | 自动发布与包签名流水线 |
 
 ## 关键证据
@@ -38,6 +39,7 @@
 - prompt transform：`packages/server/src/prompt-transform-parser.ts`、`packages/server/src/routes/conversation-routes.ts`
 - 会话记忆与执行：`packages/orchestration/src/conversation-history.ts`、`packages/orchestration/src/conversation-orchestrator.ts`、`packages/persistence/src/migrations.ts`、`packages/persistence/src/sqlite-store.ts`、`packages/harness-adapter/src/history-prompt.ts`、`packages/harness-adapter/src/adapter.ts`、`packages/orchestration/tests/conversation-history.test.ts`、`packages/orchestration/tests/conversation-memory.test.ts`、`packages/server/tests/conversation-memory-restart.test.ts`
 - 动作审批：`packages/server/src/services/character-skill-runtime.ts`、`packages/server/src/skills/sqlite-skill-action-repository.ts`、`packages/persistence/src/migrations.ts`、`packages/persistence/src/sqlite-store.ts`、`packages/server/tests/character-skill-runtime.test.ts`、[Approval Gate V1](../architecture/approval-gate-v1.md)
+- 世界轨迹：`packages/server/src/services/world-trace-service.ts`、`packages/server/src/world-trace/agent-run-trace-adapter.ts`、`packages/web/src/components/world-trace/`、[世界轨迹中心](../architecture/world-trace-center-v1.md)
 - 模型交互日志：`packages/server/src/services/model-interaction-service.ts`、`packages/server/src/routes/model-interaction-routes.ts`、`packages/persistence/src/migrations.ts`（v11）、[模块说明与观测边界](model-interaction-logs.md)
 - CI：`.github/workflows/ci.yml`
 

--- a/docs/community/model-interaction-logs.md
+++ b/docs/community/model-interaction-logs.md
@@ -8,7 +8,7 @@
 
 | 采集点 | source | 观测内容 | 边界 |
 | --- | --- | --- | --- |
-| 对话回合（server 用 `TurnInteractionLoggingRuntime` 装饰器包住 `AgentRuntimePort`，见 `packages/server/src/server.ts`） | `turn` | 服务端发起的**整轮** turn 交互：开始时间、模型 ID、provider（来自模型路由解析；未配置路由时为 `dsh-default` / `默认 DSH 模型`）、成功/失败、耗时、工具调用次数、最终响应字符摘要 | 不是单次模型请求；worker 内部发生了几次请求、每次多少 token，服务端不可见 |
+| 对话回合 | `turn` | 整轮角色运行的开始时间、模型 ID、模型服务、成功或失败、耗时、工具调用次数、最终响应字符数，以及 Harness 返回的真实 Token | 一条记录对应一个 AgentRun，不拆分 worker 内部的多次模型请求 |
 | `/models` 模型发现（`model-catalog-service.discover` 调用处，见 `packages/server/src/routes/model-routes.ts`） | `discovery` | 真实 HTTP 往返：成功/失败、状态码（`ServiceError.code`）、耗时 | GET 请求无 prompt，请求摘要恒为 0 |
 
 运行时升级金丝雀走独立 runtime（无 workspace 归属），不记录。
@@ -17,7 +17,7 @@
 
 每条日志字段见 contracts 的 `ModelInteractionLog`（`packages/contracts/src/index.ts`）。以下口径在使用日志做分析时必须先明确，**不能混算**：
 
-1. **token 用量字段当前恒为空**：需求约定「若接口返回才填」。但 DSH worker 内部的单次请求 token 用量没有透出到服务端，因此 `tokensPrompt / tokensCompletion / tokensTotal` 目前**永远填不上**（字段已预留，落库为 NULL，前端显示 `—`）。拿到真实 token 数需要到 harness-adapter 的 model-router / adapter.ts（worker 进程内）采集并透出，属于后继迭代项——**不是本模块坏了**。
+1. **Token 只记录真实返回值**：Harness 通知含用量时写入 `tokensPrompt / tokensCompletion / tokensTotal`，并归属到对应的世界、角色、WorkTurn 和 AgentRun。没有返回用量的模型保持为空，系统不会按字符数估算。
 2. **`durationMs` 是双语义**：`turn` 级是**整轮延迟**（从服务端发起 turn 到 worker 返回，含全部工具调用）；`discovery` 级才是**单次 HTTP 往返**。前端用 source 徽标（对话回合/模型发现）区分，做报表/性能分析时两类必须分开。
 3. **`promptMessageCount` 是近似值**：turn 级按「1 条用户 prompt + 每轮工具回填 1 条」估算（即 `1 + toolCallCount`），不是真实发送给模型的消息条数；`responseCharCount` 只含**最终响应**字符数（`result.finalResponse.length`），不含中间工具输出。`promptCharCount` 为 prompt 实际字符数（只取 `.length`，不存原文）。
 
@@ -33,9 +33,9 @@
 
 ## 持久化
 
-SQLite 新表 `model_interaction_logs`（走项目现有 migration 机制，v11，见 `packages/persistence/src/migrations.ts`）：
+SQLite 表 `model_interaction_logs` 通过版本化迁移维护。v11 创建日志表，v17 增加 WorkTurn 和 AgentRun 归属：
 
-- STRICT 表，主键 `id`；`workspace_id` 必填且级联删除，`world_id / session_id / employee_id` 可选（级联删除）。
+- STRICT 表，主键 `id`；`workspace_id` 必填，`world_id / session_id / employee_id / work_turn_id / agent_run_id` 可选并接受严格归属校验。
 - 约束：`source` ∈ turn/discovery，`status` ∈ success/failed，计数与耗时字段非负。
 - 索引：`(workspace_id, created_at DESC, id)`、`(workspace_id, status, created_at DESC, id)`、`(workspace_id, model_id, created_at DESC, id)`——覆盖列表默认排序与状态/模型筛选。
 - 存储层方法（`packages/persistence/src/sqlite-store.ts`）：`recordModelInteraction`（含归属与字段校验）、`listModelInteractions`（分页+筛选+去重 modelIds）、`getModelInteraction`、`clearModelInteractions`。
@@ -62,12 +62,11 @@ SQLite 新表 `model_interaction_logs`（走项目现有 migration 机制，v11�
 
 ## 测试与验证
 
-- `pnpm verify`：20 个测试文件 / 119 个测试全部通过（typecheck + build + vitest），含存储层单测（记录/列表/筛选/分页/清空/持久化/校验）与 API 集成测试（turn 成功/失败、discovery 失败、筛选、详情、清空）。
-- `pnpm test:e2e`：7 个 e2e 全部通过；日志面板用例覆盖「发消息产生真实日志 → API total 断言 → 面板列表 → 详情展开（且详情不含 prompt 明文）→ 状态筛选 → 清空 → 空态」，并产出三视口截图与 console 记录供视觉审批。
-- 视觉审批（合并门禁）：截图 `artifacts/ui-world-conversations/model-logs-{1440x900,1920x1080,3840x2160}.png` + `model-logs-console.log`，需视觉岗按 AGENTS.md 护栏逐项查验。
+- `pnpm typecheck` 验证合同、迁移、服务和界面类型。
+- `pnpm test` 验证生产构建与完整单元、服务集成测试。
+- World Trace 集成测试验证 Token 与 AgentRun、角色和世界归属，并验证 Prompt 与凭据不会进入轨迹。
 
 ## 已知限制与后继迭代（不阻塞当前合入）
 
-1. **真实 token 用量**：需在 harness-adapter（worker 进程内）采集单次请求 token 并透出到服务端，`tokens_*` 字段才有值。
-2. **保留策略**：日志表目前只支持手动清空，无自动清理/条数上限，长跑后表会无限增长（现有索引 + 分页钳制下短期无性能风险），建议后续加自动清理策略。
-3. **错误清洗单测**：`sanitizeErrorMessage` 的密钥替换行为暂无直接单测（现有断言覆盖「不含 prompt 明文」与错误码落库），建议补一条喂含 `sk-…` / `Bearer …` 错误消息验证 `[已隐藏]` 的单测，作为隐私红线的直接证据。
+1. **逐请求明细**：当前 Token 是 AgentRun 整轮用量，worker 内部每次模型请求尚未单独记录。
+2. **保留策略**：日志表目前支持手动清空，没有自动清理和条数上限。

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -26,6 +26,11 @@
 - [x] Controlled Harness update / rollback
 - [x] SQLite-backed conversation continuity across runtime restart
 - [x] Approval Gate V1 for trusted external Skill actions
+- [x] Trace Intelligence V1 with per-run reasoning summaries, tool orchestration, Token attribution and role/date/search filters
+- [ ] World Package Instance V1
+- [ ] Integration Registry and Firecrawl V1
+- [ ] MCP Skill Adapter V1
+- [ ] Extension Host and JSON-RPC Gateway
 - [ ] Finish Creative Workshop project lifecycle
 - [ ] Add Creative Workshop smoke E2E
 - [ ] Define Creative Platform V1 local-data compatibility baseline

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,4 +1,4 @@
-export const CYBER_SCHEMA_VERSION = 16 as const
+export const CYBER_SCHEMA_VERSION = 17 as const
 
 export type IsoTimestamp = string
 export type JsonPrimitive = boolean | number | string | null
@@ -504,6 +504,12 @@ export type ModelApiKind = 'openai-completions' | 'openai-responses' | 'anthropi
 export type ModelInteractionLogStatus = 'success' | 'failed'
 export type ModelInteractionLogSource = 'turn' | 'discovery'
 
+export interface ModelTokenUsage {
+  prompt: number
+  completion: number
+  total: number
+}
+
 /**
  * 一条模型交互日志。隐私红线：绝不保存 API 密钥、prompt 明文或响应明文，
  * 只保存请求摘要统计（消息数 / 字符数）与可读的错误信息（不含密钥）。
@@ -514,6 +520,8 @@ export interface ModelInteractionLog {
   worldId?: string
   sessionId?: string
   employeeId?: string
+  workTurnId?: string
+  agentRunId?: string
   /** 采集来源：turn=对话回合（服务端发起的整轮交互），discovery=/models 模型发现 */
   source: ModelInteractionLogSource
   modelId: string
@@ -543,6 +551,8 @@ export interface RecordModelInteractionInput {
   worldId?: string
   sessionId?: string
   employeeId?: string
+  workTurnId?: string
+  agentRunId?: string
   source: ModelInteractionLogSource
   modelId: string
   provider: string
@@ -842,6 +852,8 @@ export interface AgentTurnRequest {
    * runtime session and is not a conversation key.
    */
   conversationId: string
+  workTurnId?: string
+  agentRunId?: string
   /**
    * Prior user-visible messages of `conversationId`, oldest first, excluding
    * the prompt of the current turn.
@@ -869,6 +881,7 @@ export interface AgentTurnResult {
   agentSessionId: string
   finalResponse: string
   eventCount: number
+  tokenUsage?: ModelTokenUsage
 }
 
 export interface AgentRuntimePort {

--- a/packages/contracts/src/world-trace.ts
+++ b/packages/contracts/src/world-trace.ts
@@ -1,4 +1,4 @@
-import type { IsoTimestamp } from './index.js'
+import type { IsoTimestamp, ModelTokenUsage } from './index.js'
 
 export const WORLD_TRACE_CATEGORIES = [
   'agent',
@@ -31,6 +31,16 @@ export type WorldTraceSourceKind =
   | 'skill-action'
   | 'conversation'
   | 'scheduled-run'
+  | 'agent-run'
+
+export interface WorldTraceToolStep {
+  callId: string
+  name?: string
+  label: string
+  status: 'running' | 'success' | 'failed'
+  createdAt?: IsoTimestamp
+  completedAt?: IsoTimestamp
+}
 
 /**
  * Provider- and renderer-neutral read model for meaningful activity in a world.
@@ -51,6 +61,13 @@ export interface WorldTraceEntry {
   skillId?: string
   scheduleId?: string
   runId?: string
+  workTurnId?: string
+  reasoningSummary?: string
+  tools?: WorldTraceToolStep[]
+  tokenUsage?: ModelTokenUsage
+  durationMs?: number
+  modelId?: string
+  provider?: string
   sourceKind: WorldTraceSourceKind
   sourceId: string
   sourceSequence?: number
@@ -64,6 +81,8 @@ export interface WorldTraceQuery {
   category?: WorldTraceCategory
   status?: WorldTraceStatus
   actorId?: string
+  date?: string
+  search?: string
 }
 
 export interface WorldTracePage {

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -12,6 +12,7 @@ import type {
   EmployeeInstance,
   EmployeeRevision,
   JsonObject,
+  ModelTokenUsage,
 } from '@dsh-cyber/contracts'
 
 import { formatRecoveredHistoryPrompt, unseenHistory } from './history-prompt.js'
@@ -117,10 +118,12 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       }
     }
     const result = await this.runEmployeeTurn(employeeRequest)
+    const tokenUsage = extractHarnessTokenUsage(result.notifications)
     return {
       agentSessionId: result.agentSessionId,
       finalResponse: result.finalResponse,
       eventCount: result.notifications.length,
+      ...(tokenUsage === undefined ? {} : { tokenUsage }),
     }
   }
 
@@ -398,6 +401,12 @@ export function normalizeHarnessNotification(
       const metadata: JsonObject = { reason: reasonKind }
       const failure = record(reason?.error)
       appendFailureDiagnostics(metadata, failure, reason, data)
+      const usage = extractTokenUsageFromValue(data)
+      if (usage !== undefined) {
+        metadata.tokensPrompt = usage.prompt
+        metadata.tokensCompletion = usage.completion
+        metadata.tokensTotal = usage.total
+      }
       return [
         make(reasonKind === 'completed' ? 'turn.completed' : 'turn.failed', {
           failed: reasonKind !== 'completed',
@@ -408,6 +417,52 @@ export function normalizeHarnessNotification(
     default:
       return []
   }
+}
+
+export function extractHarnessTokenUsage(
+  notifications: readonly HarnessNotification[],
+): ModelTokenUsage | undefined {
+  let latest: ModelTokenUsage | undefined
+  for (const notification of notifications) {
+    const usage = extractTokenUsageFromValue(notification)
+    if (usage !== undefined) latest = usage
+  }
+  return latest
+}
+
+function extractTokenUsageFromValue(root: unknown): ModelTokenUsage | undefined {
+  const seen = new Set<object>()
+  let latest: ModelTokenUsage | undefined
+  const visit = (value: unknown, depth: number): void => {
+    if (depth > 6 || value === null || typeof value !== 'object' || seen.has(value)) return
+    seen.add(value)
+    if (Array.isArray(value)) {
+      for (const item of value) visit(item, depth + 1)
+      return
+    }
+    const item = value as Record<string, unknown>
+    const prompt = tokenCount(item, ['prompt_tokens', 'input_tokens', 'promptTokens', 'inputTokens'])
+    const completion = tokenCount(item, ['completion_tokens', 'output_tokens', 'completionTokens', 'outputTokens'])
+    const declaredTotal = tokenCount(item, ['total_tokens', 'totalTokens'])
+    if (prompt !== undefined && completion !== undefined) {
+      latest = {
+        prompt,
+        completion,
+        total: declaredTotal ?? prompt + completion,
+      }
+    }
+    for (const nested of Object.values(item)) visit(nested, depth + 1)
+  }
+  visit(root, 0)
+  return latest
+}
+
+function tokenCount(recordValue: Record<string, unknown>, keys: readonly string[]): number | undefined {
+  for (const key of keys) {
+    const value = recordValue[key]
+    if (typeof value === 'number' && Number.isInteger(value) && value >= 0) return value
+  }
+  return undefined
 }
 
 function requiredConversationId(value: string | undefined): string {
@@ -610,13 +665,13 @@ export function workerEnvironment(
 
 function employeeSystemPrompt(employee: EmployeeInstance, revision: EmployeeRevision): string {
   return [
-    `You are the persistent DSH Cyber character "${employee.displayName}".`,
-    'Your latest user-defined Persona and identity contract below is authoritative for who you are now:',
+    `你是 DSH Cyber 中持续存在的角色「${employee.displayName}」。`,
+    '以下最新的用户自定义 Persona 和身份约定，是你当前身份的唯一权威来源：',
     revision.persona,
-    'The blueprint or job title used when this character was first created is provenance metadata only. Do not restore or infer an older template identity unless the current Persona explicitly keeps it.',
-    'Stay consistent with your current identity, maintain your own persistent conversation, and never impersonate another character.',
-    'When another character\'s statement is included in a collaboration prompt, respond to its substance and identify agreements or disagreements.',
-    'If web search is unavailable, explain the cause in plain Chinese and direct the user to 设置 → 模型 → 编辑当前模型 → 启用联网搜索. Never invent results or tell the user to configure a hidden "Web Models" page.',
-    'Give concise, evidence-based answers from your current identity, memory and granted capabilities.',
+    '角色最初创建时使用的模板或职位只是来源信息。除非当前 Persona 明确保留，否则不得恢复或推断旧模板身份。',
+    '始终保持当前身份一致，维护属于自己的持续会话，不得冒充其他角色。',
+    '协作提示中出现其他角色的发言时，请回应其实际内容，并清楚说明认同点或分歧点。',
+    '联网搜索不可用时，用简明中文说明原因，并引导用户前往“设置 → 模型 → 编辑当前模型 → 启用联网搜索”。不得编造搜索结果，也不得引导用户寻找不存在的隐藏页面。',
+    '基于当前身份、记忆和已授权能力，使用简洁中文给出有证据的回答。需要调用工具时，向用户提供可公开、安全、简短的中文推理摘要，说明目标、判断依据和工具调度结果；不得暴露隐藏思维链、密钥、原始工具参数或原始工具结果。',
   ].join('\n\n')
 }

--- a/packages/harness-adapter/tests/adapter.test.ts
+++ b/packages/harness-adapter/tests/adapter.test.ts
@@ -14,6 +14,7 @@ import {
   HarnessCompatibilityAdapter,
   HarnessModelRouter,
   ensureHarnessProfile,
+  extractHarnessTokenUsage,
   inspectHarnessCandidate,
   normalizeHarnessNotification,
   stableAgentSessionId,
@@ -54,6 +55,18 @@ function revision(modelPolicy: EmployeeRevision['modelPolicy'] = {}): EmployeeRe
 }
 
 describe('Harness profile and adapter', () => {
+  it('extracts only real provider token usage from Harness notifications', () => {
+    const notifications = [{
+      method: 'session.event' as const,
+      params: {
+        sessionId: 'employee-1',
+        event: { type: 'turn/end', data: { usage: { prompt_tokens: 420, completion_tokens: 80, total_tokens: 500 } } },
+      },
+    }]
+    expect(extractHarnessTokenUsage(notifications)).toEqual({ prompt: 420, completion: 80, total: 500 })
+    expect(extractHarnessTokenUsage([])).toBeUndefined()
+  })
+
   it('normalizes Harness facts without persisting tool arguments', () => {
     const events = normalizeHarnessNotification({
       method: 'session.event',

--- a/packages/harness-adapter/tests/current-persona-authority.test.ts
+++ b/packages/harness-adapter/tests/current-persona-authority.test.ts
@@ -46,7 +46,8 @@ describe('current character persona authority', () => {
     const prompt = environment.DSH_SYSTEM_PROMPT ?? ''
     expect(prompt).toContain('团子')
     expect(prompt).toContain(revision.persona)
-    expect(prompt).toContain('latest user-defined Persona and identity contract')
+    expect(prompt).toContain('最新的用户自定义 Persona 和身份约定')
+    expect(prompt).toContain('简短的中文推理摘要')
     expect(prompt).not.toContain('秘书')
   })
 })

--- a/packages/orchestration/src/conversation-orchestrator.ts
+++ b/packages/orchestration/src/conversation-orchestrator.ts
@@ -627,6 +627,8 @@ export class ConversationOrchestrator implements AsyncDisposable {
         agent: employee,
         revision,
         conversationId: session.id,
+        workTurnId: workTurn.id,
+        agentRunId: agentRun.id,
         history,
         observedThroughSequence,
         prompt,

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -730,6 +730,18 @@ const MIGRATIONS: readonly Migration[] = [
       CREATE INDEX approval_policies_match_idx ON approval_policies(world_id, subject_type, skill_id, action, target, risk, revoked_at);
     `,
   },
+  {
+    version: 17,
+    name: 'trace-intelligence-v1',
+    sql: `
+      ALTER TABLE model_interaction_logs ADD COLUMN work_turn_id TEXT REFERENCES work_turns(id) ON DELETE SET NULL;
+      ALTER TABLE model_interaction_logs ADD COLUMN agent_run_id TEXT REFERENCES agent_runs(id) ON DELETE SET NULL;
+      CREATE UNIQUE INDEX model_interaction_logs_agent_run_idx
+        ON model_interaction_logs(agent_run_id) WHERE agent_run_id IS NOT NULL AND source = 'turn';
+      CREATE INDEX model_interaction_logs_world_employee_created_idx
+        ON model_interaction_logs(world_id, employee_id, created_at DESC, id);
+    `,
+  },
 ]
 
 export function migrate(database: DatabaseSync, now: () => string): void {

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -905,6 +905,24 @@ export class SqliteStore {
         throw new PersistenceError('Model interaction employee does not belong to workspace')
       }
     }
+    if (input.workTurnId !== undefined) {
+      const turn = this.getWorkTurn(input.workTurnId)
+      if (turn === undefined || turn.workspaceId !== workspace.id ||
+        (input.worldId !== undefined && turn.worldId !== input.worldId) ||
+        (input.sessionId !== undefined && turn.sessionId !== input.sessionId)) {
+        throw new PersistenceError('Model interaction turn scope does not match workspace, world or session')
+      }
+    }
+    if (input.agentRunId !== undefined) {
+      const run = this.getAgentRun(input.agentRunId)
+      if (run === undefined || run.workspaceId !== workspace.id ||
+        (input.worldId !== undefined && run.worldId !== input.worldId) ||
+        (input.sessionId !== undefined && run.sessionId !== input.sessionId) ||
+        (input.employeeId !== undefined && run.employeeId !== input.employeeId) ||
+        (input.workTurnId !== undefined && run.turnId !== input.workTurnId)) {
+        throw new PersistenceError('Model interaction agent run scope does not match its trace context')
+      }
+    }
     if (input.source !== 'turn' && input.source !== 'discovery') {
       throw new PersistenceError('Model interaction source is invalid')
     }
@@ -943,6 +961,8 @@ export class SqliteStore {
     if (input.worldId !== undefined) log.worldId = input.worldId
     if (input.sessionId !== undefined) log.sessionId = input.sessionId
     if (input.employeeId !== undefined) log.employeeId = input.employeeId
+    if (input.workTurnId !== undefined) log.workTurnId = input.workTurnId
+    if (input.agentRunId !== undefined) log.agentRunId = input.agentRunId
     if (input.errorCode?.trim()) log.errorCode = input.errorCode.trim().slice(0, 120)
     if (input.errorMessage?.trim()) log.errorMessage = input.errorMessage.trim().slice(0, 1_000)
     if (input.httpStatus !== undefined) {
@@ -960,11 +980,12 @@ export class SqliteStore {
     this.database
       .prepare(
         `INSERT INTO model_interaction_logs (
-           id, workspace_id, world_id, session_id, employee_id, source, model_id, provider,
+           id, workspace_id, world_id, session_id, employee_id, work_turn_id, agent_run_id,
+           source, model_id, provider,
            status, error_code, error_message, http_status, prompt_message_count, prompt_char_count,
            response_char_count, tool_call_count, duration_ms, tokens_prompt,
            tokens_completion, tokens_total, created_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
       )
       .run(
         log.id,
@@ -972,6 +993,8 @@ export class SqliteStore {
         log.worldId ?? null,
         log.sessionId ?? null,
         log.employeeId ?? null,
+        log.workTurnId ?? null,
+        log.agentRunId ?? null,
         log.source,
         log.modelId,
         log.provider,
@@ -1040,6 +1063,25 @@ export class SqliteStore {
       .prepare('SELECT * FROM model_interaction_logs WHERE id = ?')
       .get(interactionId)
     return row ? mapModelInteractionLog(row) : undefined
+  }
+
+  getAgentRunModelInteraction(agentRunId: string): ModelInteractionLog | undefined {
+    const row = this.database
+      .prepare(`SELECT * FROM model_interaction_logs
+                WHERE agent_run_id = ? AND source = 'turn'
+                ORDER BY created_at DESC, id DESC LIMIT 1`)
+      .get(agentRunId)
+    return row ? mapModelInteractionLog(row) : undefined
+  }
+
+  listWorldModelInteractions(worldId: string): ModelInteractionLog[] {
+    this.#requireWorld(worldId)
+    return this.database
+      .prepare(`SELECT * FROM model_interaction_logs
+                WHERE world_id = ? AND source = 'turn'
+                ORDER BY created_at DESC, id DESC`)
+      .all(worldId)
+      .map(mapModelInteractionLog)
   }
 
   clearModelInteractions(workspaceId: string): number {
@@ -2146,6 +2188,14 @@ export class SqliteStore {
     return this.database.prepare('SELECT * FROM agent_runs WHERE turn_id = ? ORDER BY ordinal').all(turnId).map(mapAgentRun)
   }
 
+  listWorldAgentRuns(worldId: string): AgentRun[] {
+    this.#requireWorld(worldId)
+    return this.database
+      .prepare('SELECT * FROM agent_runs WHERE world_id = ? ORDER BY created_at DESC, id DESC')
+      .all(worldId)
+      .map(mapAgentRun)
+  }
+
   startAgentRun(runId: string): AgentRun {
     return this.#transitionAgentRun(runId, ['queued'], 'running')
   }
@@ -2511,6 +2561,20 @@ export class SqliteStore {
         'SELECT * FROM messages WHERE session_id = ? AND sequence > ? ORDER BY sequence',
       )
       .all(sessionId, afterSequence)
+      .map(mapMessage)
+  }
+
+  listWorldTraceMessages(worldId: string): WorkMessage[] {
+    this.#requireWorld(worldId)
+    return this.database
+      .prepare(
+        `SELECT messages.* FROM messages
+         INNER JOIN work_sessions ON work_sessions.id = messages.session_id
+         WHERE work_sessions.world_id = ?
+           AND messages.kind IN ('reasoning', 'tool-call', 'tool-result')
+         ORDER BY messages.created_at, messages.id`,
+      )
+      .all(worldId)
       .map(mapMessage)
   }
 
@@ -4201,6 +4265,8 @@ function mapModelInteractionLog(row: object): ModelInteractionLog {
   if (typeof value.world_id === 'string') log.worldId = value.world_id
   if (typeof value.session_id === 'string') log.sessionId = value.session_id
   if (typeof value.employee_id === 'string') log.employeeId = value.employee_id
+  if (typeof value.work_turn_id === 'string') log.workTurnId = value.work_turn_id
+  if (typeof value.agent_run_id === 'string') log.agentRunId = value.agent_run_id
   if (typeof value.error_code === 'string') log.errorCode = value.error_code
   if (typeof value.error_message === 'string') log.errorMessage = value.error_message
   if (value.http_status !== null && value.http_status !== undefined) {

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -175,7 +175,7 @@ describe('SqliteStore', () => {
       '收到，我先建立基线。',
     ])
     expect(reopened.getEmployee(employee.id)?.agentSessionId).toBe('harness-session-1')
-    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 16 })
+    expect(reopened.doctor()).toMatchObject({ ok: true, schemaVersion: 17 })
   })
 
   it('returns the latest message of one sender without loading the full transcript', async () => {
@@ -361,7 +361,7 @@ describe('SqliteStore', () => {
     expect(backupStore.getWorkspace(workspace.id)?.name).toBe('赛博公司')
     const exported = JSON.parse(await readFile(exportPath, 'utf8')) as any
     expect(exported.format).toBe('dsh-cyber-export')
-    expect(exported.schemaVersion).toBe(16)
+    expect(exported.schemaVersion).toBe(17)
     expect(exported.workspaces[0].worlds[0].world.id).toBe(world.id)
     expect(exported.workspaces[0].worlds[0].employees[0].employee.id).toBe(employee.id)
     expect(exported.workspaces[0].worlds[0].sessions[0].messages[0].content).toBe('世界内记录')
@@ -692,7 +692,7 @@ describe('SqliteStore', () => {
     expect(migrated.listWorkspaces()[0]?.name).toBe('迁移前工作区')
     expect(migrated.doctor()).toMatchObject({
       ok: true,
-      schemaVersion: 16,
+      schemaVersion: 17,
       counts: {
         installedPackages: 0,
         packageTransactions: 0,

--- a/packages/server/src/routes/world-trace-routes.ts
+++ b/packages/server/src/routes/world-trace-routes.ts
@@ -47,12 +47,22 @@ function traceQuery(search: URLSearchParams): WorldTraceQuery {
   const status = optionalEnum(search.get('status'), WORLD_TRACE_STATUSES, 'invalid_trace_status')
   const after = search.get('after')?.trim() || undefined
   const actorId = search.get('actorId')?.trim() || undefined
+  const date = search.get('date')?.trim() || undefined
+  const keyword = search.get('search')?.trim() || undefined
+  if (date !== undefined && (!/^\d{4}-\d{2}-\d{2}$/.test(date) || Number.isNaN(Date.parse(`${date}T00:00:00`)))) {
+    throw new HttpError(422, 'invalid_trace_date', '轨迹日期格式必须为 YYYY-MM-DD')
+  }
+  if (keyword !== undefined && keyword.length > 120) {
+    throw new HttpError(422, 'invalid_trace_search', '轨迹搜索内容不能超过 120 个字符')
+  }
   return {
     ...(after === undefined ? {} : { after }),
     ...(limit === undefined ? {} : { limit }),
     ...(category === undefined ? {} : { category: category as WorldTraceCategory }),
     ...(status === undefined ? {} : { status: status as WorldTraceStatus }),
     ...(actorId === undefined ? {} : { actorId }),
+    ...(date === undefined ? {} : { date }),
+    ...(keyword === undefined ? {} : { search: keyword }),
   }
 }
 

--- a/packages/server/src/services/model-interaction-service.ts
+++ b/packages/server/src/services/model-interaction-service.ts
@@ -29,14 +29,17 @@ export class ModelInteractionService {
    * 记录一次对话回合级交互（source='turn'）。
    * 观测边界：模型 API 请求发生在 DSH worker 内部，服务端只能观测整轮交互
    * （开始时间、worker 返回的成功/失败、耗时、工具调用次数、最终响应摘要）。
-   * 消息数按「1 条用户 prompt + 每轮工具回填 1 条」近似；worker 内部单次请求的
-   * token 用量接口未透出，字段保持为空。
+   * 消息数按「1 条用户 prompt + 每轮工具回填 1 条」统计。Token 只记录 Harness
+   * 明确返回的真实用量，不做字符数估算。
    */
   recordTurn(input: RecordTurnInteractionInput): ModelInteractionLog {
     return this.#store.recordModelInteraction({
       workspaceId: input.workspaceId,
       ...(input.worldId === undefined ? {} : { worldId: input.worldId }),
+      ...(input.sessionId === undefined ? {} : { sessionId: input.sessionId }),
       ...(input.employeeId === undefined ? {} : { employeeId: input.employeeId }),
+      ...(input.workTurnId === undefined ? {} : { workTurnId: input.workTurnId }),
+      ...(input.agentRunId === undefined ? {} : { agentRunId: input.agentRunId }),
       source: 'turn',
       modelId: input.modelId,
       provider: input.provider,
@@ -49,6 +52,11 @@ export class ModelInteractionService {
       ...(input.responseCharCount === undefined ? {} : { responseCharCount: input.responseCharCount }),
       ...(input.toolCallCount === undefined ? {} : { toolCallCount: input.toolCallCount }),
       durationMs: input.durationMs,
+      ...(input.tokenUsage === undefined ? {} : {
+        tokensPrompt: input.tokenUsage.prompt,
+        tokensCompletion: input.tokenUsage.completion,
+        tokensTotal: input.tokenUsage.total,
+      }),
     })
   }
 
@@ -88,7 +96,10 @@ export class ModelInteractionService {
 export interface RecordTurnInteractionInput {
   workspaceId: string
   worldId?: string
+  sessionId?: string
   employeeId?: string
+  workTurnId?: string
+  agentRunId?: string
   modelId: string
   provider: string
   status: ModelInteractionLogStatus
@@ -99,6 +110,7 @@ export interface RecordTurnInteractionInput {
   responseCharCount?: number
   toolCallCount?: number
   durationMs: number
+  tokenUsage?: AgentTurnResult['tokenUsage']
 }
 
 export interface RecordDiscoveryInteractionInput {
@@ -159,6 +171,11 @@ export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
         request.onEvent?.(event)
       },
     }
+    const traceContext = {
+      sessionId: request.conversationId,
+      ...(request.workTurnId === undefined ? {} : { workTurnId: request.workTurnId }),
+      ...(request.agentRunId === undefined ? {} : { agentRunId: request.agentRunId }),
+    }
     try {
       const result = await this.#inner.runTurn(wrapped)
       // worker 返回 turn.failed 事件但 runTurn 未抛异常时（如空回复），
@@ -168,6 +185,7 @@ export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
           workspaceId: request.agent.workspaceId,
           worldId: request.agent.worldId,
           employeeId: request.agent.id,
+          ...traceContext,
           modelId,
           provider,
           status: 'failed',
@@ -178,6 +196,7 @@ export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
           responseCharCount: result.finalResponse.length,
           toolCallCount,
           durationMs: Date.now() - startedAt,
+          ...(result.tokenUsage === undefined ? {} : { tokenUsage: result.tokenUsage }),
         })
         return result
       }
@@ -185,6 +204,7 @@ export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
         workspaceId: request.agent.workspaceId,
         worldId: request.agent.worldId,
         employeeId: request.agent.id,
+        ...traceContext,
         modelId,
         provider,
         status: 'success',
@@ -192,6 +212,7 @@ export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
         responseCharCount: result.finalResponse.length,
         toolCallCount,
         durationMs: Date.now() - startedAt,
+        ...(result.tokenUsage === undefined ? {} : { tokenUsage: result.tokenUsage }),
       })
       return result
     } catch (error) {
@@ -201,6 +222,7 @@ export class TurnInteractionLoggingRuntime implements AgentRuntimePort {
         workspaceId: request.agent.workspaceId,
         worldId: request.agent.worldId,
         employeeId: request.agent.id,
+        ...traceContext,
         modelId,
         provider,
         status: 'failed',

--- a/packages/server/src/services/world-trace-service.ts
+++ b/packages/server/src/services/world-trace-service.ts
@@ -8,6 +8,7 @@ import type { SqliteStore } from '@dsh-cyber/persistence'
 
 import type { CharacterSkillActionRepository } from '../skills/skill-action-repository.js'
 import {
+  AgentRunTraceAdapter,
   ConversationTraceAdapter,
   DomainEventTraceAdapter,
   RuntimeEventTraceAdapter,
@@ -46,6 +47,7 @@ export class WorldTraceService {
   readonly #registry: WorldTraceAdapterRegistry
   readonly #sanitizer: TraceSanitizer
   readonly #clock: () => string
+  readonly #liveRuns = new Map<string, WorldTraceEntry>()
 
   constructor(options: WorldTraceServiceOptions) {
     this.#store = options.store
@@ -58,15 +60,19 @@ export class WorldTraceService {
   async list(worldId: string, query: WorldTraceQuery = {}): Promise<WorldTracePage> {
     const world = this.#store.getWorld(worldId)
     if (world === undefined) return { items: [] }
+    const actorNames = new Map(this.#store.listEmployees(worldId, true).map((employee) => [employee.id, employee.displayName]))
+    const search = query.search?.trim().toLocaleLowerCase('zh-CN')
     const entries = (await this.#materialize(worldId))
       .filter((entry) => query.category === undefined || entry.category === query.category)
       .filter((entry) => query.status === undefined || entry.status === query.status)
       .filter((entry) => query.actorId === undefined || entry.actorId === query.actorId)
+      .filter((entry) => query.date === undefined || localCalendarDate(entry.createdAt) === query.date)
+      .filter((entry) => search === undefined || search.length === 0 || traceSearchText(entry, actorNames).includes(search))
       .sort(compareTraceEntries)
     const cursor = query.after === undefined ? undefined : decodeTraceCursor(query.after)
     const after = cursor === undefined
       ? entries
-      : entries.filter((entry) => compareCursor(entry, cursor) > 0)
+      : entries.filter((entry) => compareCursor(entry, cursor) < 0)
     const limit = Math.min(200, Math.max(1, query.limit ?? 50))
     const items = after.slice(0, limit)
     return {
@@ -86,18 +92,26 @@ export class WorldTraceService {
   }
 
   adaptRuntime(envelope: ConversationRealtimeEnvelope): WorldTraceEntry[] {
-    return this.#registry.adapt({
+    const updates = this.#registry.adapt({
       kind: 'runtime-event',
       value: {
         worldId: envelope.worldId,
         sessionId: envelope.sessionId,
         actorId: envelope.agentId,
         event: envelope.event,
+        workTurnId: envelope.workTurnId,
+        agentRunId: envelope.agentRunId,
         createdAt: envelope.event.sourceTime === undefined
           ? this.#clock()
           : new Date(envelope.event.sourceTime).toISOString(),
       },
     }, this.#context(envelope.worldId))
+    return updates.map((update) => {
+      const merged = mergeTraceEntry(this.#liveRuns.get(update.id), update)
+      this.#liveRuns.set(update.id, merged)
+      if (merged.status !== 'running') setTimeout(() => this.#liveRuns.delete(merged.id), 30_000).unref?.()
+      return merged
+    })
   }
 
   #context(worldId: string) {
@@ -110,21 +124,32 @@ export class WorldTraceService {
 
   async #materialize(worldId: string): Promise<WorldTraceEntry[]> {
     const context = this.#context(worldId)
+    const messages = this.#store.listWorldTraceMessages(worldId)
+    const interactions = new Map(this.#store.listWorldModelInteractions(worldId)
+      .filter((interaction) => interaction.agentRunId !== undefined)
+      .map((interaction) => [interaction.agentRunId!, interaction]))
     const facts: WorldTraceFact[] = [
+      ...this.#store.listWorldAgentRuns(worldId).map((run) => ({
+        kind: 'agent-run' as const,
+        value: {
+          worldId,
+          run,
+          messages,
+          ...(interactions.get(run.id) === undefined ? {} : { interaction: interactions.get(run.id)! }),
+        },
+      })),
       ...this.#store.listWorldDomainEvents(worldId).map((value) => ({ kind: 'domain-event' as const, value })),
-      ...this.#store.listSessions(worldId).flatMap((session) =>
-        this.#store.listMessages(session.id).map((message) => ({
-          kind: 'conversation' as const,
-          value: { worldId, session, message },
-        }))),
       ...(await this.#actions.listByWorld(worldId)).map((value) => ({ kind: 'skill-action' as const, value })),
     ]
-    return deduplicate(facts.flatMap((fact) => this.#registry.adapt(fact, context)))
+    const persisted = deduplicate(facts.flatMap((fact) => this.#registry.adapt(fact, context)))
+    const live = [...this.#liveRuns.values()].filter((entry) => entry.worldId === worldId)
+    return deduplicate([...persisted, ...live])
   }
 }
 
 export function createWorldTraceRegistry(): WorldTraceAdapterRegistry {
   const registry = new WorldTraceAdapterRegistry()
+  registry.register(new AgentRunTraceAdapter())
   registry.register(new DomainEventTraceAdapter())
   registry.register(new RuntimeEventTraceAdapter())
   registry.register(new SkillActionTraceAdapter())
@@ -170,9 +195,50 @@ function deduplicate(entries: WorldTraceEntry[]): WorldTraceEntry[] {
 }
 
 function compareTraceEntries(left: WorldTraceEntry, right: WorldTraceEntry): number {
-  return left.createdAt.localeCompare(right.createdAt) || left.id.localeCompare(right.id)
+  return right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id)
 }
 
 function compareCursor(entry: WorldTraceEntry, cursor: TraceCursor): number {
   return entry.createdAt.localeCompare(cursor.createdAt) || entry.id.localeCompare(cursor.id)
+}
+
+function traceSearchText(entry: WorldTraceEntry, actorNames: ReadonlyMap<string, string>): string {
+  return [
+    entry.summary,
+    entry.detail,
+    entry.reasoningSummary,
+    entry.actorId === undefined ? undefined : actorNames.get(entry.actorId),
+    entry.modelId,
+    entry.provider,
+    ...((entry.tools ?? []).flatMap((tool) => [tool.label, tool.name])),
+  ].filter((value): value is string => typeof value === 'string')
+    .join('\n')
+    .toLocaleLowerCase('zh-CN')
+}
+
+function localCalendarDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.valueOf())) return ''
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
+function mergeTraceEntry(current: WorldTraceEntry | undefined, next: WorldTraceEntry): WorldTraceEntry {
+  if (current === undefined) return next
+  const tools = new Map((current.tools ?? []).map((tool) => [tool.callId, tool]))
+  for (const tool of next.tools ?? []) tools.set(tool.callId, { ...tools.get(tool.callId), ...tool })
+  const reasoning = [current.reasoningSummary, next.reasoningSummary]
+    .filter((value, index, values): value is string => Boolean(value) && values.indexOf(value) === index)
+    .join('\n\n')
+  return {
+    ...current,
+    ...next,
+    category: tools.size > 0 ? 'tool' : next.category,
+    createdAt: current.createdAt.localeCompare(next.createdAt) <= 0 ? current.createdAt : next.createdAt,
+    updatedAt: current.updatedAt.localeCompare(next.updatedAt) >= 0 ? current.updatedAt : next.updatedAt,
+    ...(reasoning ? { reasoningSummary: reasoning } : {}),
+    ...(tools.size > 0 ? { tools: [...tools.values()] } : {}),
+  }
 }

--- a/packages/server/src/world-trace/agent-run-trace-adapter.ts
+++ b/packages/server/src/world-trace/agent-run-trace-adapter.ts
@@ -1,0 +1,138 @@
+import type {
+  AgentRunStatus,
+  WorkMessage,
+  WorldTraceEntry,
+  WorldTraceStatus,
+  WorldTraceToolStep,
+} from '@dsh-cyber/contracts'
+
+import { traceId, type AgentRunTraceFact, type WorldTraceAdapter } from './trace-adapter.js'
+
+export class AgentRunTraceAdapter implements WorldTraceAdapter<'agent-run'> {
+  readonly kind = 'agent-run' as const
+
+  adapt({ value }: { kind: 'agent-run'; value: AgentRunTraceFact }): WorldTraceEntry[] {
+    const { run, interaction } = value
+    const runMessages = value.messages.filter((message) => belongsToRun(message, run.id))
+    const reasoningSummary = runMessages
+      .filter((message) => message.kind === 'reasoning')
+      .map((message) => message.content.trim())
+      .filter(Boolean)
+      .join('\n\n')
+    const tools = buildToolSteps(runMessages)
+    const createdAt = run.startedAt ?? run.createdAt
+    const updatedAt = run.completedAt ?? interaction?.createdAt ?? createdAt
+    const entry: WorldTraceEntry = {
+      id: traceId('agent-run', run.id),
+      worldId: value.worldId,
+      category: tools.length > 0 ? 'tool' : 'agent',
+      status: traceStatus(run.status),
+      summary: traceSummary(run.status, tools.length),
+      actorId: run.employeeId,
+      sessionId: run.sessionId,
+      taskId: `turn:${run.turnId}`,
+      workTurnId: run.turnId,
+      sourceKind: 'agent-run',
+      sourceId: run.id,
+      createdAt,
+      updatedAt,
+    }
+    if (reasoningSummary) entry.reasoningSummary = reasoningSummary
+    if (tools.length > 0) entry.tools = tools
+    if (run.errorCode) entry.detail = friendlyRunError(run.errorCode)
+    if (interaction !== undefined) {
+      entry.durationMs = interaction.durationMs
+      entry.modelId = interaction.modelId
+      entry.provider = interaction.provider
+      if (interaction.tokensPrompt !== undefined &&
+        interaction.tokensCompletion !== undefined &&
+        interaction.tokensTotal !== undefined) {
+        entry.tokenUsage = {
+          prompt: interaction.tokensPrompt,
+          completion: interaction.tokensCompletion,
+          total: interaction.tokensTotal,
+        }
+      }
+    }
+    return [entry]
+  }
+}
+
+function belongsToRun(message: WorkMessage, runId: string): boolean {
+  return message.metadata.agentRunId === runId || message.metadata.traceTurnId === runId
+}
+
+function buildToolSteps(messages: readonly WorkMessage[]): WorldTraceToolStep[] {
+  const steps = new Map<string, WorldTraceToolStep>()
+  for (const message of messages) {
+    if (message.kind !== 'tool-call' && message.kind !== 'tool-result') continue
+    const callId = stringMetadata(message, 'callId') ?? message.id
+    const current = steps.get(callId)
+    if (message.kind === 'tool-call') {
+      const name = stringMetadata(message, 'toolName') ?? (message.content.trim() || undefined)
+      steps.set(callId, {
+        callId,
+        ...(name === undefined ? {} : { name }),
+        label: toolDisplayLabel(name),
+        status: current?.status ?? 'running',
+        createdAt: message.createdAt,
+        ...(current?.completedAt === undefined ? {} : { completedAt: current.completedAt }),
+      })
+      continue
+    }
+    const failed = message.metadata.failed === true
+    steps.set(callId, {
+      callId,
+      ...(current?.name === undefined ? {} : { name: current.name }),
+      label: current?.label ?? '执行工具',
+      status: failed ? 'failed' : 'success',
+      ...(current?.createdAt === undefined ? {} : { createdAt: current.createdAt }),
+      completedAt: message.createdAt,
+    })
+  }
+  return [...steps.values()]
+}
+
+function stringMetadata(message: WorkMessage, key: string): string | undefined {
+  const value = message.metadata[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+export function toolDisplayLabel(name: string | undefined): string {
+  if (!name) return '执行工具'
+  const normalized = name.toLowerCase()
+  if (/search|web|firecrawl/.test(normalized)) return '搜索并核对网络信息'
+  if (/read|open|view|get/.test(normalized)) return '读取信息'
+  if (/write|edit|patch|update/.test(normalized)) return '更新内容'
+  if (/shell|command|terminal|exec/.test(normalized)) return '执行工作区命令'
+  if (/browser|click|navigate/.test(normalized)) return '操作浏览器'
+  if (/file|list|glob/.test(normalized)) return '检查文件'
+  return `调用 ${name}`
+}
+
+function traceStatus(status: AgentRunStatus): WorldTraceStatus {
+  if (status === 'completed') return 'success'
+  if (status === 'failed' || status === 'interrupted') return 'failed'
+  if (status === 'running' || status === 'queued') return 'running'
+  return 'info'
+}
+
+function traceSummary(status: AgentRunStatus, toolCount: number): string {
+  if (status === 'completed') return toolCount > 0 ? `完成处理，调度了 ${toolCount} 个工具` : '完成本轮分析与回复'
+  if (status === 'failed') return '本轮处理失败'
+  if (status === 'interrupted') return '本轮处理已中断'
+  if (status === 'queued') return '等待开始处理'
+  return toolCount > 0 ? `正在处理，已调度 ${toolCount} 个工具` : '正在分析请求'
+}
+
+function friendlyRunError(code: string): string {
+  const labels: Record<string, string> = {
+    'service-restarted': '本地服务重启，本轮运行已安全结束。',
+    timeout: '模型或工具响应超时。',
+    authentication: '模型服务认证失败。',
+    'rate-limited': '模型服务请求过于频繁。',
+    'model-not-found': '当前模型不可用。',
+    interrupted: '本轮运行被中断。',
+  }
+  return labels[code] ?? '本轮运行未能完成，请在会话中重试。'
+}

--- a/packages/server/src/world-trace/domain-event-trace-adapter.ts
+++ b/packages/server/src/world-trace/domain-event-trace-adapter.ts
@@ -27,6 +27,25 @@ interface DomainPresentation {
 const EXCLUDED = new Set<DomainEventType>([
   'message.appended',
   'world.runtime.snapshot.saved',
+  'world.entered',
+  'employee.milestone.recorded',
+  'employee.journal.written',
+  'employee.relationship.updated',
+  'workspace.preferences.updated',
+  'model.profile.updated',
+  'model.assignment.updated',
+  'local.asset.saved',
+  'session.created',
+  'session.participant.joined',
+  'turn.started',
+  'turn.completed',
+  'turn.failed',
+  'tool.started',
+  'tool.completed',
+  'task.started',
+  'task.waiting',
+  'task.blocked',
+  'task.completed',
 ])
 
 export class DomainEventTraceAdapter implements WorldTraceAdapter<'domain-event'> {

--- a/packages/server/src/world-trace/index.ts
+++ b/packages/server/src/world-trace/index.ts
@@ -1,3 +1,4 @@
+export * from './agent-run-trace-adapter.js'
 export * from './conversation-trace-adapter.js'
 export * from './domain-event-trace-adapter.js'
 export * from './runtime-event-trace-adapter.js'

--- a/packages/server/src/world-trace/runtime-event-trace-adapter.ts
+++ b/packages/server/src/world-trace/runtime-event-trace-adapter.ts
@@ -1,6 +1,7 @@
 import type { AgentRuntimeEvent, WorldTraceEntry, WorldTraceStatus } from '@dsh-cyber/contracts'
 
-import { runtimeIdentity, traceId, type RuntimeTraceFact, type WorldTraceAdapter } from './trace-adapter.js'
+import { toolDisplayLabel } from './agent-run-trace-adapter.js'
+import { traceId, type RuntimeTraceFact, type WorldTraceAdapter } from './trace-adapter.js'
 
 export class RuntimeEventTraceAdapter implements WorldTraceAdapter<'runtime-event'> {
   readonly kind = 'runtime-event' as const
@@ -8,66 +9,68 @@ export class RuntimeEventTraceAdapter implements WorldTraceAdapter<'runtime-even
   adapt({ value }: { kind: 'runtime-event'; value: RuntimeTraceFact }): WorldTraceEntry[] {
     const event = value.event
     if (event.kind === 'reasoning.delta' || event.kind === 'text.delta') return []
+    const runId = value.agentRunId ?? stringMetadata(event, 'agentRunId')
+      ?? stringMetadata(event, 'traceTurnId') ?? `${event.source}:${event.sourceSessionId}`
     const presentation = runtimePresentation(event)
-    const traceTurnId = typeof event.metadata.traceTurnId === 'string' ? event.metadata.traceTurnId : undefined
-    const id = runtimeIdentity({ ...event, ...(traceTurnId === undefined ? {} : { traceTurnId }) })
-    return [{
-      id,
+    const entry: WorldTraceEntry = {
+      id: traceId('agent-run', runId),
       worldId: value.worldId,
-      category: presentation.category,
+      category: event.kind.startsWith('tool.') ? 'tool' : 'agent',
       status: presentation.status,
       summary: presentation.summary,
-      ...(presentation.detail === undefined ? {} : { detail: presentation.detail }),
       actorId: value.actorId,
       sessionId: value.sessionId,
-      ...(event.kind.startsWith('turn.') ? { taskId: `turn:${event.sourceSessionId}` } : {}),
-      sourceKind: 'runtime-event',
-      sourceId: traceId(event.source, event.sourceSessionId, event.sourceSequence, event.kind),
+      ...(value.workTurnId === undefined ? {} : { taskId: `turn:${value.workTurnId}`, workTurnId: value.workTurnId }),
+      sourceKind: 'agent-run',
+      sourceId: runId,
       ...(event.sourceSequence === undefined ? {} : { sourceSequence: event.sourceSequence }),
       createdAt: value.createdAt,
       updatedAt: value.createdAt,
-    }]
+    }
+    if (event.kind === 'assistant.reasoning' && event.content?.trim()) entry.reasoningSummary = event.content.trim()
+    if (event.kind === 'tool.started' || event.kind === 'tool.completed') {
+      const callId = event.callId ?? `event-${event.sourceSequence ?? value.createdAt}`
+      entry.tools = [{
+        callId,
+        ...(event.toolName === undefined ? {} : { name: event.toolName }),
+        label: toolDisplayLabel(event.toolName),
+        status: event.kind === 'tool.started' ? 'running' : event.failed ? 'failed' : 'success',
+        ...(event.kind === 'tool.started' ? { createdAt: value.createdAt } : { completedAt: value.createdAt }),
+      }]
+    }
+    const usage = tokenUsage(event)
+    if (usage !== undefined) entry.tokenUsage = usage
+    return [entry]
   }
 }
 
-function runtimePresentation(event: AgentRuntimeEvent): {
-  category: 'agent' | 'tool'
-  status: WorldTraceStatus
-  summary: string
-  detail?: string
-} {
+function runtimePresentation(event: AgentRuntimeEvent): { status: WorldTraceStatus; summary: string } {
   switch (event.kind) {
-    case 'turn.started':
-      return { category: 'agent', status: 'running', summary: '角色开始处理请求' }
-    case 'turn.completed':
-      return { category: 'agent', status: 'success', summary: '角色已完成本轮处理' }
-    case 'turn.failed':
-      return { category: 'agent', status: 'failed', summary: '角色本轮处理失败' }
-    case 'assistant.reasoning':
-      return {
-        category: 'agent',
-        status: 'info',
-        summary: '角色生成了推理摘要',
-        ...(event.content?.trim() ? { detail: event.content } : {}),
-      }
-    case 'assistant.message':
-      return { category: 'agent', status: 'success', summary: '角色已生成最终回复' }
-    case 'tool.started':
-      return {
-        category: 'tool',
-        status: 'running',
-        summary: `开始使用工具：${event.toolName ?? '未命名工具'}`,
-        ...(event.toolName === undefined ? {} : { detail: event.toolName }),
-      }
-    case 'tool.completed':
-      return {
-        category: 'tool',
-        status: event.failed ? 'failed' : 'success',
-        summary: event.failed ? '工具执行失败' : '工具执行完成',
-        ...(event.toolName === undefined ? {} : { detail: event.toolName }),
-      }
+    case 'turn.started': return { status: 'running', summary: '正在分析请求' }
+    case 'turn.completed': return { status: 'success', summary: '完成本轮分析与回复' }
+    case 'turn.failed': return { status: 'failed', summary: '本轮处理失败' }
+    case 'assistant.reasoning': return { status: 'running', summary: '正在整理判断依据' }
+    case 'assistant.message': return { status: 'running', summary: '正在生成最终回复' }
+    case 'tool.started': return { status: 'running', summary: `正在${toolDisplayLabel(event.toolName)}` }
+    case 'tool.completed': return {
+      status: event.failed ? 'failed' : 'running',
+      summary: event.failed ? `${toolDisplayLabel(event.toolName)}失败` : `${toolDisplayLabel(event.toolName)}完成`,
+    }
     case 'reasoning.delta':
-    case 'text.delta':
-      return { category: 'agent', status: 'info', summary: '运行时增量' }
+    case 'text.delta': return { status: 'running', summary: '正在处理' }
   }
+}
+
+function stringMetadata(event: AgentRuntimeEvent, key: string): string | undefined {
+  const value = event.metadata[key]
+  return typeof value === 'string' && value.trim() ? value.trim() : undefined
+}
+
+function tokenUsage(event: AgentRuntimeEvent) {
+  const prompt = event.metadata.tokensPrompt
+  const completion = event.metadata.tokensCompletion
+  const total = event.metadata.tokensTotal
+  return typeof prompt === 'number' && typeof completion === 'number' && typeof total === 'number'
+    ? { prompt, completion, total }
+    : undefined
 }

--- a/packages/server/src/world-trace/trace-adapter.ts
+++ b/packages/server/src/world-trace/trace-adapter.ts
@@ -2,7 +2,9 @@ import { createHash } from 'node:crypto'
 
 import type {
   AgentRuntimeEvent,
+  AgentRun,
   DomainEvent,
+  ModelInteractionLog,
   ScheduledRunTraceFact,
   WorkMessage,
   WorkSession,
@@ -19,9 +21,19 @@ export interface RuntimeTraceFact {
   actorId: string
   event: AgentRuntimeEvent
   createdAt: string
+  workTurnId?: string
+  agentRunId?: string
+}
+
+export interface AgentRunTraceFact {
+  worldId: string
+  run: AgentRun
+  messages: WorkMessage[]
+  interaction?: ModelInteractionLog
 }
 
 export type WorldTraceFact =
+  | { kind: 'agent-run'; value: AgentRunTraceFact }
   | { kind: 'domain-event'; value: DomainEvent }
   | { kind: 'runtime-event'; value: RuntimeTraceFact }
   | { kind: 'skill-action'; value: CharacterSkillAction }

--- a/packages/server/src/world-trace/trace-sanitizer.ts
+++ b/packages/server/src/world-trace/trace-sanitizer.ts
@@ -24,11 +24,20 @@ export class TraceSanitizer {
   entry(entry: WorldTraceEntry): WorldTraceEntry {
     const summary = this.text(entry.summary, 160)
     const detail = entry.detail === undefined ? undefined : this.text(entry.detail, 500)
-    const { detail: _originalDetail, ...rest } = entry
+    const reasoningSummary = entry.reasoningSummary === undefined ? undefined : this.text(entry.reasoningSummary, 1_200)
+    const tools = entry.tools?.map((tool) => ({
+      ...tool,
+      callId: this.text(tool.callId, 160),
+      ...(tool.name === undefined ? {} : { name: this.text(tool.name, 160) }),
+      label: this.text(tool.label, 200),
+    }))
+    const { detail: _originalDetail, reasoningSummary: _originalReasoning, tools: _originalTools, ...rest } = entry
     return {
       ...rest,
       summary: summary || '世界活动已更新',
       ...(detail === undefined || detail.length === 0 ? {} : { detail }),
+      ...(reasoningSummary === undefined || reasoningSummary.length === 0 ? {} : { reasoningSummary }),
+      ...(tools === undefined ? {} : { tools }),
     }
   }
 

--- a/packages/server/tests/world-trace-integration.test.ts
+++ b/packages/server/tests/world-trace-integration.test.ts
@@ -24,7 +24,7 @@ class TraceRuntime implements AgentRuntimePort {
     request.onEvent?.({ kind: 'tool.completed', source: 'trace-test', sourceSessionId, sourceSequence: 4, toolName: 'sk-1234567890123456', callId: 'call-1', failed: false, metadata: {} })
     request.onEvent?.({ kind: 'assistant.message', source: 'trace-test', sourceSessionId, sourceSequence: 5, content: '最终回答', metadata: {} })
     request.onEvent?.({ kind: 'turn.completed', source: 'trace-test', sourceSessionId, sourceSequence: 6, metadata: {} })
-    return { agentSessionId: sourceSessionId, finalResponse: '最终回答', eventCount: 6 }
+    return { agentSessionId: sourceSessionId, finalResponse: '最终回答', eventCount: 6, tokenUsage: { prompt: 120, completion: 30, total: 150 } }
   }
   async close(): Promise<void> {}
 }
@@ -63,12 +63,10 @@ describe('World Trace HTTP and live recovery', () => {
     })
     const interactionLogs = first.server.store.listModelInteractions(workspace.id, { page: 1, pageSize: 10 })
     expect(chat.response.status, JSON.stringify({ body: chat.body, logs: interactionLogs.items })).toBe(200)
-    await stream.waitFor(6)
-    const live = await stream.waitForMatch((entry) => entry.category === 'task' && entry.status === 'success')
+    const live = await stream.waitForMatch((entry) => entry.sourceKind === 'agent-run' && entry.status === 'success')
     stream.close()
     expect(live.some((entry) => entry.category === 'tool' && entry.status === 'success')).toBe(true)
-    expect(live.some((entry) => entry.category === 'task' && entry.status === 'success')).toBe(true)
-    expect(live.some((entry) => entry.category === 'task' && entry.status === 'pending')).toBe(true)
+    expect(live.some((entry) => entry.sourceKind === 'agent-run' && entry.status === 'success')).toBe(true)
     expect(JSON.stringify(live)).not.toContain('sk-1234567890123456')
 
     const historyResponse = await json(first.origin, `/api/worlds/${world.id}/trace?limit=200`)
@@ -76,8 +74,10 @@ describe('World Trace HTTP and live recovery', () => {
     const history = historyResponse.body as WorldTracePage
     expect(JSON.stringify(history)).not.toContain('完整用户提示')
     expect(JSON.stringify(history)).not.toContain('sk-1234567890123456')
-    const liveTurn = live.find((entry) => entry.summary.includes('本轮处理') && entry.status === 'success')
-    const durableTurn = history.items.find((entry) => entry.summary.includes('本轮处理'))
+    const liveTurn = live.find((entry) => entry.sourceKind === 'agent-run' && entry.status === 'success')
+    const durableTurn = history.items.find((entry) => entry.sourceKind === 'agent-run')
+    expect(durableTurn?.tokenUsage).toEqual({ prompt: 120, completion: 30, total: 150 })
+    expect(durableTurn?.actorId).toBe(employee.id)
     expect(liveTurn?.id).toBe(durableTurn?.id)
     expect(history.items.filter((entry) => entry.id === durableTurn?.id)).toHaveLength(1)
     const filtered = await json(first.origin, `/api/worlds/${world.id}/trace?category=tool&status=success&actorId=${employee.id}&limit=10`)

--- a/packages/server/tests/world-trace-service.test.ts
+++ b/packages/server/tests/world-trace-service.test.ts
@@ -55,6 +55,33 @@ async function fixture() {
   return { store, workspace, world, session, employee }
 }
 
+function completeAgentRun(store: SqliteStore, context: Awaited<ReturnType<typeof fixture>>, reasoning = '先核对事实，再执行工具。') {
+  const turn = store.createWorkTurn({
+    workspaceId: context.workspace.id, worldId: context.world.id, sessionId: context.session.id, interactionKind: 'chat',
+  })
+  store.startWorkTurn(turn.id)
+  const run = store.createAgentRun({
+    workspaceId: context.workspace.id, worldId: context.world.id, sessionId: context.session.id,
+    turnId: turn.id, employeeId: context.employee.id, ordinal: 1,
+  })
+  store.startAgentRun(run.id)
+  store.appendMessage({
+    sessionId: context.session.id, senderId: context.employee.id, senderKind: 'employee', kind: 'reasoning',
+    content: reasoning, metadata: { agentRunId: run.id, traceTurnId: run.id },
+  })
+  store.appendMessage({
+    sessionId: context.session.id, senderId: context.employee.id, senderKind: 'employee', kind: 'tool-call',
+    content: 'search', metadata: { agentRunId: run.id, traceTurnId: run.id, callId: `call-${run.id}`, toolName: 'search' },
+  })
+  store.appendMessage({
+    sessionId: context.session.id, senderId: context.employee.id, senderKind: 'employee', kind: 'tool-result',
+    content: '已完成', metadata: { agentRunId: run.id, traceTurnId: run.id, callId: `call-${run.id}`, failed: false },
+  })
+  store.completeAgentRun(run.id, `runtime-${run.id}`)
+  store.completeWorkTurn(turn.id)
+  return run
+}
+
 describe('World Trace projection', () => {
   it('merges lifecycle updates into stable ids, filters, and paginates canonical facts', async () => {
     const { store, workspace, world, session, employee } = await fixture()
@@ -66,24 +93,7 @@ describe('World Trace projection', () => {
       content: '这是完整提示词，不应该进入轨迹详情',
       metadata: { participantIds: [employee.id] },
     })
-    store.appendDomainEvent({
-      workspaceId: workspace.id,
-      worldId: world.id,
-      sessionId: session.id,
-      type: 'turn.started',
-      actorId: employee.id,
-      actorKind: 'employee',
-      payload: { source: 'test', sourceSessionId: 'runtime-1', sourceSequence: 1 },
-    })
-    store.appendDomainEvent({
-      workspaceId: workspace.id,
-      worldId: world.id,
-      sessionId: session.id,
-      type: 'turn.completed',
-      actorId: employee.id,
-      actorKind: 'employee',
-      payload: { source: 'test', sourceSessionId: 'runtime-1', sourceSequence: 2 },
-    })
+    completeAgentRun(store, { store, workspace, world, session, employee })
     const actions = new MemoryActions([{
       id: 'action-1',
       worldId: world.id,
@@ -104,14 +114,24 @@ describe('World Trace projection', () => {
     const service = new WorldTraceService({ store, actions })
 
     const all = await service.list(world.id, { limit: 200 })
-    expect(all.items.filter((item) => item.summary.includes('本轮处理'))).toHaveLength(1)
-    expect(all.items.find((item) => item.summary.includes('本轮处理'))?.status).toBe('success')
+    expect(all.items.filter((item) => item.sourceKind === 'agent-run')).toHaveLength(1)
+    expect(all.items.find((item) => item.sourceKind === 'agent-run')).toMatchObject({
+      status: 'success', reasoningSummary: '先核对事实，再执行工具。', tools: [expect.objectContaining({ status: 'success' })],
+    })
     expect(JSON.stringify(all)).not.toContain('这是完整提示词')
     expect((await service.list(world.id, { category: 'skill' })).items).toEqual([
       expect.objectContaining({ category: 'skill', status: 'success', skillId: 'lights' }),
     ])
     expect((await service.list(world.id, { status: 'success', actorId: employee.id })).items.every((item) => item.status === 'success' && item.actorId === employee.id)).toBe(true)
     expect((await service.list(world.id, { actorId: 'missing-actor' })).items).toEqual([])
+    expect((await service.list(world.id, { search: '核对事实' })).items).toEqual([
+      expect.objectContaining({ sourceKind: 'agent-run', actorId: employee.id }),
+    ])
+    expect((await service.list(world.id, { search: '测试角色' })).items.some((item) => item.actorId === employee.id)).toBe(true)
+    const runEntry = all.items.find((item) => item.sourceKind === 'agent-run')!
+    const runDate = new Date(runEntry.createdAt)
+    const localDate = `${runDate.getFullYear()}-${String(runDate.getMonth() + 1).padStart(2, '0')}-${String(runDate.getDate()).padStart(2, '0')}`
+    expect((await service.list(world.id, { date: localDate })).items).toContainEqual(expect.objectContaining({ id: runEntry.id }))
 
     const first = await service.list(world.id, { limit: 1 })
     expect(first.items).toHaveLength(1)
@@ -142,6 +162,8 @@ describe('World Trace projection', () => {
       worldId: world.id,
       sessionId: session.id,
       agentId: employee.id,
+      workTurnId: 'work-turn-1',
+      agentRunId: 'turn-1',
       event: {
         kind: 'tool.started',
         source: 'test',
@@ -157,30 +179,13 @@ describe('World Trace projection', () => {
   })
 
   it('keeps lifecycle updates stable within a turn and distinct across turns', async () => {
-    const { store, workspace, world, session, employee } = await fixture()
-    for (const traceTurnId of ['turn-1', 'turn-2']) {
-      store.appendDomainEvent({
-        workspaceId: workspace.id,
-        worldId: world.id,
-        sessionId: session.id,
-        type: 'turn.started',
-        actorId: employee.id,
-        actorKind: 'employee',
-        payload: { source: 'test', sourceSessionId: 'shared-runtime-session', sourceSequence: 1, traceTurnId },
-      })
-      store.appendDomainEvent({
-        workspaceId: workspace.id,
-        worldId: world.id,
-        sessionId: session.id,
-        type: 'turn.completed',
-        actorId: employee.id,
-        actorKind: 'employee',
-        payload: { source: 'test', sourceSessionId: 'shared-runtime-session', sourceSequence: 2, traceTurnId },
-      })
-    }
+    const context = await fixture()
+    const { store, workspace, world, session, employee } = context
+    completeAgentRun(store, context, '第一轮判断摘要')
+    completeAgentRun(store, context, '第二轮判断摘要')
     const service = new WorldTraceService({ store, actions: new MemoryActions() })
-    const turns = (await service.list(world.id, { category: 'agent', actorId: employee.id, limit: 200 })).items
-      .filter((entry) => entry.summary.includes('本轮处理'))
+    const turns = (await service.list(world.id, { actorId: employee.id, limit: 200 })).items
+      .filter((entry) => entry.sourceKind === 'agent-run')
     expect(turns).toHaveLength(2)
     expect(new Set(turns.map((entry) => entry.id)).size).toBe(2)
     expect(turns.every((entry) => entry.status === 'success')).toBe(true)
@@ -213,28 +218,14 @@ describe('World Trace projection', () => {
   })
 
   it('returns only new or updated durable facts after a live checkpoint', async () => {
-    const { store, workspace, world, session, employee } = await fixture()
+    const context = await fixture()
+    const { store, world } = context
     const service = new WorldTraceService({ store, actions: new MemoryActions() })
     const checkpoint = await service.checkpoint(world.id)
-    store.appendDomainEvent({
-      workspaceId: workspace.id,
-      worldId: world.id,
-      sessionId: session.id,
-      type: 'task.started',
-      actorId: employee.id,
-      actorKind: 'employee',
-    })
-    store.appendDomainEvent({
-      workspaceId: workspace.id,
-      worldId: world.id,
-      sessionId: session.id,
-      type: 'task.completed',
-      actorId: employee.id,
-      actorKind: 'employee',
-    })
+    completeAgentRun(store, context)
     const changes = await service.changesSince(world.id, checkpoint)
-    expect(changes.filter((entry) => entry.taskId !== undefined)).toEqual([
-      expect.objectContaining({ category: 'task', status: 'success', summary: '真实任务已完成' }),
+    expect(changes.filter((entry) => entry.sourceKind === 'agent-run')).toEqual([
+      expect.objectContaining({ status: 'success', reasoningSummary: '先核对事实，再执行工具。' }),
     ])
   })
 })

--- a/packages/web/src/components/world-trace/WorldTraceFilters.tsx
+++ b/packages/web/src/components/world-trace/WorldTraceFilters.tsx
@@ -1,3 +1,4 @@
+import { CalendarBlank, MagnifyingGlass } from '@phosphor-icons/react'
 import type { WorldTraceCategory, WorldTraceStatus } from '@dsh-cyber/contracts'
 
 import type { CyberEmployee } from '../../types.js'
@@ -6,6 +7,8 @@ export interface TraceFilters {
   category: '' | WorldTraceCategory
   status: '' | WorldTraceStatus
   actorId: string
+  date: string
+  search: string
 }
 
 export function WorldTraceFilters({ value, employees, onChange }: {
@@ -14,14 +17,16 @@ export function WorldTraceFilters({ value, employees, onChange }: {
   onChange(value: TraceFilters): void
 }) {
   return <div className="world-trace-filters" aria-label="筛选世界轨迹">
-    <label><span>类型</span><select value={value.category} onChange={(event) => onChange({ ...value, category: event.target.value as TraceFilters['category'] })}>
-      <option value="">全部</option><option value="agent">角色</option><option value="tool">工具</option><option value="skill">技能</option><option value="task">任务</option><option value="collaboration">协作</option><option value="world">世界</option><option value="schedule">日程</option><option value="system">系统</option>
+    <label className="world-trace-filters__search"><span>搜索轨迹</span><span className="world-trace-control"><MagnifyingGlass size={16} aria-hidden="true" /><input type="search" value={value.search} maxLength={120} placeholder="搜索判断、工具或模型" onChange={(event) => onChange({ ...value, search: event.target.value })} /></span></label>
+    <label><span>日期</span><span className="world-trace-control"><CalendarBlank size={16} aria-hidden="true" /><input type="date" value={value.date} onChange={(event) => onChange({ ...value, date: event.target.value })} /></span></label>
+    <label><span>角色</span><select value={value.actorId} onChange={(event) => onChange({ ...value, actorId: event.target.value })}>
+      <option value="">全部角色</option>{employees.map((employee) => <option key={employee.id} value={employee.id}>{employee.displayName}</option>)}
+    </select></label>
+    <label><span>内容</span><select value={value.category} onChange={(event) => onChange({ ...value, category: event.target.value as TraceFilters['category'] })}>
+      <option value="">全部内容</option><option value="agent">分析</option><option value="tool">工具调度</option><option value="skill">技能</option><option value="task">任务</option><option value="collaboration">协作</option><option value="world">世界</option><option value="schedule">日程</option><option value="system">系统</option>
     </select></label>
     <label><span>状态</span><select value={value.status} onChange={(event) => onChange({ ...value, status: event.target.value as TraceFilters['status'] })}>
-      <option value="">全部</option><option value="running">进行中</option><option value="pending">待处理</option><option value="waiting">等待中</option><option value="success">已完成</option><option value="failed">失败</option><option value="cancelled">已取消</option><option value="info">记录</option>
-    </select></label>
-    <label><span>角色</span><select value={value.actorId} onChange={(event) => onChange({ ...value, actorId: event.target.value })}>
-      <option value="">全部</option><option value="owner">你</option>{employees.map((employee) => <option key={employee.id} value={employee.id}>{employee.displayName}</option>)}
+      <option value="">全部状态</option><option value="running">进行中</option><option value="success">已完成</option><option value="failed">失败</option><option value="pending">待处理</option><option value="waiting">等待中</option><option value="cancelled">已取消</option><option value="info">记录</option>
     </select></label>
   </div>
 }

--- a/packages/web/src/components/world-trace/WorldTraceItem.tsx
+++ b/packages/web/src/components/world-trace/WorldTraceItem.tsx
@@ -1,41 +1,36 @@
 import {
-  ArrowsClockwise,
-  CaretDown,
-  CheckCircle,
-  CircleNotch,
-  Clock,
-  GearSix,
-  GlobeHemisphereWest,
-  Robot,
-  Sparkle,
-  UsersThree,
-  WarningCircle,
-  Wrench,
+  ArrowsClockwise, CaretDown, CheckCircle, CircleNotch, Clock, GearSix,
+  GlobeHemisphereWest, Robot, Sparkle, UsersThree, WarningCircle, Wrench,
 } from '@phosphor-icons/react'
 import type { WorldTraceEntry } from '@dsh-cyber/contracts'
 
 import type { CyberEmployee } from '../../types.js'
 
 const categoryLabel: Record<WorldTraceEntry['category'], string> = {
-  agent: '角色', tool: '工具', skill: '技能', task: '任务', collaboration: '协作', world: '世界', schedule: '日程', system: '系统',
+  agent: '角色运行', tool: '角色运行', skill: '技能', task: '任务', collaboration: '协作', world: '世界', schedule: '日程', system: '系统',
 }
-
 const statusLabel: Record<WorldTraceEntry['status'], string> = {
   pending: '待处理', running: '进行中', waiting: '等待中', success: '已完成', failed: '失败', cancelled: '已取消', info: '记录',
 }
 
 export function WorldTraceItem({ entry, employees }: { entry: WorldTraceEntry; employees: CyberEmployee[] }) {
   const Icon = categoryIcon(entry.category)
-  const actor = entry.actorId === 'owner' ? '你' : employees.find((employee) => employee.id === entry.actorId)?.displayName
+  const actor = employees.find((employee) => employee.id === entry.actorId)?.displayName
+  const hasDetails = Boolean(entry.reasoningSummary || entry.detail || entry.tools?.length)
   const content = <>
     <header><span>{categoryLabel[entry.category]}</span><time dateTime={entry.updatedAt}>{formatTraceTime(entry.updatedAt)}</time></header>
     <strong>{entry.summary}</strong>
-    <div className="world-trace-item__meta"><span className={`trace-status trace-status--${entry.status}`}>{statusIcon(entry.status)}{statusLabel[entry.status]}</span>{actor === undefined ? null : <span>{actor}</span>}</div>
+    <div className="world-trace-item__meta"><span className={`trace-status trace-status--${entry.status}`}>{statusIcon(entry.status)}{statusLabel[entry.status]}</span>{actor === undefined ? null : <span>{actor}</span>}{entry.durationMs === undefined ? null : <span>{formatDuration(entry.durationMs)}</span>}{entry.tokenUsage === undefined ? null : <span>{entry.tokenUsage.total.toLocaleString('zh-CN')} Token</span>}</div>
   </>
   return <li className={`world-trace-item world-trace-item--${entry.status}`}>
     <span className="world-trace-item__rail" aria-hidden="true" />
     <span className="world-trace-item__icon" aria-hidden="true"><Icon size={17} /></span>
-    {entry.detail === undefined ? <article>{content}</article> : <article className="world-trace-item__expandable"><details><summary><div className="world-trace-item__summary">{content}</div><span className="world-trace-item__expand-label">{entry.category === 'agent' ? '展开推理' : entry.category === 'tool' ? '展开工具详情' : '展开详情'}<CaretDown size={14} /></span></summary><div className="world-trace-item__detail"><strong>{entry.category === 'agent' ? '推理摘要' : entry.category === 'tool' ? '工具记录' : '事实详情'}</strong><p>{entry.detail}</p></div></details></article>}
+    {!hasDetails ? <article>{content}</article> : <article className="world-trace-item__expandable"><details><summary><div className="world-trace-item__summary">{content}</div><span className="world-trace-item__expand-label">查看过程<CaretDown size={14} /></span></summary><div className="world-trace-item__detail">
+      {entry.reasoningSummary ? <section><strong>判断摘要</strong><p>{entry.reasoningSummary}</p></section> : null}
+      {entry.tools?.length ? <section><strong>工具调度</strong><ol className="world-trace-tools">{entry.tools.map((tool) => <li key={tool.callId} className={`is-${tool.status}`}>{tool.status === 'running' ? <CircleNotch size={14} className="spin" /> : tool.status === 'failed' ? <WarningCircle size={14} /> : <CheckCircle size={14} weight="fill" />}<span>{tool.label}</span><small>{tool.status === 'running' ? '执行中' : tool.status === 'failed' ? '失败' : '完成'}</small></li>)}</ol></section> : null}
+      {entry.detail ? <section><strong>运行说明</strong><p>{entry.detail}</p></section> : null}
+      {entry.modelId || entry.provider || entry.tokenUsage ? <section className="world-trace-usage"><strong>模型用量</strong><dl>{entry.provider ? <><dt>服务</dt><dd>{entry.provider}</dd></> : null}{entry.modelId ? <><dt>模型</dt><dd>{entry.modelId}</dd></> : null}{entry.tokenUsage ? <><dt>输入</dt><dd>{entry.tokenUsage.prompt.toLocaleString('zh-CN')}</dd><dt>输出</dt><dd>{entry.tokenUsage.completion.toLocaleString('zh-CN')}</dd><dt>合计</dt><dd>{entry.tokenUsage.total.toLocaleString('zh-CN')} Token</dd></> : null}</dl></section> : null}
+    </div></details></article>}
   </li>
 }
 
@@ -54,5 +49,9 @@ function statusIcon(status: WorldTraceEntry['status']) {
 function formatTraceTime(value: string): string {
   const date = new Date(value)
   if (Number.isNaN(date.valueOf())) return '时间未知'
-  return date.toLocaleTimeString('zh-CN', { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+  return date.toLocaleString('zh-CN', { month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+}
+
+function formatDuration(value: number): string {
+  return value < 1_000 ? `${value} 毫秒` : `${(value / 1_000).toFixed(value < 10_000 ? 1 : 0)} 秒`
 }

--- a/packages/web/src/components/world-trace/WorldTracePanel.tsx
+++ b/packages/web/src/components/world-trace/WorldTracePanel.tsx
@@ -1,6 +1,6 @@
 import { ArrowClockwise, Path } from '@phosphor-icons/react'
-import { useMemo, useState } from 'react'
-import type { World } from '@dsh-cyber/contracts'
+import { useDeferredValue, useMemo, useState } from 'react'
+import type { World, WorldTraceQuery } from '@dsh-cyber/contracts'
 
 import type { CyberEmployee } from '../../types.js'
 import { WorldTraceFilters, type TraceFilters } from './WorldTraceFilters.js'
@@ -8,19 +8,41 @@ import { WorldTraceTimeline } from './WorldTraceTimeline.js'
 import { useWorldTrace } from './useWorldTrace.js'
 import './world-trace.css'
 
+const EMPTY_FILTERS: TraceFilters = { category: '', status: '', actorId: '', date: '', search: '' }
+
 export function WorldTracePanel({ world, employees, demoMode }: { world: World; employees: CyberEmployee[]; demoMode: boolean }) {
-  const trace = useWorldTrace(world.id, demoMode)
-  const [filters, setFilters] = useState<TraceFilters>({ category: '', status: '', actorId: '' })
-  const entries = useMemo(() => trace.entries
-    .filter((entry) => !filters.category || entry.category === filters.category)
-    .filter((entry) => !filters.status || entry.status === filters.status)
-    .filter((entry) => !filters.actorId || entry.actorId === filters.actorId), [filters, trace.entries])
+  const [filters, setFilters] = useState<TraceFilters>(EMPTY_FILTERS)
+  const deferredSearch = useDeferredValue(filters.search.trim())
+  const query = useMemo<WorldTraceQuery>(() => ({
+    ...(filters.category ? { category: filters.category } : {}),
+    ...(filters.status ? { status: filters.status } : {}),
+    ...(filters.actorId ? { actorId: filters.actorId } : {}),
+    ...(filters.date ? { date: filters.date } : {}),
+    ...(deferredSearch ? { search: deferredSearch } : {}),
+  }), [deferredSearch, filters.actorId, filters.category, filters.date, filters.status])
+  const trace = useWorldTrace(world.id, demoMode, query)
+  const tokenByActor = useMemo(() => {
+    const totals = new Map<string, number>()
+    for (const entry of trace.entries) {
+      if (entry.actorId && entry.tokenUsage) totals.set(entry.actorId, (totals.get(entry.actorId) ?? 0) + entry.tokenUsage.total)
+    }
+    return [...totals.entries()].sort((left, right) => right[1] - left[1])
+  }, [trace.entries])
+  const totalTokens = tokenByActor.reduce((total, [, count]) => total + count, 0)
 
   return <section className="world-trace-panel" aria-label={`${world.name}的世界轨迹`}>
-    <header className="world-trace-panel__header"><span className="world-trace-panel__mark"><Path size={20} /></span><span><strong>世界轨迹</strong><small>只展示经过脱敏的真实执行事实</small></span><button type="button" className="icon-button" aria-label="刷新世界轨迹" disabled={trace.loading} onClick={() => void trace.refresh()}><ArrowClockwise size={17} className={trace.loading ? 'spin' : ''} /></button></header>
+    <header className="world-trace-panel__header"><span className="world-trace-panel__mark"><Path size={20} /></span><span><strong>世界轨迹</strong><small>可读的判断摘要、工具调度与实际用量</small></span><button type="button" className="icon-button" aria-label="刷新世界轨迹" disabled={trace.loading} onClick={() => void trace.refresh()}><ArrowClockwise size={17} className={trace.loading ? 'spin' : ''} /></button></header>
     <WorldTraceFilters value={filters} employees={employees} onChange={setFilters} />
     {trace.error === undefined ? null : <div className="world-trace-error" role="alert">{trace.error}</div>}
-    <div className="world-trace-summary"><strong>{entries.length}</strong><span>条可见轨迹</span><i />实时回补已开启</div>
-    <WorldTraceTimeline entries={entries} employees={employees} />
+    <div className="world-trace-summary"><strong>{trace.entries.length}</strong><span>条轨迹</span><span className="world-trace-summary__tokens">{totalTokens > 0 ? `${formatTokenCount(totalTokens)} Token` : 'Token 暂无返回'}</span><i />实时更新</div>
+    {tokenByActor.length === 0 ? null : <div className="world-trace-token-strip" aria-label="按角色统计 Token">
+      {tokenByActor.map(([actorId, total]) => <button key={actorId} type="button" className={filters.actorId === actorId ? 'is-active' : ''} onClick={() => setFilters((current) => ({ ...current, actorId: current.actorId === actorId ? '' : actorId }))}><span>{employees.find((employee) => employee.id === actorId)?.displayName ?? '未知角色'}</span><strong>{formatTokenCount(total)}</strong></button>)}
+    </div>}
+    <WorldTraceTimeline entries={trace.entries} employees={employees} />
+    {trace.nextCursor === undefined ? null : <footer className="world-trace-panel__footer"><button type="button" disabled={trace.loadingMore} onClick={() => void trace.loadMore()}>{trace.loadingMore ? '正在加载…' : '加载更早轨迹'}</button></footer>}
   </section>
+}
+
+function formatTokenCount(value: number): string {
+  return value >= 1_000 ? `${(value / 1_000).toFixed(value >= 10_000 ? 0 : 1)}k` : value.toLocaleString('zh-CN')
 }

--- a/packages/web/src/components/world-trace/useWorldTrace.ts
+++ b/packages/web/src/components/world-trace/useWorldTrace.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
-import type { WorldTraceEntry, WorldTracePage } from '@dsh-cyber/contracts'
+import type { WorldTraceEntry, WorldTracePage, WorldTraceQuery } from '@dsh-cyber/contracts'
 
 import { api } from '../../api.js'
 import { subscribeWorldLive } from '../../world-live-client.js'
@@ -8,45 +8,82 @@ import { subscribeWorldLive } from '../../world-live-client.js'
 export interface UseWorldTraceResult {
   entries: WorldTraceEntry[]
   loading: boolean
+  loadingMore: boolean
+  nextCursor?: string
   error?: string
   refresh(): Promise<void>
+  loadMore(): Promise<void>
 }
 
-export function useWorldTrace(worldId: string, demoMode: boolean): UseWorldTraceResult {
+export function useWorldTrace(worldId: string, demoMode: boolean, query: WorldTraceQuery = {}): UseWorldTraceResult {
+  const queryKey = useMemo(() => JSON.stringify(query), [query])
+  const activeQuery = useMemo(() => JSON.parse(queryKey) as WorldTraceQuery, [queryKey])
   const [entries, setEntries] = useState<WorldTraceEntry[]>(() => demoMode ? demoTrace(worldId) : [])
   const [loading, setLoading] = useState(!demoMode)
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [nextCursor, setNextCursor] = useState<string>()
   const [error, setError] = useState<string>()
+  const requestGeneration = useRef(0)
+
+  const fetchPage = useCallback(async (after?: string) => {
+    const params = new URLSearchParams({ limit: '50' })
+    for (const [key, value] of Object.entries(activeQuery)) {
+      if (value !== undefined && value !== '') params.set(key, String(value))
+    }
+    if (after !== undefined) params.set('after', after)
+    return api<WorldTracePage>(`/api/worlds/${encodeURIComponent(worldId)}/trace?${params.toString()}`)
+  }, [activeQuery, worldId])
 
   const refresh = useCallback(async () => {
+    const generation = ++requestGeneration.current
     if (demoMode) {
-      setEntries(demoTrace(worldId))
+      setEntries(demoTrace(worldId).filter((entry) => matchesQuery(entry, activeQuery)))
+      setNextCursor(undefined)
       return
     }
     setLoading(true)
     setError(undefined)
     try {
-      const result = await api<WorldTracePage>(`/api/worlds/${encodeURIComponent(worldId)}/trace?limit=200`)
-      // A live event can arrive while this request is in flight. Merge instead of
-      // replacing so an older history response cannot erase that newer fact.
+      const result = await fetchPage()
+      if (generation !== requestGeneration.current) return
       setEntries((current) => mergeTraceEntries(current, result.items))
+      setNextCursor(result.nextCursor)
     } catch (cause) {
-      setError(cause instanceof Error ? cause.message : '世界轨迹加载失败')
+      if (generation === requestGeneration.current) setError(cause instanceof Error ? cause.message : '世界轨迹加载失败')
     } finally {
-      setLoading(false)
+      if (generation === requestGeneration.current) setLoading(false)
     }
-  }, [demoMode, worldId])
+  }, [activeQuery, demoMode, fetchPage, worldId])
+
+  const loadMore = useCallback(async () => {
+    if (demoMode || nextCursor === undefined || loadingMore) return
+    const generation = requestGeneration.current
+    setLoadingMore(true)
+    try {
+      const result = await fetchPage(nextCursor)
+      if (generation !== requestGeneration.current) return
+      setEntries((current) => mergeTraceEntries(current, result.items))
+      setNextCursor(result.nextCursor)
+    } catch (cause) {
+      if (generation === requestGeneration.current) setError(cause instanceof Error ? cause.message : '更早轨迹加载失败')
+    } finally {
+      if (generation === requestGeneration.current) setLoadingMore(false)
+    }
+  }, [demoMode, fetchPage, loadingMore, nextCursor])
 
   useEffect(() => {
-    setEntries(demoMode ? demoTrace(worldId) : [])
+    requestGeneration.current += 1
+    setEntries([])
+    setNextCursor(undefined)
     void refresh()
-  }, [demoMode, refresh, worldId])
+  }, [queryKey, refresh, worldId])
 
   useEffect(() => {
     if (demoMode) return
     const onTrace = (raw: Event) => {
       try {
         const entry = JSON.parse((raw as MessageEvent<string>).data) as WorldTraceEntry
-        if (entry.worldId !== worldId) return
+        if (entry.worldId !== worldId || !matchesQuery(entry, activeQuery)) return
         setEntries((current) => mergeTraceEntries(current, [entry]))
       } catch {
         // History refresh is authoritative after malformed or interrupted transient data.
@@ -59,41 +96,64 @@ export function useWorldTrace(worldId: string, demoMode: boolean): UseWorldTrace
       unsubscribeTrace()
       unsubscribeReady()
     }
-  }, [demoMode, refresh, worldId])
+  }, [activeQuery, demoMode, refresh, worldId])
 
-  return { entries, loading, ...(error === undefined ? {} : { error }), refresh }
+  return { entries, loading, loadingMore, ...(nextCursor === undefined ? {} : { nextCursor }), ...(error === undefined ? {} : { error }), refresh, loadMore }
 }
 
-export function mergeTraceEntries(
-  current: WorldTraceEntry[],
-  incoming: WorldTraceEntry[],
-): WorldTraceEntry[] {
+export function mergeTraceEntries(current: WorldTraceEntry[], incoming: WorldTraceEntry[]): WorldTraceEntry[] {
   const merged = new Map<string, WorldTraceEntry>(current.map((entry) => [entry.id, entry]))
   for (const entry of incoming) {
     const existing = merged.get(entry.id)
     if (existing === undefined || existing.updatedAt.localeCompare(entry.updatedAt) <= 0) {
+      const tools = new Map((existing?.tools ?? []).map((tool) => [tool.callId, tool]))
+      for (const tool of entry.tools ?? []) tools.set(tool.callId, { ...tools.get(tool.callId), ...tool })
       merged.set(entry.id, existing === undefined ? entry : {
         ...existing,
         ...entry,
         createdAt: existing.createdAt.localeCompare(entry.createdAt) <= 0 ? existing.createdAt : entry.createdAt,
+        ...(tools.size === 0 ? {} : { tools: [...tools.values()] }),
       })
     }
   }
   return [...merged.values()].sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id))
 }
 
+function matchesQuery(entry: WorldTraceEntry, query: WorldTraceQuery): boolean {
+  if (query.category && entry.category !== query.category) return false
+  if (query.status && entry.status !== query.status) return false
+  if (query.actorId && entry.actorId !== query.actorId) return false
+  if (query.date && localCalendarDate(entry.createdAt) !== query.date) return false
+  if (query.search) {
+    const search = query.search.toLocaleLowerCase('zh-CN')
+    const text = [entry.summary, entry.detail, entry.reasoningSummary, entry.modelId, entry.provider,
+      ...(entry.tools ?? []).flatMap((tool) => [tool.label, tool.name])]
+      .filter((value): value is string => typeof value === 'string').join('\n').toLocaleLowerCase('zh-CN')
+    if (!text.includes(search)) return false
+  }
+  return true
+}
+
+function localCalendarDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.valueOf())) return ''
+  return `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, '0')}-${String(date.getDate()).padStart(2, '0')}`
+}
+
 function demoTrace(worldId: string): WorldTraceEntry[] {
   const base = Date.now() - 5 * 60_000
-  const entries: Array<Omit<WorldTraceEntry, 'worldId' | 'sourceKind' | 'createdAt' | 'updatedAt'> & { offset: number }> = [
-    { id: 'demo-request', category: 'task', status: 'success', summary: '用户提交了新的会话请求', actorId: 'owner', sourceId: 'demo-message', offset: 0 },
-    { id: 'demo-turn', category: 'agent', status: 'success', summary: '角色已完成本轮处理', actorId: 'employee-demo', sourceId: 'demo-turn', offset: 35_000 },
-    { id: 'demo-tool', category: 'tool', status: 'success', summary: '工具执行完成', detail: '检索世界档案', actorId: 'employee-demo', sourceId: 'demo-tool', offset: 48_000 },
-    { id: 'demo-skill', category: 'skill', status: 'success', summary: '灯光控制技能执行成功', actorId: 'employee-demo', skillId: 'world.lights', sourceId: 'demo-skill', offset: 70_000 },
-    { id: 'demo-world', category: 'world', status: 'success', summary: '世界灯光已切换', actorId: 'owner', sourceId: 'demo-world', offset: 92_000 },
+  return [
+    {
+      id: 'demo-run', worldId, category: 'tool', status: 'success', summary: '完成处理，调度了 2 个工具',
+      actorId: 'employee-demo', workTurnId: 'demo-turn', sourceKind: 'agent-run', sourceId: 'demo-run',
+      reasoningSummary: '先核对世界档案中的目标，再读取相关文件，最后根据两处证据整理结论。',
+      tools: [
+        { callId: 'demo-read', name: 'read_file', label: '读取信息', status: 'success' },
+        { callId: 'demo-search', name: 'web_search', label: '搜索并核对网络信息', status: 'success' },
+      ],
+      tokenUsage: { prompt: 1_280, completion: 436, total: 1_716 }, durationMs: 4_860,
+      modelId: 'deepseek-chat', provider: 'DeepSeek',
+      createdAt: new Date(base).toISOString(), updatedAt: new Date(base + 48_000).toISOString(),
+    },
   ]
-  const projected: WorldTraceEntry[] = entries.map(({ offset, ...entry }) => {
-    const timestamp = new Date(base + offset).toISOString()
-    return { ...entry, worldId, sourceKind: entry.category === 'skill' ? 'skill-action' : 'domain-event', createdAt: timestamp, updatedAt: timestamp }
-  })
-  return projected.sort((left, right) => right.createdAt.localeCompare(left.createdAt) || right.id.localeCompare(left.id))
 }

--- a/packages/web/src/components/world-trace/world-trace.css
+++ b/packages/web/src/components/world-trace/world-trace.css
@@ -1,44 +1,44 @@
-.world-trace-panel { height: 100%; min-height: 0; display: grid; grid-template-rows: auto auto auto 1fr; color: var(--text); background: linear-gradient(180deg, color-mix(in srgb, var(--surface-1) 92%, var(--accent) 8%), var(--surface-0)); }
+.world-trace-panel {
+  --trace-control-height: 44px;
+  --trace-pad: 16px;
+  --trace-gap: 10px;
+  height: 100%; min-height: 0; display: flex; flex-direction: column; color: var(--text);
+  background: linear-gradient(180deg, color-mix(in srgb, var(--surface-1) 92%, var(--accent) 8%), var(--surface-0));
+}
 .world-trace-panel__header { min-height: 72px; display: flex; align-items: center; gap: 12px; padding: 14px 18px; border-bottom: 1px solid var(--border); }
 .world-trace-panel__header > span:nth-child(2) { display: grid; gap: 3px; min-width: 0; flex: 1; }
-.world-trace-panel__header strong { font-size: 16px; }
-.world-trace-panel__header small { color: var(--text-muted); font-size: 12px; }
+.world-trace-panel__header strong { font-size: 16px; }.world-trace-panel__header small { color: var(--text-muted); font-size: 12px; }
 .world-trace-panel__mark { width: 38px; height: 38px; display: grid; place-items: center; color: var(--accent); border: 1px solid color-mix(in srgb, var(--accent) 48%, transparent); background: color-mix(in srgb, var(--accent) 10%, transparent); }
-.world-trace-filters { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 8px; padding: 12px 16px; border-bottom: 1px solid var(--border); }
-.world-trace-filters label { display: grid; gap: 5px; color: var(--text-muted); font-size: 12px; }
-.world-trace-filters select { width: 100%; min-height: 34px; padding: 0 9px; color: var(--text); background: var(--surface-1); border: 1px solid var(--border-strong); font: inherit; font-size: 13px; }
-.world-trace-summary { min-height: 42px; display: flex; align-items: center; gap: 7px; padding: 0 18px; color: var(--text-muted); font-size: 12px; border-bottom: 1px solid var(--border); }
-.world-trace-summary strong { color: var(--text); font-size: 15px; }
+.world-trace-filters { display: grid; grid-template-columns: minmax(180px, 1.7fr) repeat(4, minmax(108px, 1fr)); gap: var(--trace-gap); padding: 12px var(--trace-pad); border-bottom: 1px solid var(--border); }
+.world-trace-filters label { display: grid; gap: 5px; min-width: 0; color: var(--text-muted); font-size: 12px; }
+.world-trace-filters select, .world-trace-control { width: 100%; min-width: 0; height: var(--trace-control-height); color: var(--text); background: var(--surface-1); border: 1px solid var(--border-strong); font: inherit; font-size: 13px; }
+.world-trace-filters select { padding: 0 10px; }.world-trace-control { display: flex; align-items: center; gap: 8px; padding: 0 11px; }
+.world-trace-control svg { flex: 0 0 auto; color: var(--text-muted); }.world-trace-control input { min-width: 0; flex: 1; border: 0; outline: 0; color: var(--text); background: transparent; font: inherit; }
+.world-trace-control input::placeholder { color: var(--text-muted); }.world-trace-control:focus-within, .world-trace-filters select:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.world-trace-summary { min-height: 44px; display: flex; align-items: center; gap: 7px; padding: 0 18px; color: var(--text-muted); font-size: 12px; border-bottom: 1px solid var(--border); }
+.world-trace-summary strong { color: var(--text); font-size: 15px; }.world-trace-summary__tokens { margin-left: 6px; color: var(--text-soft); }
 .world-trace-summary i { width: 6px; height: 6px; margin-left: auto; border-radius: 50%; background: var(--success); box-shadow: 0 0 10px color-mix(in srgb, var(--success) 70%, transparent); }
-.world-trace-timeline-wrap { position: relative; min-height: 0; }
-.world-trace-timeline { height: 100%; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; }
+.world-trace-token-strip { display: flex; gap: 8px; overflow-x: auto; padding: 9px var(--trace-pad); border-bottom: 1px solid var(--border); scrollbar-width: thin; }
+.world-trace-token-strip button { min-height: 44px; display: flex; align-items: center; gap: 8px; flex: 0 0 auto; padding: 0 11px; color: var(--text-muted); border: 1px solid var(--border); background: var(--surface-1); cursor: pointer; }
+.world-trace-token-strip button strong { color: var(--text); }.world-trace-token-strip button.is-active { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }
+.world-trace-timeline-wrap { position: relative; min-height: 0; flex: 1; }.world-trace-timeline { height: 100%; overflow: auto; overscroll-behavior: contain; scrollbar-gutter: stable; }
 .world-trace-timeline ol { list-style: none; margin: 0; padding: 18px 18px 32px; }
-.world-trace-item { position: relative; display: grid; grid-template-columns: 34px minmax(0, 1fr); gap: 10px; padding: 0 0 18px; content-visibility: auto; contain-intrinsic-size: 104px; }
-.world-trace-item__rail { position: absolute; left: 16px; top: 34px; bottom: 0; width: 1px; background: var(--border-strong); }
-.world-trace-item:last-child .world-trace-item__rail { display: none; }
+.world-trace-item { position: relative; display: grid; grid-template-columns: 34px minmax(0, 1fr); gap: 10px; padding: 0 0 18px; content-visibility: auto; contain-intrinsic-size: 118px; }
+.world-trace-item__rail { position: absolute; left: 16px; top: 34px; bottom: 0; width: 1px; background: var(--border-strong); }.world-trace-item:last-child .world-trace-item__rail { display: none; }
 .world-trace-item__icon { position: relative; z-index: 1; width: 34px; height: 34px; display: grid; place-items: center; color: var(--text-muted); border: 1px solid var(--border-strong); background: var(--surface-1); }
-.world-trace-item--running .world-trace-item__icon, .world-trace-item--pending .world-trace-item__icon { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }
-.world-trace-item--failed .world-trace-item__icon { color: var(--danger); }
-.world-trace-item > article { min-width: 0; padding: 10px 12px 11px; border: 1px solid var(--border); background: color-mix(in srgb, var(--surface-1) 88%, transparent); }
-.world-trace-item article header { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 7px; color: var(--text-muted); font-size: 12px; }
-.world-trace-item article strong { display: block; color: var(--text); font-size: 14px; line-height: 1.45; overflow-wrap: anywhere; }
-.world-trace-item__meta { display: flex; align-items: center; gap: 9px; margin-top: 9px; color: var(--text-muted); font-size: 12px; }
-.trace-status { display: inline-flex; align-items: center; gap: 4px; }
+.world-trace-item--running .world-trace-item__icon, .world-trace-item--pending .world-trace-item__icon { color: var(--accent); border-color: color-mix(in srgb, var(--accent) 55%, var(--border)); }.world-trace-item--failed .world-trace-item__icon { color: var(--danger); }
+.world-trace-item > article { min-width: 0; padding: 11px 13px; border: 1px solid var(--border); background: color-mix(in srgb, var(--surface-1) 88%, transparent); }
+.world-trace-item article header { display: flex; justify-content: space-between; gap: 12px; margin-bottom: 7px; color: var(--text-muted); font-size: 12px; }.world-trace-item article > strong, .world-trace-item__summary > strong { display: block; color: var(--text); font-size: 14px; line-height: 1.45; overflow-wrap: anywhere; }
+.world-trace-item__meta { display: flex; flex-wrap: wrap; align-items: center; gap: 5px 10px; margin-top: 9px; color: var(--text-muted); font-size: 12px; }.trace-status { display: inline-flex; align-items: center; gap: 4px; }
 .trace-status--success { color: var(--success); }.trace-status--failed { color: var(--danger); }.trace-status--running, .trace-status--pending { color: var(--accent); }
-.world-trace-item__expandable { padding: 0 !important; }
-.world-trace-item__expandable details { height: 100%; }
-.world-trace-item__expandable summary { min-height: 94px; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 12px; padding: 10px 12px 11px; cursor: pointer; list-style: none; }
-.world-trace-item__expandable summary::-webkit-details-marker { display: none; }
-.world-trace-item__expandable summary:hover { background: color-mix(in srgb, var(--accent) 5%, transparent); }
-.world-trace-item__expandable summary:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
-.world-trace-item__summary { min-width: 0; }
-.world-trace-item__expand-label { display: inline-flex; align-items: center; gap: 4px; padding-bottom: 1px; color: var(--text-muted); font-size: 12px; white-space: nowrap; }
-.world-trace-item__expand-label svg { transition: transform 150ms ease; }
-.world-trace-item__expandable details[open] .world-trace-item__expand-label svg { transform: rotate(180deg); }
-.world-trace-item__detail { padding: 12px; border-top: 1px solid var(--border); background: color-mix(in srgb, var(--surface-0) 80%, transparent); }
-.world-trace-item__detail > strong { color: var(--text-soft) !important; font-size: 12px !important; }
-.world-trace-item__detail p { margin: 7px 0 0; color: var(--text-soft); font-size: 13px; line-height: 1.65; white-space: pre-wrap; overflow-wrap: anywhere; }
-.world-trace-empty { min-height: 240px; display: grid; place-content: center; gap: 8px; padding: 28px; text-align: center; }
-.world-trace-empty strong { font-size: 15px; }.world-trace-empty span { max-width: 340px; color: var(--text-muted); font-size: 13px; line-height: 1.6; }
+.world-trace-item__expandable { padding: 0 !important; }.world-trace-item__expandable details { height: 100%; }.world-trace-item__expandable summary { min-height: 110px; display: grid; grid-template-columns: minmax(0, 1fr) auto; align-items: end; gap: 12px; padding: 11px 13px; cursor: pointer; list-style: none; }
+.world-trace-item__expandable summary::-webkit-details-marker { display: none; }.world-trace-item__expandable summary:hover { background: color-mix(in srgb, var(--accent) 5%, transparent); }.world-trace-item__expandable summary:focus-visible { outline: 2px solid var(--accent); outline-offset: -2px; }
+.world-trace-item__summary { min-width: 0; }.world-trace-item__expand-label { min-height: 32px; display: inline-flex; align-items: center; gap: 4px; color: var(--text-muted); font-size: 12px; white-space: nowrap; }.world-trace-item__expand-label svg { transition: transform 150ms ease; }.world-trace-item__expandable details[open] .world-trace-item__expand-label svg { transform: rotate(180deg); }
+.world-trace-item__detail { display: grid; gap: 16px; padding: 14px; border-top: 1px solid var(--border); background: color-mix(in srgb, var(--surface-0) 80%, transparent); }.world-trace-item__detail section { min-width: 0; }.world-trace-item__detail section > strong { color: var(--text-soft); font-size: 12px; }.world-trace-item__detail p { margin: 7px 0 0; color: var(--text-soft); font-size: 13px; line-height: 1.65; white-space: pre-wrap; overflow-wrap: anywhere; }
+.world-trace-tools { display: grid; gap: 6px; margin: 8px 0 0; padding: 0; list-style: none; }.world-trace-tools li { min-height: 38px; display: grid; grid-template-columns: 18px minmax(0, 1fr) auto; align-items: center; gap: 7px; padding: 0 9px; color: var(--text-soft); border: 1px solid var(--border); background: var(--surface-1); }.world-trace-tools li svg { color: var(--success); }.world-trace-tools li.is-failed svg { color: var(--danger); }.world-trace-tools li.is-running svg { color: var(--accent); }.world-trace-tools small { color: var(--text-muted); }
+.world-trace-usage dl { display: grid; grid-template-columns: minmax(70px, auto) minmax(0, 1fr); gap: 6px 12px; margin: 8px 0 0; font-size: 12px; }.world-trace-usage dt { color: var(--text-muted); }.world-trace-usage dd { min-width: 0; margin: 0; color: var(--text-soft); overflow-wrap: anywhere; }
+.world-trace-panel__footer { padding: 10px var(--trace-pad); border-top: 1px solid var(--border); }.world-trace-panel__footer button { width: 100%; min-height: 44px; color: var(--text-soft); border: 1px solid var(--border-strong); background: var(--surface-1); cursor: pointer; }.world-trace-panel__footer button:disabled { cursor: wait; opacity: .65; }
+.world-trace-empty { min-height: 240px; display: grid; place-content: center; gap: 8px; padding: 28px; text-align: center; }.world-trace-empty strong { font-size: 15px; }.world-trace-empty span { max-width: 340px; color: var(--text-muted); font-size: 13px; line-height: 1.6; }
 .world-trace-error { margin: 10px 16px 0; padding: 10px 12px; color: var(--danger); border: 1px solid color-mix(in srgb, var(--danger) 55%, transparent); background: color-mix(in srgb, var(--danger) 8%, transparent); font-size: 13px; }
-@media (max-width: 900px) { .world-trace-filters { grid-template-columns: 1fr; } }
+@media (max-width: 1100px) { .world-trace-filters { grid-template-columns: repeat(2, minmax(0, 1fr)); }.world-trace-filters__search { grid-column: 1 / -1; } }
+@media (max-width: 620px) { .world-trace-panel { --trace-pad: 12px; }.world-trace-filters { grid-template-columns: 1fr; }.world-trace-filters__search { grid-column: auto; }.world-trace-item__expandable summary { grid-template-columns: 1fr; }.world-trace-item__expand-label { min-height: 30px; justify-self: start; } }

--- a/packages/web/tests/world-trace-ui.test.ts
+++ b/packages/web/tests/world-trace-ui.test.ts
@@ -162,17 +162,18 @@ describe('Trace dock and live merge', () => {
   })
 
   it('renders reasoning and tool facts as keyboard-expandable cards', () => {
-    const reasoning = { ...trace('reasoning', 'info', '2026-08-23T00:02:00.000Z'), category: 'agent' as const, summary: '角色生成了推理摘要', detail: '先核对事实，再执行工具。' }
-    const tool = { ...trace('tool', 'success', '2026-08-23T00:01:00.000Z'), category: 'tool' as const, summary: '工具执行完成', detail: 'read_file' }
+    const reasoning = { ...trace('reasoning', 'info', '2026-08-23T00:02:00.000Z'), category: 'agent' as const, summary: '角色生成了推理摘要', reasoningSummary: '先核对事实，再执行工具。' }
+    const tool = { ...trace('tool', 'success', '2026-08-23T00:01:00.000Z'), category: 'tool' as const, summary: '工具执行完成', tools: [{ callId: 'read-1', name: 'read_file', label: '读取信息', status: 'success' as const }] }
     const html = renderToStaticMarkup(createElement('ol', {},
       createElement(WorldTraceItem, { entry: reasoning, employees: [] }),
       createElement(WorldTraceItem, { entry: tool, employees: [] }),
     ))
     expect(html).toContain('<details>')
-    expect(html).toContain('展开推理')
-    expect(html).toContain('展开工具详情')
+    expect(html.match(/查看过程/g)).toHaveLength(2)
+    expect(html).toContain('判断摘要')
+    expect(html).toContain('工具调度')
     expect(html).toContain('先核对事实，再执行工具。')
-    expect(html).toContain('read_file')
+    expect(html).toContain('读取信息')
   })
 })
 


### PR DESCRIPTION
## 变更

- 将每个 AgentRun 聚合为一条可读轨迹，合并判断摘要、工具调度和最终状态
- 新增真实 Token 用量采集，并按世界、角色、WorkTurn、AgentRun 归属
- 新增角色、日期、关键词、内容、状态筛选和最新优先游标分页
- 将 Harness 角色系统约定统一为中文，并明确只输出安全的公开判断摘要
- 移除聊天、日记、里程碑和重复生命周期产生的无用事迹
- 更新轨迹面板、公开架构文档和实现状态

## 验证

- `pnpm typecheck`
- `pnpm test`
- 76 个测试文件、326 项测试通过
- 生产构建通过

## 待补门禁

- 应用内浏览器安全策略阻止本机地址访问，三档视口截图和控制台记录尚未补齐
