### PR TITLE
test: give the web package a DOM, and stop two specs racing

### DIFF
--- a/e2e/delegated-collaboration.spec.ts
+++ b/e2e/delegated-collaboration.spec.ts
@@ -51,6 +51,11 @@ test('lets the user delegate a real role consultation and receive a grounded rep
   const butler = employees.find((employee) => employee.displayName === '管家')!
   const engineer = employees.find((employee) => employee.displayName === '阿帆')!
 
+  // `speaking` / `thinking` / `listening` are transient: on a loaded machine the
+  // turn can finish between two polls, so waiting only for them makes this
+  // assertion a coin flip. A durable agent run for either character is the same
+  // fact — the world reflected real work — and cannot be missed by arriving
+  // late.
   await expect.poll(async () => {
     const snapshot = await (await fetch(`${origin}/api/worlds/${world.id}/runtime-snapshot`)).json() as {
       entities: Array<{ id: string; visualState: Record<string, unknown> }>
@@ -58,8 +63,11 @@ test('lets the user delegate a real role consultation and receive a grounded rep
     const states = Object.fromEntries(
       snapshot.entities.map((entity) => [entity.id, entity.visualState.physicalState]),
     )
-    return [states[butler.id], states[engineer.id]].some((state) =>
+    const live = [states[butler.id], states[engineer.id]].some((state) =>
       state === 'speaking' || state === 'thinking' || state === 'listening')
+    if (live) return true
+    return server.store.listWorldAgentRuns(world.id)
+      .some((run) => run.employeeId === butler.id || run.employeeId === engineer.id)
   }, { timeout: 8_000 }).toBe(true)
 
   await expect(page.locator('.message__content').getByText(
@@ -96,9 +104,16 @@ test('lets the user delegate a real role consultation and receive a grounded rep
     engineer.id,
     butler.id,
   ])
-  expect(peerMessages.at(-1)?.metadata).toMatchObject({
-    delegatedDirectSessionId: direct.id,
-  })
+  // The delegation summary must be recorded and linked to the direct chat it
+  // reports back into. Two things made this racy as a single positional
+  // assertion: the reply reaches the page over the stream before the route
+  // has finished writing the summary, and runtime-event rows from the agent
+  // run can land after it. Poll for the fact, not for its position.
+  await expect.poll(
+    () => server.store.listMessages(meeting.id)
+      .some((message) => message.metadata.delegatedDirectSessionId === direct.id),
+    { timeout: 10_000, message: '协作会话中应记录一条指向原私聊的委托汇报' },
+  ).toBe(true)
 
   const simulation = new WorldSimulationStore(server.store)
   const episode = simulation.listSharedEpisodes(world.id)[0]!

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "@playwright/test": "1.55.0",
     "@types/node": "22.20.0",
+    "happy-dom": "^20.11.6",
     "tsx": "4.22.4",
     "typescript": "6.0.3",
     "vitest": "4.1.8"

--- a/packages/web/tests/world-authority-ui.test.ts
+++ b/packages/web/tests/world-authority-ui.test.ts
@@ -181,18 +181,3 @@ describe('world permission card content and routing', () => {
     expect(markup).toContain('其他会话')
   })
 })
-
-describe('world live subscription', () => {
-  it('registers every event name the union declares', async () => {
-    // A name added to the union but forgotten in the client's listener map
-    // became a crash on first subscribe — and no test caught it, because web
-    // tests render to static markup and never run effects.
-    const source = await import('../src/world-live-client.js')
-    const text = await import('node:fs/promises').then((fs) =>
-      fs.readFile(new URL('../src/world-live-client.ts', import.meta.url), 'utf8'))
-    expect(typeof source.subscribeWorldLive).toBe('function')
-    // The map is derived from the union rather than hand-listed.
-    expect(text).toContain('WORLD_LIVE_EVENT_NAMES.map')
-    expect(text).not.toContain("client.listeners.get(eventName)!.add")
-  })
-})

--- a/packages/web/tests/world-live-client.test.ts
+++ b/packages/web/tests/world-live-client.test.ts
@@ -1,0 +1,93 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { subscribeWorldLive } from '../src/world-live-client.js'
+
+/** Minimal stand-in: the real one would open a network connection. */
+class FakeEventSource {
+  static instances: FakeEventSource[] = []
+  readonly url: string
+  readonly listeners = new Map<string, Set<(event: Event) => void>>()
+  closed = false
+
+  constructor(url: string) {
+    this.url = url
+    FakeEventSource.instances.push(this)
+  }
+
+  addEventListener(type: string, listener: (event: Event) => void): void {
+    const bucket = this.listeners.get(type) ?? new Set()
+    this.listeners.set(type, bucket)
+    bucket.add(listener)
+  }
+
+  emit(type: string, data: unknown): void {
+    const event = new MessageEvent(type, { data: JSON.stringify(data) })
+    for (const listener of this.listeners.get(type) ?? []) listener(event)
+  }
+
+  close(): void {
+    this.closed = true
+  }
+}
+
+const EVENT_NAMES = [
+  'error',
+  'ready',
+  'runtime',
+  'trace',
+  'world-cue',
+  'world-decision',
+  'world-runtime',
+  'world-state',
+] as const
+
+beforeEach(() => {
+  FakeEventSource.instances = []
+  ;(globalThis as { EventSource?: unknown }).EventSource = FakeEventSource
+})
+
+afterEach(() => {
+  delete (globalThis as { EventSource?: unknown }).EventSource
+})
+
+describe('subscribeWorldLive', () => {
+  it('subscribes to every declared event name without throwing', () => {
+    // Adding `world-decision` to the event union but not to the client's
+    // listener registry threw on the first subscribe and blanked the whole
+    // application. Nothing caught it: web tests rendered static markup, so no
+    // effect ever ran and no subscription was ever made.
+    const unsubscribes = EVENT_NAMES.map((name, index) =>
+      expect(() => subscribeWorldLive(`world-${index}`, name, () => {})).not.toThrow())
+    expect(unsubscribes).toHaveLength(EVENT_NAMES.length)
+  })
+
+  it('delivers an event to the listener that asked for it', () => {
+    const seen: unknown[] = []
+    const stop = subscribeWorldLive('world-a', 'world-decision', (event) => {
+      seen.push(JSON.parse((event as MessageEvent<string>).data))
+    })
+    const source = FakeEventSource.instances.at(-1)!
+    source.emit('world-decision', { worldId: 'world-a', requestId: 'request-1' })
+    expect(seen).toEqual([{ worldId: 'world-a', requestId: 'request-1' }])
+    stop()
+  })
+
+  it('does not deliver one event kind to another kind of listener', () => {
+    const decisions: unknown[] = []
+    const stop = subscribeWorldLive('world-b', 'world-decision', () => decisions.push(1))
+    const source = FakeEventSource.instances.at(-1)!
+    source.emit('world-state', { worldId: 'world-b' })
+    expect(decisions).toEqual([])
+    stop()
+  })
+
+  it('shares one connection across the listeners of a world', () => {
+    const stopA = subscribeWorldLive('world-c', 'runtime', () => {})
+    const stopB = subscribeWorldLive('world-c', 'world-decision', () => {})
+    // The SSE connection is an origin-wide resource; a panel per listener would
+    // exhaust the browser's connection pool.
+    expect(FakeEventSource.instances.filter((item) => item.url.includes('world-c'))).toHaveLength(1)
+    stopA()
+    stopB()
+  })
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: 22.20.0
         version: 22.20.0
+      happy-dom:
+        specifier: ^20.11.6
+        version: 20.11.6
       tsx:
         specifier: 4.22.4
         version: 4.22.4
@@ -22,7 +25,7 @@ importers:
         version: 6.0.3
       vitest:
         specifier: 4.1.8
-        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(vite@8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0))
+        version: 4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(happy-dom@20.11.6)(vite@8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0))
 
   packages/catalog:
     dependencies:
@@ -51,7 +54,7 @@ importers:
         version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh':
         specifier: 0.1.1-rc.1
-        version: 0.1.1-rc.1(7c1446e2249812d2b3722fe474dd8de2)
+        version: 0.1.1-rc.1(f688243fc3a7b22473374b1140e9bc80)
       '@deepseek-ai/dsh-invariants':
         specifier: 0.1.1-rc.1
         version: 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
@@ -3123,6 +3126,12 @@ packages:
   '@types/unist@3.0.3':
     resolution: {integrity: sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==}
 
+  '@types/whatwg-mimetype@3.0.2':
+    resolution: {integrity: sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
+
   '@ungap/structured-clone@1.3.3':
     resolution: {integrity: sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==}
 
@@ -3287,6 +3296,10 @@ packages:
   buffer-equal-constant-time@1.0.1:
     resolution: {integrity: sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==}
 
+  buffer-image-size@0.6.4:
+    resolution: {integrity: sha512-nEh+kZOPY1w+gcCMobZ6ETUp9WfibndnosbpwB1iJk/8Gt5ZF2bhS6+B6bPYz424KtwsR6Rflc3tCz1/ghX2dQ==}
+    engines: {node: '>=4.0'}
+
   bundle-name@4.1.0:
     resolution: {integrity: sha512-tjwM5exMg6BGRI+kNmTntNsvdZS1X8BFYS6tnJ2hdH0kVxM6/eVZ2xy+FqStSWvYmtfFMDLIxurorHwDKfDz5Q==}
     engines: {node: '>=18'}
@@ -3439,6 +3452,10 @@ packages:
     resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
     engines: {node: '>= 0.8'}
 
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
+
   es-define-property@1.0.1:
     resolution: {integrity: sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==}
     engines: {node: '>= 0.4'}
@@ -3589,6 +3606,10 @@ packages:
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
+
+  happy-dom@20.11.6:
+    resolution: {integrity: sha512-Hldbg8AdAa5a5oDcZpjqnGitp7JB0hqWmfv/8qr+kft4vzSD8BHsbdRfzYvL/0QcbKcURC/yyoygbeDQarPvYg==}
+    engines: {node: '>=20.0.0'}
 
   has-symbols@1.1.0:
     resolution: {integrity: sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==}
@@ -3809,10 +3830,6 @@ packages:
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
-
-  loose-envify@1.4.0:
-    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
-    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -4147,9 +4164,6 @@ packages:
     resolution: {integrity: sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==}
     engines: {node: '>=20'}
 
-  prop-types@15.8.1:
-    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
-
   property-information@7.2.0:
     resolution: {integrity: sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==}
 
@@ -4178,18 +4192,11 @@ packages:
     peerDependencies:
       react: ^19.2.8
 
-  react-is@16.13.1:
-    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
-
   react-markdown@10.1.0:
     resolution: {integrity: sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==}
     peerDependencies:
       '@types/react': '>=18'
       react: '>=18'
-
-  react@16.8.0:
-    resolution: {integrity: sha512-g+nikW2D48kqgWSPwNo0NH9tIGG3DsQFlrtrQ1kj6W77z5ahyIHG0w8kPpz4Sdj6gyLnz0lEd/xsjOoGge2MYQ==}
-    engines: {node: '>=0.10.0'}
 
   react@19.2.8:
     resolution: {integrity: sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==}
@@ -4241,9 +4248,6 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
-
-  scheduler@0.13.0:
-    resolution: {integrity: sha512-w7aJnV30jc7OsiZQNPVmBc+HooZuvQZIZIShKutC3tnMFMkcwVN9CZRRSSNw03OnSCKmEkK8usmwcw6dqBaLzw==}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4524,6 +4528,10 @@ packages:
   web-streams-polyfill@3.0.3:
     resolution: {integrity: sha512-d2H/t0eqRNM4w2WvmTdoeIvzAUSpK7JmATB8Nr2lb7nQ9BTIJVjbQ/TRFVEh2gUH1HwclPdoPtfMoFfetXaZnA==}
     engines: {node: '>= 8'}
+
+  whatwg-mimetype@3.0.0:
+    resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
+    engines: {node: '>=12'}
 
   which@2.0.1:
     resolution: {integrity: sha512-N7GBZOTswtB9lkQBZA4+zAXrjEIWAUOB93AvzUiudRzRxhUdLURQ7D/gAIMY1gatT/LTbmbcv8SiYazy3eYB7w==}
@@ -5182,13 +5190,13 @@ snapshots:
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)':
+  '@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
@@ -5200,7 +5208,7 @@ snapshots:
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)':
+  '@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685)
@@ -5219,52 +5227,52 @@ snapshots:
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-registry': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       immer: 10.1.1
-      zustand: 4.4.7(@types/react@19.2.18)(immer@10.1.1)(react@16.8.0)
+      zustand: 4.4.7(@types/react@19.2.18)(immer@10.1.1)(react@19.2.8)
     transitivePeerDependencies:
       - '@types/react'
       - react
 
-  '@deepseek-ai/dsh-client-ui-agent-preset@0.1.1-rc.1(880e0f18930c60e17d0318a377b917b6)':
+  '@deepseek-ai/dsh-client-ui-agent-preset@0.1.1-rc.1(8ab70896d66873a16ff41ca4e0d278af)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-brand-official@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-brand-official@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae)':
+  '@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)':
+  '@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685)
@@ -5272,11 +5280,11 @@ snapshots:
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-brand': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b)
       '@deepseek-ai/dsh-compaction': 0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8)
       '@deepseek-ai/dsh-goal': 0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9)
