### PR TITLE
fix-world-management-decisions

### DIFF
--- a/packages/server/src/services/turn-aware-approval-continuation-service.ts
+++ b/packages/server/src/services/turn-aware-approval-continuation-service.ts
@@ -291,7 +291,10 @@ const sanitizer = new TraceSanitizer()
  */
 function factualRuntimeSource(prompt: string, actions: CharacterSkillAction[]): string {
   if (actions.length === 0) return prompt
-  const summary = actions.map((action) => `${action.label}：${statusPhrase(action)}`).join('\n')
+  const summary = actions.map((action) => {
+    const notice = unhandledClauseNotice(action)
+    return `${action.label}：${statusPhrase(action)}${notice === undefined ? '' : `；${notice}`}`
+  }).join('\n')
   const sections = [
     prompt,
     `${FACT_BLOCK_OPEN}\n${summary}\n只能根据以上持久化事实说明动作已执行、未执行、等待连接、失败或结果未知。不得自动重试结果未知的外部动作。`,
@@ -327,6 +330,17 @@ function statusPhrase(action: CharacterSkillAction): string {
     case 'outcome-unknown': return '结果未知，不得声称成功或失败，也不得自动重试'
     default: return String(action.status)
   }
+}
+
+/** A parser diagnostic is a host fact, not third-party detail. */
+function unhandledClauseNotice(action: CharacterSkillAction): string | undefined {
+  const value = action.parameters?.unhandledClauses
+  const clauses = Array.isArray(value)
+    ? value
+      .filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+      .map((item) => sanitizer.text(item, MAX_EXTERNAL_LINE_LENGTH))
+    : []
+  return clauses.length === 0 ? undefined : `未识别，未执行：${clauses.join('；')}`
 }
 
 function quoteExternalContent(detail: string | undefined): string | undefined {

--- a/packages/server/src/services/world-permission-request-service.ts
+++ b/packages/server/src/services/world-permission-request-service.ts
@@ -216,10 +216,12 @@ export class WorldPermissionRequestService {
       throw new WorldPermissionRequestExpiredError()
     }
     if (input.decision === 'reject') {
-      return await this.#store.decideWorldPermissionRequest(input.requestId, {
+      const decided = await this.#store.decideWorldPermissionRequest(input.requestId, {
         decisionScope: 'reject',
         decidedBy: input.decidedBy,
       }, now.toISOString())
+      this.#announce(decided)
+      return decided
     }
     if (input.decision === 'persistent') {
       if (this.#authority.updateAuthority === undefined) {

--- a/packages/server/src/skills/world-management-adapter.ts
+++ b/packages/server/src/skills/world-management-adapter.ts
@@ -194,23 +194,29 @@ export class WorldManagementAdapter implements CharacterSkillAdapter {
 
   async execute(action: CharacterSkillAction, _context: CharacterSkillExecutionContext): Promise<CharacterSkillExecutionResult> {
     try {
-      switch (action.action) {
-        case 'world.settings.read': return await this.#readSettings(action)
-        case 'world.settings.update': return await this.#updateSettings(action)
-        case 'world.rename': return await this.#rename(action)
-        case 'world.characters.list': return this.#listCharacters(action)
-        case 'world.characters.update': return await this.#updateCharacter(action)
-        case 'world.authority.read': return await this.#readAuthority(action)
-        case 'world.authority.update': return await this.#updateAuthority(action)
-        case 'world.packages.list': return await this.#listPackages(action)
-        case 'world.packages.instantiate': return await this.#instantiatePackage(action)
-        case 'world.packages.disable': return await this.#disablePackage(action)
-        case 'world.model.read': return await this.#readModel(action)
-        case 'world.model.assign': return await this.#assignModel(action)
-        default: return { status: 'failed', detail: '未知的世界管理动作，已阻止执行' }
-      }
+      const result = await (async (): Promise<CharacterSkillExecutionResult> => {
+        switch (action.action) {
+          case 'world.settings.read': return await this.#readSettings(action)
+          case 'world.settings.update': return await this.#updateSettings(action)
+          case 'world.rename': return await this.#rename(action)
+          case 'world.characters.list': return this.#listCharacters(action)
+          case 'world.characters.update': return await this.#updateCharacter(action)
+          case 'world.authority.read': return await this.#readAuthority(action)
+          case 'world.authority.update': return await this.#updateAuthority(action)
+          case 'world.packages.list': return await this.#listPackages(action)
+          case 'world.packages.instantiate': return await this.#instantiatePackage(action)
+          case 'world.packages.disable': return await this.#disablePackage(action)
+          case 'world.model.read': return await this.#readModel(action)
+          case 'world.model.assign': return await this.#assignModel(action)
+          default: return { status: 'failed', detail: '未知的世界管理动作，已阻止执行' }
+        }
+      })()
+      return appendUnhandledClauseNotice(action, result)
     } catch (error) {
-      return { status: 'failed', detail: error instanceof Error ? error.message : '世界管理动作执行失败' }
+      return appendUnhandledClauseNotice(action, {
+        status: 'failed',
+        detail: error instanceof Error ? error.message : '世界管理动作执行失败',
+      })
     }
   }
 
@@ -252,6 +258,18 @@ export class WorldManagementAdapter implements CharacterSkillAdapter {
     // failing: it is a confident wrong answer the model will repeat.
     if (this.#host.listCharacters === undefined) return { status: 'failed', detail: '角色列表服务不可用' }
     const list = this.#host.listCharacters(action.worldId)
+    if (stringParameter(action.parameters, 'reason') === 'ambiguous-character') {
+      const candidateIds = objectArrayParameter(action.parameters, 'candidates')
+        .map((candidate) => stringParameter(candidate, 'id'))
+        .filter((candidate): candidate is string => candidate !== undefined)
+      const candidates = candidateIds
+        .map((id) => list.find((item) => item.id === id))
+        .filter((item): item is WorldManagementCharacterRef => item !== undefined)
+      if (candidates.length > 0) {
+        const labels = candidates.map((item, index) => `${index + 1}. ${item.displayName}（${item.id}）`)
+        return { status: 'executed', detail: `目标角色存在歧义，请从候选中选择：${labels.join('、')}` }
+      }
+    }
     return { status: 'executed', detail: `当前世界共有 ${list.length} 个可用角色` }
   }
 
@@ -352,6 +370,25 @@ function arrayParameter(parameters: Record<string, unknown>, key: string): World
   return Array.isArray(value) ? value.filter((item): item is WorldCharacterPermission => typeof item === 'string') : []
 }
 
+function objectArrayParameter(parameters: Record<string, unknown>, key: string): Record<string, unknown>[] {
+  const value = parameters[key]
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => item !== null && typeof item === 'object' && !Array.isArray(item))
+    : []
+}
+
+function appendUnhandledClauseNotice(
+  action: CharacterSkillAction,
+  result: CharacterSkillExecutionResult,
+): CharacterSkillExecutionResult {
+  const value = action.parameters?.unhandledClauses
+  const clauses = Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim() !== '')
+    : []
+  if (clauses.length === 0) return result
+  return { ...result, detail: `${result.detail}；未识别，未执行：${clauses.join('；')}` }
+}
+
 function withoutManagementFields(parameters: Record<string, unknown>): Record<string, unknown> {
   const result = { ...parameters }
   delete result.managementKind
@@ -360,6 +397,9 @@ function withoutManagementFields(parameters: Record<string, unknown>): Record<st
   delete result.role
   delete result.permissionGrants
   delete result.removePermissions
+  delete result.unhandledClauses
+  delete result.planOrdinal
+  delete result.planSize
   return result
 }
 

--- a/packages/server/tests/world-file-access.test.ts
+++ b/packages/server/tests/world-file-access.test.ts
@@ -178,25 +178,37 @@ describe('world file access', () => {
 describe('pending decisions are announced, not polled for', () => {
   it('publishes a decision envelope on change and none per streamed token', async () => {
     const { origin, server, world, characterId } = await start()
-    const envelopes: Array<{ kind: string; worldId: string }> = []
+    const envelopes: Array<{
+      kind: string
+      worldId: string
+      payload?: { requestId?: string; status?: string }
+    }> = []
+    let targetRequestId: string | undefined
     // Watch the live stream the client subscribes to.
     const response = await fetch(`${origin}/api/worlds/${world.id}/live`, { headers: { Accept: 'text/event-stream' } })
     const reader = response.body!.getReader()
     const decoder = new TextDecoder()
     const read = (async () => {
       const deadline = Date.now() + 4_000
-      while (Date.now() < deadline) {
+      while (Date.now() < deadline && !envelopes.some((item) => item.payload?.requestId === targetRequestId && item.payload.status === 'rejected')) {
         const chunk = await Promise.race([
           reader.read(),
-          new Promise<{ done: true; value: undefined }>((resolvePromise) =>
-            setTimeout(() => resolvePromise({ done: true, value: undefined }), 600)),
+          new Promise<{ timedOut: true }>((resolvePromise) =>
+            setTimeout(() => resolvePromise({ timedOut: true }), 600)),
         ])
+        if ('timedOut' in chunk) continue
         if (chunk.done || chunk.value === undefined) break
         for (const line of decoder.decode(chunk.value).split('\n')) {
           if (!line.startsWith('data:')) continue
           try {
-            const envelope = JSON.parse(line.slice(5).trim()) as { kind?: string; worldId?: string }
-            if (envelope.kind !== undefined) envelopes.push({ kind: envelope.kind, worldId: envelope.worldId ?? '' })
+            const envelope = JSON.parse(line.slice(5).trim()) as {
+              kind?: string
+              worldId?: string
+              payload?: { requestId?: string; status?: string }
+            }
+            if (envelope.kind !== undefined) {
+              envelopes.push({ kind: envelope.kind, worldId: envelope.worldId ?? '', payload: envelope.payload })
+            }
           } catch {
             // Non-JSON keep-alive lines.
           }
@@ -210,11 +222,18 @@ describe('pending decisions are announced, not polled for', () => {
       prompt: '把这个世界改名为 通知测试世界',
       employeeIds: [characterId],
     }))
+    const pending = await json(origin, `/api/worlds/${world.id}/permission-requests`)
+    const request = (pending.body.permissionRequests ?? pending.body.requests ?? [])[0] as { id?: string } | undefined
+    expect(request?.id, '应当创建待处理的世界权限请求').toBeDefined()
+    targetRequestId = request!.id
+    const rejected = await json(origin, `/api/world-permission-requests/${request!.id}/decision`, send('POST', { decision: 'reject' }))
+    expect(rejected.response.status).toBe(200)
     await read
     await reader.cancel().catch(() => undefined)
 
     const decisions = envelopes.filter((item) => item.kind === 'world-decision')
-    expect(decisions.length, '决策变化应当被广播').toBeGreaterThan(0)
+    expect(decisions.some((item) => item.payload?.requestId === request!.id && item.payload.status === 'pending'), '创建决策应当被广播').toBe(true)
+    expect(decisions.some((item) => item.payload?.requestId === request!.id && item.payload.status === 'rejected'), '拒绝决策也应当被广播').toBe(true)
     void server
   })
 })

--- a/packages/server/tests/world-management-host-contract.test.ts
+++ b/packages/server/tests/world-management-host-contract.test.ts
@@ -22,7 +22,10 @@ afterEach(async () => {
 })
 
 class QuietRuntime implements AgentRuntimePort {
+  readonly prompts: string[] = []
+
   async runTurn(request: AgentTurnRequest) {
+    this.prompts.push(request.prompt)
     return { agentSessionId: `agent-${request.agent.id}`, finalResponse: '好的。', eventCount: 0 }
   }
   async close(): Promise<void> {}
@@ -37,16 +40,17 @@ class QuietRuntime implements AgentRuntimePort {
  */
 async function start() {
   const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-world-mgmt-'))
+  const runtime = new QuietRuntime()
   const server = await createCyberServer({
     stateRoot,
     workspacePath: stateRoot,
     port: 0,
-    runtime: new QuietRuntime(),
+    runtime,
     bootstrapDefaultWorld: true,
   })
   servers.push(server)
   const address = await server.start()
-  return { origin: address.origin, server }
+  return { origin: address.origin, server, runtime }
 }
 
 async function json(origin: string, path: string, init?: RequestInit): Promise<{ response: Response; body: any }> {
@@ -121,6 +125,55 @@ describe('world management host wiring', () => {
     // The change must go through the profile revision chain, not a raw row
     // update: character history is an audit trail, not mutable state.
     expect(server.store.getEmployeeProfile(characterId)!.revision).toBeGreaterThan(profileBefore)
+  })
+
+  it('reports unsupported compound clauses as not executed', async () => {
+    const { origin, runtime } = await start()
+    const { world, characterId } = await administratorWorld(origin)
+
+    await chat(origin, world.id, characterId, '把当前场景改成产品评审，然后请老王喝杯咖啡')
+
+    const actions = await skillActions(origin, world.id)
+    const update = actions.find((item) => item.action === 'world.settings.update')
+    expect(update, '可识别的子句应当执行').toBeDefined()
+    expect(update!.detail).toContain('未识别，未执行：请老王喝杯咖啡')
+    expect(runtime.prompts.at(-1)).toContain('未识别，未执行：请老王喝杯咖啡')
+  })
+
+  it('lists candidate identities when a character name is ambiguous', async () => {
+    const { origin, server } = await start()
+    const { world, characterId } = await administratorWorld(origin)
+    const recruitedIds: string[] = []
+    for (const id of ['wang-a', 'wang-b']) {
+      server.store.saveBlueprint({
+        schemaVersion: 1,
+        id,
+        version: 1,
+        worldTemplateId: 'personal-world',
+        displayName: '王',
+        role: '成员',
+        summary: '重名测试角色',
+        persona: '你是王。',
+        requestedSkills: [],
+        requestedCapabilities: [],
+        createdAt: '2026-08-25T00:00:00.000Z',
+      })
+      recruitedIds.push(server.store.recruitEmployee({
+        workspaceId: world.workspaceId,
+        worldId: world.id,
+        blueprintId: id,
+        blueprintVersion: 1,
+      }).id)
+    }
+
+    await chat(origin, world.id, characterId, '把王设置成管理员')
+
+    const actions = await skillActions(origin, world.id)
+    const clarification = actions.find((item) => item.action === 'world.characters.list')
+    expect(clarification, '重名时应当执行角色候选查询').toBeDefined()
+    expect(clarification!.detail).toContain('目标角色存在歧义')
+    expect(clarification!.detail).toContain('王')
+    for (const id of recruitedIds) expect(clarification!.detail).toContain(id)
   })
 
   it('publishes no skill whose host capability is missing', () => {


### PR DESCRIPTION
## 修复内容

- 将复合管理请求中未识别的子句作为宿主事实传给角色，并在执行详情中明确标记“未识别，未执行”。
- 角色名称歧义时列出可选择的候选角色及稳定标识。
- 拒绝世界权限请求时广播 `world-decision` 事件，保证其他会话及时刷新。
- 避免管理计划元数据写入世界设置。

## 验证

- `pnpm typecheck`
- `pnpm test`：97 个测试文件、445 个测试通过
- `pnpm test:e2e`：20/20 通过
