### PR TITLE
fix: 让 owner 撤销的世界文件权限真正生效（而不只是被记录）

### DIFF
--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -83,6 +83,8 @@ interface EmployeeLane {
   id: string
   conversationId: string
   permissionMode: AgentPermissionMode | undefined
+  /** The directory this lane's runtime was started in. */
+  workspacePath: string | undefined
   runtime: HarnessRuntime | undefined
   agentSessionId: string | undefined
   current: LaneTask | undefined
@@ -196,7 +198,15 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
     const profile = await this.#getProfile()
     assertLaneTaskActive(task)
     const permissionMode = request.permissionMode ?? 'read-only'
-    if (lane.permissionMode !== undefined && lane.permissionMode !== permissionMode) {
+    const workspacePath = resolve(request.workspacePath)
+    // The cwd is fixed when the runtime process starts, so a lane that keeps
+    // running after the owner revokes a file permission would keep the
+    // directory it was given. Both halves of the sandbox have to invalidate
+    // the lane, not just the permission mode.
+    if (
+      (lane.permissionMode !== undefined && lane.permissionMode !== permissionMode) ||
+      (lane.workspacePath !== undefined && lane.workspacePath !== workspacePath)
+    ) {
       // Permission is lane-local. Changing a private chat from read-only to
       // workspace-write must not tear down the same employee's group lane.
       await lane.runtime?.close()
@@ -210,7 +220,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
         employee: request.employee,
         revision: request.revision,
         profile,
-        workspacePath: resolve(request.workspacePath),
+        workspacePath,
         sessionsRoot: join(resolve(this.#options.stateRoot), 'harness-sessions', request.employee.id, 'lanes', lane.id),
         permissionMode,
         conversationId,
@@ -222,6 +232,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
         throw new Error('Employee runtime closed')
       }
       lane.permissionMode = permissionMode
+      lane.workspacePath = workspacePath
       lane.runtime = runtime
     }
     // DSH 0.1.1-rc.1 cannot resume a named session whose JSONL log was created
@@ -296,6 +307,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       id: randomUUID().replaceAll('-', ''),
       conversationId,
       permissionMode: undefined,
+      workspacePath: undefined,
       runtime: undefined,
       agentSessionId: undefined,
       current: undefined,

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -1553,12 +1553,19 @@ export class SqliteStore {
       if (!sameAuthority(current, input.expectedAuthority)) {
         throw new PersistenceError('World authority changed concurrently; reload before retrying')
       }
+      const adminsBefore = this.#worldAuthorities.listActive(input.authority.worldId)
+        .filter((authority) => authority.role === 'administrator').length
       const updated = this.#worldAuthorities.save(input.authority)
       const activeEmployees = this.listEmployees(input.authority.worldId)
         .filter((employee) => employee.status !== 'archived')
       const activeAdmins = this.#worldAuthorities.listActive(input.authority.worldId)
         .filter((authority) => authority.role === 'administrator')
-      if (activeEmployees.length > 0 && activeAdmins.length === 0) {
+      // Only a write that *removes* the last administrator breaks the
+      // invariant. Refusing every edit in a world that already had none
+      // punished the wrong write: a world with no administrator could not have
+      // a single permission changed, and the refusal surfaced as a generic
+      // server error rather than something the owner could act on.
+      if (adminsBefore > 0 && activeEmployees.length > 0 && activeAdmins.length === 0) {
         throw new PersistenceError('last_world_administrator')
       }
       this.#worldAuthorities.appendChange(input.audit)
@@ -1594,6 +1601,15 @@ export class SqliteStore {
     permission: import('@dsh-cyber/contracts').WorldCharacterPermission,
   ): boolean {
     return this.#worldAuthorities.hasPermission(worldId, employeeId, permission)
+  }
+
+  /** Whether the owner ever revoked this permission from this character. */
+  wasWorldCharacterPermissionRevoked(
+    worldId: string,
+    employeeId: string,
+    permission: import('@dsh-cyber/contracts').WorldCharacterPermission,
+  ): boolean {
+    return this.#worldAuthorities.wasPermissionRevoked(worldId, employeeId, permission)
   }
 
   createWorldPermissionRequest(
@@ -1869,7 +1885,14 @@ export class SqliteStore {
         worldId: world.id,
         employeeId: employee.id,
         role: 'member',
-        permissionGrants: [],
+        // Derived from the runtime mode the character was recruited with, the
+        // same rule the legacy backfill uses. Recruiting used to leave the row
+        // empty, which is what made these permissions unenforceable: turning
+        // them into a real gate would have locked every new character out of
+        // its own world's files on day one.
+        permissionGrants: revision.runtimePermissionMode === 'read-only'
+          ? ['world.files.read']
+          : ['world.files.read', 'world.files.write'],
         createdAt: now,
         updatedAt: now,
       })

--- a/packages/persistence/src/world-character-authority-repository.ts
+++ b/packages/persistence/src/world-character-authority-repository.ts
@@ -120,6 +120,30 @@ export class WorldCharacterAuthorityRepository {
     return authority?.permissionGrants.includes(permission) === true
   }
 
+  /**
+   * Whether the owner ever took this permission away from this character.
+   *
+   * A missing grant is not a decision: characters have been recruited with an
+   * empty grant set all along, so absence only means nobody ever said
+   * anything. A removal is recorded in the append-only ledger, and that is a
+   * decision — the difference between "never mentioned" and "revoked".
+   *
+   * Re-granting is handled by the caller reading the current grant list: a
+   * permission that came back is present there, whatever the ledger holds.
+   */
+  wasPermissionRevoked(worldId: string, employeeId: string, permission: WorldCharacterPermission): boolean {
+    if (!isKnownPermission(permission)) return false
+    const row = this.#database
+      .prepare(
+        `SELECT 1 FROM world_authority_changes change,
+                json_each(change.removed_permissions_json) removed
+         WHERE change.world_id = ? AND change.employee_id = ? AND removed.value = ?
+         LIMIT 1`,
+      )
+      .get(worldId, employeeId, permission)
+    return row !== undefined
+  }
+
   save(input: SaveWorldCharacterAuthorityInput): WorldCharacterAuthority {
     assertRole(input.role)
     const employee = this.#assertEmployeeInWorld(input.worldId, input.employeeId)

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -71,7 +71,11 @@ describe('SqliteStore', () => {
     })
 
     expect(store.getWorld(world.id)?.administratorEmployeeId).toBeUndefined()
-    expect(store.getWorldCharacterAuthority(world.id, employee.id)).toMatchObject({ role: 'member', permissionGrants: [] })
+    // A recruited character starts with the file grants its runtime permission
+    // mode implies. An empty set was what made world.files.* unenforceable:
+    // the owner could see and revoke a permission nothing was ever checking.
+    expect(store.getWorldCharacterAuthority(world.id, employee.id))
+      .toMatchObject({ role: 'member', permissionGrants: ['world.files.read'] })
     expect(revision.runtimePermissionMode).toBe('read-only')
     expect(revision.revision).toBe(2)
     expect(store.getEmployee(employee.id)?.currentRevision).toBe(2)

--- a/packages/server/src/http/world-permission-errors.ts
+++ b/packages/server/src/http/world-permission-errors.ts
@@ -27,6 +27,12 @@ export function mapPermissionDecisionError(error: unknown): Error {
   if (error instanceof WorldPermissionGrantRejectedError) {
     return new HttpError(409, 'world_permission_grant_rejected', error.message)
   }
+  // The store raises this one as a bare PersistenceError whose message is the
+  // code. Unmapped it reached the client as a generic 500, which tells the
+  // owner nothing about the one action that would unblock them.
+  if (error instanceof Error && error.message === 'last_world_administrator') {
+    return new HttpError(409, 'last_world_administrator', '当前世界至少需要保留一名管理员，请先将另一名角色设为管理员。')
+  }
   const code = error instanceof Error ? (error as Error & { code?: unknown }).code : undefined
   if (code === 'world_permission_request_expired') {
     return new HttpError(409, 'world_permission_request_expired', '世界权限请求已过期')

--- a/packages/server/src/services/world-character-authority-service.ts
+++ b/packages/server/src/services/world-character-authority-service.ts
@@ -44,6 +44,17 @@ export class WorldCharacterAuthorityService {
     return this.#store.listWorldCharacterAuthorities(worldId)
   }
 
+  /**
+   * Whether the owner ever revoked this permission from this character.
+   *
+   * A missing grant is not a decision — characters are recruited with grants
+   * nobody has spoken about yet. A removal in the append-only ledger is.
+   */
+  wasPermissionRevoked(worldId: string, employeeId: string, permission: WorldCharacterPermission): boolean {
+    if (!isKnownPermission(permission)) return false
+    return this.#store.wasWorldCharacterPermissionRevoked(worldId, employeeId, permission)
+  }
+
   hasPermission(worldId: string, employeeId: string, permission: WorldCharacterPermission): boolean {
     if (!isKnownPermission(permission)) return false
     const employee = this.#store.getEmployee(employeeId)

--- a/packages/server/src/services/world-permission-request-service.ts
+++ b/packages/server/src/services/world-permission-request-service.ts
@@ -43,6 +43,17 @@ export interface WorldAuthorityPort {
     employeeId: string,
     permission: WorldCharacterPermission,
   ): boolean | Promise<boolean>
+  /**
+   * Whether the owner ever revoked this permission from this character.
+   *
+   * Optional: a host without an authority ledger cannot tell "never granted"
+   * from "taken away", and callers must treat that as never revoked.
+   */
+  wasPermissionRevoked?(
+    worldId: string,
+    employeeId: string,
+    permission: WorldCharacterPermission,
+  ): boolean | Promise<boolean>
   updateAuthority?(input: {
     worldId: string
     targetEmployeeId: string

--- a/packages/server/src/services/world-runtime-permission-resolver.ts
+++ b/packages/server/src/services/world-runtime-permission-resolver.ts
@@ -1,4 +1,4 @@
-import type { AgentPermissionMode } from '@dsh-cyber/contracts'
+import type { AgentPermissionMode, WorldCharacterPermission } from '@dsh-cyber/contracts'
 
 import type { WorldPermissionRequestService, WorldAuthorityPort } from './world-permission-request-service.js'
 import type { WorldRootService } from './world-root-service.js'
@@ -29,31 +29,60 @@ export interface ResolveWorldRuntimePermissionInput {
 
 /**
  * Resolves the DSH conversation sandbox and the character's world workspace.
- * The role's three-level conversation permission controls both the DSH tool
- * sandbox and access to the current World's workspace. Legacy World authority
- * inputs remain accepted by the constructor only for composition compatibility.
+ *
+ * The role's three-level runtime permission decides what a turn may do. On top
+ * of that, a World Permission the owner has explicitly **revoked** is enforced:
+ * revoking 读取当前世界文件 was recorded, audited and reported as done while the
+ * runtime kept receiving the world's real files, which made the control a lie.
+ *
+ * Only a revocation counts, never a missing grant. Characters have been
+ * recruited with an empty grant set all along, so absence means nobody ever
+ * said anything about files — treating it as a denial would lock every
+ * existing character out of its own world on the first start after upgrading.
  */
 export class WorldRuntimePermissionResolver {
   readonly #roots: WorldRootService
+  readonly #authority: WorldAuthorityPort | undefined
 
   constructor(options: { roots: WorldRootService; authority?: WorldAuthorityPort; worldPermissions?: WorldPermissionRequestService }) {
     this.#roots = options.roots
+    this.#authority = options.authority
   }
 
   async resolve(input: ResolveWorldRuntimePermissionInput): Promise<WorldRuntimePermissionResolution> {
     const root = await this.#roots.ensure(input.worldId)
     const requested = input.requestedMode ?? 'read-only'
-    const fileAccess: WorldFileAccess = requested === 'read-only' ? 'read' : 'write'
-    const permissionMode: AgentPermissionMode = requested === 'danger-full-access'
-      // Full host access is reachable only through an explicit current-session
-      // owner grant. The grant itself is already bound to world, session and
-      // character IDs before this resolver is called.
-      ? input.ownerHostAccess === true
-        ? 'danger-full-access'
-        : 'read-only'
-      : requested
-    const workspacePath = root.filesPath
+    const readDenied = await this.#denied(input.worldId, input.employeeId, 'world.files.read')
+    const writeDenied = readDenied || await this.#denied(input.worldId, input.employeeId, 'world.files.write')
+
+    const fileAccess: WorldFileAccess = readDenied
+      ? 'none'
+      : writeDenied || requested === 'read-only' ? 'read' : 'write'
+    // A revoked read is the owner's own decision about this world's files, and
+    // it is not overridden by a host-access grant: the way to undo it is to
+    // grant the permission back, not to escalate around it.
+    const permissionMode: AgentPermissionMode = readDenied
+      ? 'read-only'
+      : requested === 'danger-full-access'
+        ? input.ownerHostAccess === true ? 'danger-full-access' : 'read-only'
+        : requested === 'workspace-write' && !writeDenied ? 'workspace-write' : 'read-only'
+    // Without world.files.read the runtime is anchored at an empty
+    // host-managed workspace instead of the world's real files. Handing both
+    // cases the same directory is what made the permission inert.
+    const workspacePath = fileAccess === 'none' ? root.restrictedFilesPath : root.filesPath
     return { worldId: input.worldId, employeeId: input.employeeId, fileAccess, permissionMode, workspacePath }
+  }
+
+  /**
+   * A permission the owner took away and has not given back.
+   *
+   * Both halves matter: the ledger says a removal happened, and the current
+   * grant list says whether it was later restored.
+   */
+  async #denied(worldId: string, employeeId: string, permission: WorldCharacterPermission): Promise<boolean> {
+    if (this.#authority?.wasPermissionRevoked === undefined) return false
+    if (await this.#authority.hasPermission(worldId, employeeId, permission)) return false
+    return await this.#authority.wasPermissionRevoked(worldId, employeeId, permission)
   }
 
   async resolveForCharacter(input: ResolveWorldRuntimePermissionInput): Promise<WorldRuntimePermissionResolution> {

--- a/packages/server/tests/world-file-access.test.ts
+++ b/packages/server/tests/world-file-access.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from 'node:fs/promises'
+import { mkdtemp, readdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -104,6 +104,136 @@ async function chat(origin: string, worldId: string, employeeId: string, permiss
     ...(permissionMode === undefined ? {} : { permissionMode }),
   }))
 }
+
+/** Grants or revokes a World Permission the way the owner's UI does. */
+async function setWorldPermissions(
+  origin: string,
+  worldId: string,
+  employeeId: string,
+  permissions: string[],
+  role: 'member' | 'administrator' = 'member',
+) {
+  const result = await json(origin, `/api/worlds/${worldId}/authorities/${employeeId}`, send('PUT', {
+    role,
+    permissionGrants: permissions,
+    reason: 'file-permission-test',
+  }))
+  expect(result.response.status).toBe(200)
+}
+
+describe('the World file permissions the owner can see and toggle', () => {
+  it('lets the owner edit permissions in a world that has no administrator', async () => {
+    const { origin, world, characterId } = await start()
+    const result = await json(origin, `/api/worlds/${world.id}/authorities/${characterId}`, send('PUT', {
+      role: 'member',
+      permissionGrants: ['world.files.read', 'world.files.write'],
+      reason: 'no-administrator-world',
+    }))
+    // The bootstrapped world has no administrator, and the store refused every
+    // authority write in that state — as a generic 500. Only a write that
+    // removes the last administrator breaks the invariant.
+    expect(result.response.status).toBe(200)
+  })
+
+  it('anchors a character whose read permission the owner revoked', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read', 'world.files.write'])
+    await setWorldPermissions(origin, world.id, characterId, [])
+    await chat(origin, world.id, characterId)
+
+    const turn = runtime.turns.at(-1)!
+    // The owner can revoke 读取当前世界文件 in the roster, or say "取消小读的读
+    // 文件权限" in chat. It was recorded, audited and reported as done while
+    // the runtime kept receiving the world's real files.
+    expect(turn.workspacePath).toContain('restricted-workspace')
+    expect(await readdir(turn.workspacePath)).toEqual([])
+  })
+
+  it('keeps a character whose write permission the owner revoked out of write mode', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setDefaultPermission(origin, characterId, 'workspace-write')
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read', 'world.files.write'])
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await chat(origin, world.id, characterId)
+
+    const turn = runtime.turns.at(-1)!
+    expect(turn.workspacePath).not.toContain('restricted-workspace')
+    expect(turn.permissionMode).toBe('read-only')
+  })
+
+  it('restores access when the owner grants the permission back', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await setWorldPermissions(origin, world.id, characterId, [])
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await chat(origin, world.id, characterId)
+
+    // The ledger still holds the removal. What decides is the current grant.
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+  })
+
+  it('leaves a character nobody ever said anything about alone', async () => {
+    const { origin, server, runtime, world, characterId } = await start()
+    // Recruiting has always written an empty grant set, so absence is not a
+    // decision. Reading it as one would lock every existing character out of
+    // its own world on the first start after an upgrade.
+    // Recruiting derives the grants its runtime mode implies, and nothing has
+            // ever been taken away.
+    expect(server.store.wasWorldCharacterPermissionRevoked(world.id, characterId, 'world.files.read')).toBe(false)
+    await chat(origin, world.id, characterId)
+
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+  })
+
+  it('takes effect on a session that is already running', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await chat(origin, world.id, characterId)
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+
+    await setWorldPermissions(origin, world.id, characterId, [])
+    await chat(origin, world.id, characterId)
+
+    // A revocation the owner has to restart the app to enforce is not a
+    // revocation. The runtime's cwd is fixed when its process starts, so the
+    // lane has to be recycled when the workspace changes underneath it.
+    expect(runtime.turns.at(-1)!.workspacePath).toContain('restricted-workspace')
+  })
+
+  it('does not let a revoked read be escalated around with a host grant', async () => {
+    const { origin, server, runtime, world, characterId } = await start()
+    const session = server.store.createSession({
+      workspaceId: world.workspaceId,
+      worldId: world.id,
+      kind: 'direct',
+      title: '越权测试',
+      participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: characterId, kind: 'employee' }],
+    })
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await setWorldPermissions(origin, world.id, characterId, [])
+    const issued = await json(origin, `/api/worlds/${world.id}/runtime-access-grants`, send('POST', {
+      scope: 'session',
+      sessionId: session.id,
+      employeeIds: [characterId],
+      confirmed: true,
+    }))
+    expect(issued.response.status).toBe(201)
+
+    await json(origin, `/api/worlds/${world.id}/chat`, send('POST', {
+      prompt: '你好',
+      employeeIds: [characterId],
+      sessionId: session.id,
+      permissionMode: 'danger-full-access',
+      clientTurnId: 'turn-escalate',
+      runtimeAccessGrantId: issued.body.grant.id,
+    }))
+
+    // Two explicit owner decisions; the one about this world's files is the
+    // specific one. Undoing it means granting the permission back.
+    expect(runtime.turns.at(-1)!.permissionMode).toBe('read-only')
+    expect(runtime.turns.at(-1)!.workspacePath).toContain('restricted-workspace')
+  })
+})
 
 describe('role runtime access', () => {
   it('defaults a role to read-only in the real World workspace', async () => {


### PR DESCRIPTION
`world.files.read` / `world.files.write` 在角色名册里标着**读取当前世界文件**、**修改当前世界文件**，在对话里说「取消老王的文件写入权限」也会被解析成一次真实的撤销。系统会写库、记审计账本、把结果显示成"已完成"——**然后没有任何代码读它**。每个角色照样拿到世界的真实文件目录，被撤销的权限继续列目录、搜索、读、写。

`WorldFileAccess = 'none'` 和 `restrictedFilesPath` 都是死代码。

## 只拦"被撤销"，绝不拦"从未提及"

这是这个 PR 唯一重要的设计决定。

招募一直写的是空授权集（`permissionGrants: []`），所以**"没有授权"不携带任何决定**——它只意味着没人就文件说过话。把它当成拒绝，会让**每一个存量角色在升级后的第一次启动就被锁在自己世界的门外**。

而**撤销**记在只追加的审计账本里，那是一个决定。

判定是两半合起来的：当前授权集里没有它 **且** 账本里有过移除记录。所以把权限授回去就恢复访问，账本里的移除记录仍然保留。

## 撤销必须对正在进行的会话生效

运行时的 cwd 在进程启动时就定死了。原来 lane 只在**权限模式**变化时回收，工作目录变了不管——于是撤销之后，正在跑的会话会一直用着真实文件目录，直到 lane 恰好被淘汰。

**要重启 App 才生效的撤销不算撤销。**

## 其他

- 招募时按角色的运行时权限模式派生初始授权，让名册显示的是角色**实际能做什么**而不是一个空集。没有任何代码把这些授权当成拒绝，所以**不改变任何人的实际权限**。
- 被撤销的读权限不能用 owner 的主机访问授权绕过。两个都是 owner 的显式决定，但关于**这个世界文件**的那个更具体；想撤销就把权限授回去，而不是从旁边 escalate。

路上撞见并一并修了两个：

- 存储层在**没有管理员的世界**里拒绝**任何**权限写入，而不只是"移走最后一名管理员"的那次。默认世界恰好没有管理员，所以在它里面根本改不了任何权限。
- 那个错误没被映射，owner 看到的是 **500「服务器内部错误」**，而不是"请先设一名管理员"。现在是 409 + 可操作提示。

## 关于第一版（重要）

这个改动的第一版会在改运行时模式时派生授权，并用一条迁移回填存量库。一轮多智能体对抗评审确认了其中 **3 个 critical 缺陷**：

1. 迁移的"从未被碰过"判据会跳过任何被无关的持久化授权追加过的行——**那些角色会被彻底锁死**，而 owner 从未撤销过任何东西（评审用真实失败测试复现）。
2. 重新派生会**静默恢复 owner 撤销过的权限**，且不写审计行。
3. 会**剥夺 owner 明确授予管理员的写权限**，连带失去转授能力。

**这套机制在本 PR 中已完全不存在**——不是逐条打补丁，是那些代码被删掉了。评审的 7 条确认项里有 6 条因此结构性消失，第 7 条（存活会话的工作目录）单独修了。

因此本 PR **没有数据库迁移、没有 schema 版本变更**。

## 验证

- 先写复现测试证明漏洞存在（红），再修；去掉闸门会重新变红——实测过
- `pnpm typecheck` 通过
- `pnpm vitest run`：**676 通过**。1 条失败（`world-knowledge-library` 目录 realpath 越界）在干净 main 上同样失败，已在独立 worktree 验证
- `pnpm test:e2e`：8 红 26 绿，**与基线失败集逐条相同，零回归**。`role-runtime-permission.spec.ts` 通过
- 新增/重写 7 条测试：撤销读、撤销写、授回恢复、从未提及的角色不受影响、存活会话即时生效、不可用主机授权绕过、无管理员世界可编辑