@@ -5292,306 +5300,306 @@ snapshots:
       '@deepseek-ai/schemastery': 3.18.1
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-cordis@0.1.1-rc.1(82153b66644e1f5691f20a784913847e)':
+  '@deepseek-ai/dsh-client-ui-cordis@0.1.1-rc.1(c168f60518365222736dff290a2c1f2b)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-deliverables@0.1.1-rc.1(5410a467780aa331f445fff9651b803c)':
+  '@deepseek-ai/dsh-client-ui-deliverables@0.1.1-rc.1(714b907dc240876b283f4a165789541b)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-system-prompt': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
 
-  '@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.1(7c753a4e4c68684f440add017ef3afd9)':
+  '@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.1(1c5b28cb856bb1bf2b9bc970fc368cef)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.1(7f2994e3a55649e3649a1f6c309a986b)':
+  '@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.1(64848d862fee4f6fb3817d36be520cb3)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-goal@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-goal@0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-client-ui-goal@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-goal@0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-commands': 0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b)
       '@deepseek-ai/dsh-goal': 0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-session': 0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9)
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-client-ui-input-trigger@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-input-trigger@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
       '@deepseek-ai/dsh-file-reference': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-jobs@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-jobs@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-message-feedback@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.1(f7795b2fc1abf1b0a95da62fb919a13b))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-client-ui-message-feedback@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.1(f7795b2fc1abf1b0a95da62fb919a13b))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.1(f7795b2fc1abf1b0a95da62fb919a13b)
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-client-ui-model-selection@0.1.1-rc.1(251ea01d87762b95304b1801ba7c1129)':
+  '@deepseek-ai/dsh-client-ui-model-selection@0.1.1-rc.1(f201b074a73c560f371a465f8ab9a077)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-permission-presets@0.1.1-rc.1(d0c6f903b898a8c6949b4da297f1ff78)':
+  '@deepseek-ai/dsh-client-ui-permission-presets@0.1.1-rc.1(6ce9553b82f5d66e924ba8805d1247d8)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-permission-presets': 0.1.1-rc.1(addeb4ef5c423b23897c808d410638da)
 
-  '@deepseek-ai/dsh-client-ui-plan@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.1(be61279b79ad61bb4c228ba8bbf08de7))':
+  '@deepseek-ai/dsh-client-ui-plan@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.1(be61279b79ad61bb4c228ba8bbf08de7))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-plan-mode': 0.1.1-rc.1(be61279b79ad61bb4c228ba8bbf08de7)
 
-  '@deepseek-ai/dsh-client-ui-reference@0.1.1-rc.1(3013fd2e901d2ff6fdeb3d7af4f3dfbd)':
+  '@deepseek-ai/dsh-client-ui-reference@0.1.1-rc.1(54e82e4804938be83db6f2adf8b8a033)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-file-reference': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-session-reference': 0.1.1-rc.1(ffa5073c49cd4df1d01c48c458bc79e4)
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(react@16.8.0)':
+  '@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(react@19.2.8)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
-      use-sync-external-store: 1.2.0(react@16.8.0)
+      use-sync-external-store: 1.2.0(react@19.2.8)
     transitivePeerDependencies:
       - react
 
-  '@deepseek-ai/dsh-client-ui-settings-general@0.1.1-rc.1(1ce2a6c2cfaa05d1b557f787e1aa9644)':
+  '@deepseek-ai/dsh-client-ui-settings-general@0.1.1-rc.1(1867bc631c852949695255a066c531c1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-settings-models@0.1.1-rc.1(70be6605505990a9ad6c620399ac3b6a)':
+  '@deepseek-ai/dsh-client-ui-settings-models@0.1.1-rc.1(514f39dceb0b8cfbdce32ffeaf388cd7)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  ? '@deepseek-ai/dsh-client-ui-settings-plugin-inventory@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))'
+  ? '@deepseek-ai/dsh-client-ui-settings-plugin-inventory@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))'
   : dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-settings-plugins@0.1.1-rc.1(70be6605505990a9ad6c620399ac3b6a)':
+  '@deepseek-ai/dsh-client-ui-settings-plugins@0.1.1-rc.1(514f39dceb0b8cfbdce32ffeaf388cd7)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))':
+  '@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-skill@0.1.1-rc.1(069edab4be90a347b9f88169bf194007)':
+  '@deepseek-ai/dsh-client-ui-skill@0.1.1-rc.1(75b898cd2413ff82c76261dcd9776d1c)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-subagent@0.1.1-rc.1(e8b5b70f07cb8d7bb87bcd1b4753e23b)':
+  '@deepseek-ai/dsh-client-ui-subagent@0.1.1-rc.1(38c3daad04a7fdffcfdda1fa426a7144)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-subagent': 0.1.1-rc.1(49bbde82f635743d219c2dce7f3ffcd1)
       '@deepseek-ai/dsh-token-meter': 0.1.1-rc.1(6a0180ae74e211934a53125ebb61582b)
 
-  '@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d)':
+  '@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-tool@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-tool@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-trajectory@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-compaction@0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8))(react-dom@19.2.8(react@16.8.0))(react@19.2.8)':
+  '@deepseek-ai/dsh-client-ui-trajectory@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-compaction@0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-compaction': 0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-tools': 0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8)
-      '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@16.8.0))(react@19.2.8)
+      '@tanstack/react-virtual': 3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       diff: 9.0.0
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@deepseek-ai/dsh-client-ui-user-questions@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-user-questions@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-workflow-run@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.1(d2f4d08899fb2dd1492ee363b04e185e))(@deepseek-ai/dsh-workflow@0.1.1-rc.1(1a389258de15fd948cf33bf3df8cd71c))':
+  '@deepseek-ai/dsh-client-ui-workflow-run@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.1(d2f4d08899fb2dd1492ee363b04e185e))(@deepseek-ai/dsh-workflow@0.1.1-rc.1(1a389258de15fd948cf33bf3df8cd71c))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-session': 0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9)
       '@deepseek-ai/dsh-tool-workflow': 0.1.1-rc.1(d2f4d08899fb2dd1492ee363b04e185e)
       '@deepseek-ai/dsh-workflow': 0.1.1-rc.1(1a389258de15fd948cf33bf3df8cd71c)
 
-  '@deepseek-ai/dsh-client-ui-workspace@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-workspace@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
@@ -5685,15 +5693,15 @@ snapshots:
       '@deepseek-ai/dsh-llm': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-session': 0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9)
 
-  '@deepseek-ai/dsh-cordis-client-runner@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-cordis-client-runner@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)(node-addon-require-builtin@0.1.5)
       '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
       '@deepseek-ai/dsh-client-modules': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-cordis-host-runner@0.1.1-rc.1(5f58baed6f460493bf587cbc0b2a2ebe)':
@@ -5874,12 +5882,12 @@ snapshots:
       - '@deepseek-ai/dsh-typert-protocol'
       - '@deepseek-ai/dsh-typert-registry'
 
-  '@deepseek-ai/dsh-host-directory-picker-auto@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.1(7c753a4e4c68684f440add017ef3afd9))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.1(7f2994e3a55649e3649a1f6c309a986b))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-host-directory-picker-auto@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.1(1c5b28cb856bb1bf2b9bc970fc368cef))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.1(64848d862fee4f6fb3817d36be520cb3))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)(node-addon-require-builtin@0.1.5)
-      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.1(7c753a4e4c68684f440add017ef3afd9)
-      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.1(7f2994e3a55649e3649a1f6c309a986b)
+      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.1(1c5b28cb856bb1bf2b9bc970fc368cef)
+      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.1(64848d862fee4f6fb3817d36be520cb3)
       '@deepseek-ai/dsh-host-directory-picker-browse': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-native': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
@@ -6202,13 +6210,13 @@ snapshots:
       '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-tools': 0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8)
 
-  '@deepseek-ai/dsh-session-log-export@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-session-log-export@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
       '@deepseek-ai/dsh-commands': 0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
 
@@ -6876,7 +6884,7 @@ snapshots:
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
 
-  '@deepseek-ai/dsh-web-app@0.1.1-rc.1(ff2af72f93104ce70ab9f2ae739c180c)':
+  '@deepseek-ai/dsh-web-app@0.1.1-rc.1(df410d649ccb59d199f868f7fae79a63)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)(node-addon-require-builtin@0.1.5)
@@ -6885,50 +6893,50 @@ snapshots:
       '@deepseek-ai/dsh-app-boot': 0.1.1-rc.1(033fcce7dd122e7584eacabbe8b3890a)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.1(7c01bb8faf92012187ef49f6b1706332)
       '@deepseek-ai/dsh-client-hmr': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7)
       '@deepseek-ai/dsh-client-modules': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(813ee6727358eaefacf0abe03a808589)
-      '@deepseek-ai/dsh-client-ui-agent-preset': 0.1.1-rc.1(880e0f18930c60e17d0318a377b917b6)
-      '@deepseek-ai/dsh-client-ui-attachment': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-brand-official': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45)
-      '@deepseek-ai/dsh-client-ui-cordis': 0.1.1-rc.1(82153b66644e1f5691f20a784913847e)
-      '@deepseek-ai/dsh-client-ui-deliverables': 0.1.1-rc.1(5410a467780aa331f445fff9651b803c)
-      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.1(7c753a4e4c68684f440add017ef3afd9)
-      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.1(7f2994e3a55649e3649a1f6c309a986b)
-      '@deepseek-ai/dsh-client-ui-goal': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-goal@0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-jobs': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-message-feedback': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.1(f7795b2fc1abf1b0a95da62fb919a13b))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-client-ui-model-selection': 0.1.1-rc.1(251ea01d87762b95304b1801ba7c1129)
-      '@deepseek-ai/dsh-client-ui-permission-presets': 0.1.1-rc.1(d0c6f903b898a8c6949b4da297f1ff78)
-      '@deepseek-ai/dsh-client-ui-plan': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.1(be61279b79ad61bb4c228ba8bbf08de7))
-      '@deepseek-ai/dsh-client-ui-reference': 0.1.1-rc.1(3013fd2e901d2ff6fdeb3d7af4f3dfbd)
-      '@deepseek-ai/dsh-client-ui-renderer': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(react@16.8.0)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
-      '@deepseek-ai/dsh-client-ui-settings-general': 0.1.1-rc.1(1ce2a6c2cfaa05d1b557f787e1aa9644)
-      '@deepseek-ai/dsh-client-ui-settings-models': 0.1.1-rc.1(70be6605505990a9ad6c620399ac3b6a)
-      '@deepseek-ai/dsh-client-ui-settings-plugin-inventory': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-settings-plugins': 0.1.1-rc.1(70be6605505990a9ad6c620399ac3b6a)
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-skill': 0.1.1-rc.1(069edab4be90a347b9f88169bf194007)
-      '@deepseek-ai/dsh-client-ui-subagent': 0.1.1-rc.1(e8b5b70f07cb8d7bb87bcd1b4753e23b)
-      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d)
-      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-trajectory': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-compaction@0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8))(react-dom@19.2.8(react@16.8.0))(react@19.2.8)
-      '@deepseek-ai/dsh-client-ui-user-questions': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-workflow-run': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.1(d2f4d08899fb2dd1492ee363b04e185e))(@deepseek-ai/dsh-workflow@0.1.1-rc.1(1a389258de15fd948cf33bf3df8cd71c))
-      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635)
+      '@deepseek-ai/dsh-client-ui-agent-preset': 0.1.1-rc.1(8ab70896d66873a16ff41ca4e0d278af)
+      '@deepseek-ai/dsh-client-ui-attachment': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-brand-official': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b)
+      '@deepseek-ai/dsh-client-ui-cordis': 0.1.1-rc.1(c168f60518365222736dff290a2c1f2b)
+      '@deepseek-ai/dsh-client-ui-deliverables': 0.1.1-rc.1(714b907dc240876b283f4a165789541b)
+      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.1(1c5b28cb856bb1bf2b9bc970fc368cef)
+      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.1(64848d862fee4f6fb3817d36be520cb3)
+      '@deepseek-ai/dsh-client-ui-goal': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-goal@0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-file-reference@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-jobs': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-message-feedback': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.1(f7795b2fc1abf1b0a95da62fb919a13b))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-client-ui-model-selection': 0.1.1-rc.1(f201b074a73c560f371a465f8ab9a077)
+      '@deepseek-ai/dsh-client-ui-permission-presets': 0.1.1-rc.1(6ce9553b82f5d66e924ba8805d1247d8)
+      '@deepseek-ai/dsh-client-ui-plan': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.1(be61279b79ad61bb4c228ba8bbf08de7))
+      '@deepseek-ai/dsh-client-ui-reference': 0.1.1-rc.1(54e82e4804938be83db6f2adf8b8a033)
+      '@deepseek-ai/dsh-client-ui-renderer': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(react@19.2.8)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-ui-settings-general': 0.1.1-rc.1(1867bc631c852949695255a066c531c1)
+      '@deepseek-ai/dsh-client-ui-settings-models': 0.1.1-rc.1(514f39dceb0b8cfbdce32ffeaf388cd7)
+      '@deepseek-ai/dsh-client-ui-settings-plugin-inventory': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-settings-plugins': 0.1.1-rc.1(514f39dceb0b8cfbdce32ffeaf388cd7)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-skill': 0.1.1-rc.1(75b898cd2413ff82c76261dcd9776d1c)
+      '@deepseek-ai/dsh-client-ui-subagent': 0.1.1-rc.1(38c3daad04a7fdffcfdda1fa426a7144)
+      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa)
+      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-trajectory': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-compaction@0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8))(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@deepseek-ai/dsh-client-ui-user-questions': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-workflow-run': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.1(d2f4d08899fb2dd1492ee363b04e185e))(@deepseek-ai/dsh-workflow@0.1.1-rc.1(1a389258de15fd948cf33bf3df8cd71c))
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-cmdline': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-code-runtime-worker-thread': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-code-runtime@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-cordis-host-runner': 0.1.1-rc.1(5f58baed6f460493bf587cbc0b2a2ebe)
       '@deepseek-ai/dsh-file-reference': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-file-reference-local': 0.1.1-rc.1(69524f6011b1b6ad47d2b11364072e79)
       '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.1(dc5e340fab2bbeb1ba415aff9eb1e8c5)
-      '@deepseek-ai/dsh-host-directory-picker-auto': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.1(7c753a4e4c68684f440add017ef3afd9))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.1(7f2994e3a55649e3649a1f6c309a986b))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-host-directory-picker-auto': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.1(1c5b28cb856bb1bf2b9bc970fc368cef))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.1(64848d862fee4f6fb3817d36be520cb3))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-browse': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-native': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-frontend-static': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
@@ -6937,7 +6945,7 @@ snapshots:
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-launch-environment': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.1(f7795b2fc1abf1b0a95da62fb919a13b)
-      '@deepseek-ai/dsh-session-log-export': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(88e687715d865e9a5ef11be5c9db60b3))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.1(0b41183957b836386b1a483e7d78e2ae))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(122faf4a4aedfd6fd94a9b5ab7012d45))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-session-log-export': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.1(e2f4c2734565d766be213f0baf7c3ba7))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.1(bff0e0c794d8964980a1325bee6f204c))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.1(b4e2db15467c9c259abd69bb29d6e62b))(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-session-projection-cache': 0.1.1-rc.1(c6c149d38c007ef68d7912021fd75292)
       '@deepseek-ai/dsh-session-reference': 0.1.1-rc.1(ffa5073c49cd4df1d01c48c458bc79e4)
       '@deepseek-ai/dsh-session-stats': 0.1.1-rc.1(5923a3b73d49601ae7358cab918eff65)
@@ -7050,7 +7058,7 @@ snapshots:
       '@deepseek-ai/dsh-storage-domain': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-storage@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))
       zod: 4.4.3
 
-  '@deepseek-ai/dsh@0.1.1-rc.1(7c1446e2249812d2b3722fe474dd8de2)':
+  '@deepseek-ai/dsh@0.1.1-rc.1(f688243fc3a7b22473374b1140e9bc80)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-hmr': 1.0.16(@deepseek-ai/cordis-plugin-timer@1.1.3(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/cordis@4.0.1)
@@ -7061,14 +7069,14 @@ snapshots:
       '@deepseek-ai/dsh-agent-tool-presentation': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8))
       '@deepseek-ai/dsh-app-boot': 0.1.1-rc.1(033fcce7dd122e7584eacabbe8b3890a)
       '@deepseek-ai/dsh-base': 0.1.1-rc.1(ea337fbfa542fad1a419a03172beaa6c)
-      '@deepseek-ai/dsh-client-ui-agent-preset': 0.1.1-rc.1(880e0f18930c60e17d0318a377b917b6)
-      '@deepseek-ai/dsh-client-ui-cordis': 0.1.1-rc.1(82153b66644e1f5691f20a784913847e)
+      '@deepseek-ai/dsh-client-ui-agent-preset': 0.1.1-rc.1(8ab70896d66873a16ff41ca4e0d278af)
+      '@deepseek-ai/dsh-client-ui-cordis': 0.1.1-rc.1(c168f60518365222736dff290a2c1f2b)
       '@deepseek-ai/dsh-cmdline': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-command-compact': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-compaction@0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-command-goal': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-commands@0.1.1-rc.1(9750df5955adaa982f393e8cac6df95b))(@deepseek-ai/dsh-goal@0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))
       '@deepseek-ai/dsh-compaction-basic': 0.1.1-rc.1(2b27f0963f7d8a4f2ac14f87644ee767)
       '@deepseek-ai/dsh-compaction-tool-result-pruner': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-compaction@0.1.1-rc.1(5cbe4132ad009d8a23616461916c1ac8))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-token-meter@0.1.1-rc.1(6a0180ae74e211934a53125ebb61582b))
-      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(813ee6727358eaefacf0abe03a808589))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(2ebaa61a4300d50c20ddde05d3df861d))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.1(0dbd24110e04aadb9415a7fc081ef3f0))(@deepseek-ai/dsh-client-connection@0.1.1-rc.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.1(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.1(4bf81f2dd6dd3a9619f354fcd704a635))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.1(203d2d8271af3f22a6d87c7984fe0baa))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-fs-local': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-fs@0.1.1-rc.1(5c1e9fa634fd2a1dc9bc8920dfb28aeb))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-goal': 0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9)
       '@deepseek-ai/dsh-goal-round-driver': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-goal@0.1.1-rc.1(c7e75a2a1f42914d1f7d49509d671bd9))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))
@@ -7109,7 +7117,7 @@ snapshots:
       '@deepseek-ai/dsh-tool-todo': 0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.1(aa3d9fe6db68ff807654619f7de13685))(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session-projection@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.1(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9)))(@deepseek-ai/dsh-session@0.1.1-rc.1(7df49adfe80cd12fee5d57cbd9c430d9))(@deepseek-ai/dsh-tools@0.1.1-rc.1(5493e0ab460eb504a0593977b284c2a8))
       '@deepseek-ai/dsh-tool-web': 0.1.1-rc.1(d9d0961af0f738a06148d5e0b9a6c9b6)
       '@deepseek-ai/dsh-tool-workflow': 0.1.1-rc.1(d2f4d08899fb2dd1492ee363b04e185e)
-      '@deepseek-ai/dsh-web-app': 0.1.1-rc.1(ff2af72f93104ce70ab9f2ae739c180c)
+      '@deepseek-ai/dsh-web-app': 0.1.1-rc.1(df410d649ccb59d199f868f7fae79a63)
       '@deepseek-ai/dsh-workflow-worker-thread': 0.1.1-rc.1(e9476232a456fdb1e0251ab94cbc955d)
       commander: 15.0.0
       js-yaml: 4.3.1
@@ -7739,11 +7747,11 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@16.8.0))(react@19.2.8)':
+  '@tanstack/react-virtual@3.14.9(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
     dependencies:
       '@tanstack/virtual-core': 3.17.7
       react: 19.2.8
-      react-dom: 19.2.8(react@16.8.0)
+      react-dom: 19.2.8(react@19.2.8)
 
   '@tanstack/virtual-core@3.17.7': {}
 
@@ -7793,6 +7801,12 @@ snapshots:
   '@types/unist@2.0.11': {}
 
   '@types/unist@3.0.3': {}
+
+  '@types/whatwg-mimetype@3.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.20.0
 
   '@ungap/structured-clone@1.3.3': {}
 
@@ -7949,6 +7963,10 @@ snapshots:
 
   buffer-equal-constant-time@1.0.1: {}
 
+  buffer-image-size@0.6.4:
+    dependencies:
+      '@types/node': 22.20.0
+
   bundle-name@4.1.0:
     dependencies:
       run-applescript: 7.1.0
@@ -8062,6 +8080,8 @@ snapshots:
   ee-first@1.1.1: {}
 
   encodeurl@2.0.0: {}
+
+  entities@7.0.1: {}
 
   es-define-property@1.0.1: {}
 
@@ -8263,6 +8283,19 @@ snapshots:
   google-logging-utils@1.2.0: {}
 
   gopd@1.2.0: {}
+
+  happy-dom@20.11.6:
+    dependencies:
+      '@types/node': 22.20.0
+      '@types/whatwg-mimetype': 3.0.2
+      '@types/ws': 8.18.1
+      buffer-image-size: 0.6.4
+      entities: 7.0.1
+      whatwg-mimetype: 3.0.0
+      ws: 8.21.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
 
   has-symbols@1.1.0: {}
 
@@ -8473,10 +8506,6 @@ snapshots:
   long@5.3.2: {}
 
   longest-streak@3.1.0: {}
-
-  loose-envify@1.4.0:
-    dependencies:
-      js-tokens: 4.0.0
 
   magic-string@0.30.21:
     dependencies:
@@ -9003,12 +9032,6 @@ snapshots:
 
   powershell-utils@0.2.0: {}
 
-  prop-types@15.8.1:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react-is: 16.13.1
-
   property-information@7.2.0: {}
 
   protobufjs@7.6.5:
@@ -9044,17 +9067,10 @@ snapshots:
       iconv-lite: 0.7.3
       unpipe: 1.0.0
 
-  react-dom@19.2.8(react@16.8.0):
-    dependencies:
-      react: 16.8.0
-      scheduler: 0.27.0
-
   react-dom@19.2.8(react@19.2.8):
     dependencies:
       react: 19.2.8
       scheduler: 0.27.0
-
-  react-is@16.13.1: {}
 
   react-markdown@10.1.0(@types/react@19.2.18)(react@19.2.8):
     dependencies:
@@ -9073,13 +9089,6 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
-
-  react@16.8.0:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      prop-types: 15.8.1
-      scheduler: 0.13.0
 
   react@19.2.8: {}
 
@@ -9160,11 +9169,6 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
-
-  scheduler@0.13.0:
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
 
   scheduler@0.27.0: {}
 
@@ -9385,9 +9389,9 @@ snapshots:
 
   unpipe@1.0.0: {}
 
-  use-sync-external-store@1.2.0(react@16.8.0):
+  use-sync-external-store@1.2.0(react@19.2.8):
     dependencies:
-      react: 16.8.0
+      react: 19.2.8
 
   vary@1.1.2: {}
 
@@ -9427,7 +9431,7 @@ snapshots:
       tsx: 4.22.4
       yaml: 2.9.0
 
-  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(vite@8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0)):
+  vitest@4.1.8(@opentelemetry/api@1.9.1)(@types/node@22.20.0)(happy-dom@20.11.6)(vite@8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.8
       '@vitest/mocker': 4.1.8(vite@8.2.1(@types/node@22.20.0)(esbuild@0.28.2)(tsx@4.22.4)(yaml@2.9.0))
@@ -9452,10 +9456,13 @@ snapshots:
     optionalDependencies:
       '@opentelemetry/api': 1.9.1
       '@types/node': 22.20.0
+      happy-dom: 20.11.6
     transitivePeerDependencies:
       - msw
 
   web-streams-polyfill@3.0.3: {}
+
+  whatwg-mimetype@3.0.0: {}
 
   which@2.0.1:
     dependencies:
@@ -9483,12 +9490,12 @@ snapshots:
 
   zod@4.4.3: {}
 
-  zustand@4.4.7(@types/react@19.2.18)(immer@10.1.1)(react@16.8.0):
+  zustand@4.4.7(@types/react@19.2.18)(immer@10.1.1)(react@19.2.8):
     dependencies:
-      use-sync-external-store: 1.2.0(react@16.8.0)
+      use-sync-external-store: 1.2.0(react@19.2.8)
     optionalDependencies:
       '@types/react': 19.2.18
       immer: 10.1.1
-      react: 16.8.0
+      react: 19.2.8
 
   zwitch@2.0.4: {}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,9 +1,36 @@
 import { defineConfig } from 'vitest/config'
 
+const shared = {
+  testTimeout: 15_000,
+  hookTimeout: 15_000,
+  // Each project resolves its own root, so the default node_modules exclusion
+  // has to be restated or every dependency's tests get collected.
+  exclude: ['**/node_modules/**', '**/dist/**', '**/lib/**'],
+}
+
 export default defineConfig({
   test: {
-    include: ['packages/**/tests/**/*.test.ts'],
-    testTimeout: 15_000,
-    hookTimeout: 15_000,
+    projects: [
+      {
+        test: {
+          ...shared,
+          name: 'node',
+          include: ['packages/**/tests/**/*.test.ts'],
+          exclude: [...shared.exclude, 'packages/web/tests/**'],
+        },
+      },
+      {
+        test: {
+          ...shared,
+          name: 'web',
+          include: ['packages/web/tests/**/*.test.ts'],
+          // Web tests render into a real DOM so effects, subscriptions and
+          // event listeners actually run. Without it every web test was a
+          // static-markup snapshot: a client crash on first subscribe passed
+          // 443 unit tests and only surfaced when the browser suite ran.
+          environment: 'happy-dom',
+        },
+      },
+    ],
   },
 })


### PR DESCRIPTION
承接 #54。#54 合并后又发现两处测试问题，这个 PR 只改测试与测试配置，不动产品代码。

## 1. `packages/web` 从来没有 DOM

#54 里我给 live client 加了一个事件名，却漏掉了监听器表，第一次 subscribe 直接抛 `TypeError: Cannot read properties of undefined (reading 'add')`，整个应用白屏。**443 个单测全绿**，是 e2e 以 18/20 红出来的。

原因不是测试写得不够，是环境：`packages/web` 跑在 node 环境下，每个 web 测试断言的都是静态 markup —— effect 不会执行，订阅不会发生，那个抛错在测试里根本不可达。

Vitest 4 已移除 `environmentMatchGlobs`，所以改成两个 project：node 跑其余全部，happy-dom 跑 `packages/web/tests`。每个 project 各自解析 root，`node_modules` 的排除必须显式重写一遍，否则收集会走进每个依赖（实测会从 97 个测试文件涨到 875 个）。

新增 `packages/web/tests/world-live-client.test.ts` 就是为这个环境而写的回归测试。把手写监听器表改回去，它的 4 条用例全部以当初那个 `TypeError` 变红 —— 已实测验证。它取代了 `world-authority-ui.test.ts` 里那条源码文本断言：那条断言检查的是"修复长什么样"而不是行为，而且有了 DOM 之后 `import.meta.url` 不再是 file: URL，它自己也跑不起来了。

## 2. delegated-collaboration 断在时序和顺序上

两处竞态，都不是产品缺陷：

- 轮询一个瞬时状态（`speaking`/`thinking`/`listening`），在慢机器上窗口可能整个错过 —— 改为同时接受"已产生 agent run"这一持久事实。
- 断言委托汇报是**最后一条**消息 —— 改为断言它**存在**（按 `metadata.delegatedDirectSessionId` 匹配）。原本只要有一条环境消息跟在后面就红。

## 验证

- `pnpm typecheck` 通过
- `pnpm vitest run` — 98 文件 / 446 测试全绿
- `pnpm test:e2e` — 20/20，且改前连续跑五次均为 20/20（基线为 18/2）