### PR TITLE
"fix:让撤销的世界文件权限真正生效"

### DIFF
--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -83,6 +83,8 @@ interface EmployeeLane {
   id: string
   conversationId: string
   permissionMode: AgentPermissionMode | undefined
+  /** The directory this lane's runtime was started in. */
+  workspacePath: string | undefined
   runtime: HarnessRuntime | undefined
   agentSessionId: string | undefined
   current: LaneTask | undefined
@@ -196,7 +198,15 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
     const profile = await this.#getProfile()
     assertLaneTaskActive(task)
     const permissionMode = request.permissionMode ?? 'read-only'
-    if (lane.permissionMode !== undefined && lane.permissionMode !== permissionMode) {
+    const workspacePath = resolve(request.workspacePath)
+    // The cwd is fixed when the runtime process starts, so a lane that keeps
+    // running after the owner revokes a file permission would keep the
+    // directory it was given. Both halves of the sandbox have to invalidate
+    // the lane, not just the permission mode.
+    if (
+      (lane.permissionMode !== undefined && lane.permissionMode !== permissionMode) ||
+      (lane.workspacePath !== undefined && lane.workspacePath !== workspacePath)
+    ) {
       // Permission is lane-local. Changing a private chat from read-only to
       // workspace-write must not tear down the same employee's group lane.
       await lane.runtime?.close()
@@ -210,7 +220,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
         employee: request.employee,
         revision: request.revision,
         profile,
-        workspacePath: resolve(request.workspacePath),
+        workspacePath,
         sessionsRoot: join(resolve(this.#options.stateRoot), 'harness-sessions', request.employee.id, 'lanes', lane.id),
         permissionMode,
         conversationId,
@@ -222,6 +232,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
         throw new Error('Employee runtime closed')
       }
       lane.permissionMode = permissionMode
+      lane.workspacePath = workspacePath
       lane.runtime = runtime
     }
     // DSH 0.1.1-rc.1 cannot resume a named session whose JSONL log was created
@@ -296,6 +307,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       id: randomUUID().replaceAll('-', ''),
       conversationId,
       permissionMode: undefined,
+      workspacePath: undefined,
       runtime: undefined,
       agentSessionId: undefined,
       current: undefined,

--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -1553,12 +1553,19 @@ export class SqliteStore {
       if (!sameAuthority(current, input.expectedAuthority)) {
         throw new PersistenceError('World authority changed concurrently; reload before retrying')
       }
+      const adminsBefore = this.#worldAuthorities.listActive(input.authority.worldId)
+        .filter((authority) => authority.role === 'administrator').length
       const updated = this.#worldAuthorities.save(input.authority)
       const activeEmployees = this.listEmployees(input.authority.worldId)
         .filter((employee) => employee.status !== 'archived')
       const activeAdmins = this.#worldAuthorities.listActive(input.authority.worldId)
         .filter((authority) => authority.role === 'administrator')
-      if (activeEmployees.length > 0 && activeAdmins.length === 0) {
+      // Only a write that *removes* the last administrator breaks the
+      // invariant. Refusing every edit in a world that already had none
+      // punished the wrong write: a world with no administrator could not have
+      // a single permission changed, and the refusal surfaced as a generic
+      // server error rather than something the owner could act on.
+      if (adminsBefore > 0 && activeEmployees.length > 0 && activeAdmins.length === 0) {
         throw new PersistenceError('last_world_administrator')
       }
       this.#worldAuthorities.appendChange(input.audit)
@@ -1594,6 +1601,15 @@ export class SqliteStore {
     permission: import('@dsh-cyber/contracts').WorldCharacterPermission,
   ): boolean {
     return this.#worldAuthorities.hasPermission(worldId, employeeId, permission)
+  }
+
+  /** Whether the owner ever revoked this permission from this character. */
+  wasWorldCharacterPermissionRevoked(
+    worldId: string,
+    employeeId: string,
+    permission: import('@dsh-cyber/contracts').WorldCharacterPermission,
+  ): boolean {
+    return this.#worldAuthorities.wasPermissionRevoked(worldId, employeeId, permission)
   }
 
   createWorldPermissionRequest(
@@ -1869,7 +1885,14 @@ export class SqliteStore {
         worldId: world.id,
         employeeId: employee.id,
         role: 'member',
-        permissionGrants: [],
+        // Derived from the runtime mode the character was recruited with, the
+        // same rule the legacy backfill uses. Recruiting used to leave the row
+        // empty, which is what made these permissions unenforceable: turning
+        // them into a real gate would have locked every new character out of
+        // its own world's files on day one.
+        permissionGrants: revision.runtimePermissionMode === 'read-only'
+          ? ['world.files.read']
+          : ['world.files.read', 'world.files.write'],
         createdAt: now,
         updatedAt: now,
       })

--- a/packages/persistence/src/world-character-authority-repository.ts
+++ b/packages/persistence/src/world-character-authority-repository.ts
@@ -120,6 +120,30 @@ export class WorldCharacterAuthorityRepository {
     return authority?.permissionGrants.includes(permission) === true
   }
 
+  /**
+   * Whether the owner ever took this permission away from this character.
+   *
+   * A missing grant is not a decision: characters have been recruited with an
+   * empty grant set all along, so absence only means nobody ever said
+   * anything. A removal is recorded in the append-only ledger, and that is a
+   * decision — the difference between "never mentioned" and "revoked".
+   *
+   * Re-granting is handled by the caller reading the current grant list: a
+   * permission that came back is present there, whatever the ledger holds.
+   */
+  wasPermissionRevoked(worldId: string, employeeId: string, permission: WorldCharacterPermission): boolean {
+    if (!isKnownPermission(permission)) return false
+    const row = this.#database
+      .prepare(
+        `SELECT 1 FROM world_authority_changes change,
+                json_each(change.removed_permissions_json) removed
+         WHERE change.world_id = ? AND change.employee_id = ? AND removed.value = ?
+         LIMIT 1`,
+      )
+      .get(worldId, employeeId, permission)
+    return row !== undefined
+  }
+
   save(input: SaveWorldCharacterAuthorityInput): WorldCharacterAuthority {
     assertRole(input.role)
     const employee = this.#assertEmployeeInWorld(input.worldId, input.employeeId)

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -71,7 +71,11 @@ describe('SqliteStore', () => {
     })
 
     expect(store.getWorld(world.id)?.administratorEmployeeId).toBeUndefined()
-    expect(store.getWorldCharacterAuthority(world.id, employee.id)).toMatchObject({ role: 'member', permissionGrants: [] })
+    // A recruited character starts with the file grants its runtime permission
+    // mode implies. An empty set was what made world.files.* unenforceable:
+    // the owner could see and revoke a permission nothing was ever checking.
+    expect(store.getWorldCharacterAuthority(world.id, employee.id))
+      .toMatchObject({ role: 'member', permissionGrants: ['world.files.read'] })
     expect(revision.runtimePermissionMode).toBe('read-only')
     expect(revision.revision).toBe(2)
     expect(store.getEmployee(employee.id)?.currentRevision).toBe(2)

--- a/packages/server/src/http/world-permission-errors.ts
+++ b/packages/server/src/http/world-permission-errors.ts
@@ -27,6 +27,12 @@ export function mapPermissionDecisionError(error: unknown): Error {
   if (error instanceof WorldPermissionGrantRejectedError) {
     return new HttpError(409, 'world_permission_grant_rejected', error.message)
   }
+  // The store raises this one as a bare PersistenceError whose message is the
+  // code. Unmapped it reached the client as a generic 500, which tells the
+  // owner nothing about the one action that would unblock them.
+  if (error instanceof Error && error.message === 'last_world_administrator') {
+    return new HttpError(409, 'last_world_administrator', '当前世界至少需要保留一名管理员，请先将另一名角色设为管理员。')
+  }
   const code = error instanceof Error ? (error as Error & { code?: unknown }).code : undefined
   if (code === 'world_permission_request_expired') {
     return new HttpError(409, 'world_permission_request_expired', '世界权限请求已过期')

--- a/packages/server/src/services/world-character-authority-service.ts
+++ b/packages/server/src/services/world-character-authority-service.ts
@@ -44,6 +44,17 @@ export class WorldCharacterAuthorityService {
     return this.#store.listWorldCharacterAuthorities(worldId)
   }
 
+  /**
+   * Whether the owner ever revoked this permission from this character.
+   *
+   * A missing grant is not a decision — characters are recruited with grants
+   * nobody has spoken about yet. A removal in the append-only ledger is.
+   */
+  wasPermissionRevoked(worldId: string, employeeId: string, permission: WorldCharacterPermission): boolean {
+    if (!isKnownPermission(permission)) return false
+    return this.#store.wasWorldCharacterPermissionRevoked(worldId, employeeId, permission)
+  }
+
   hasPermission(worldId: string, employeeId: string, permission: WorldCharacterPermission): boolean {
     if (!isKnownPermission(permission)) return false
     const employee = this.#store.getEmployee(employeeId)

--- a/packages/server/src/services/world-permission-request-service.ts
+++ b/packages/server/src/services/world-permission-request-service.ts
@@ -43,6 +43,17 @@ export interface WorldAuthorityPort {
     employeeId: string,
     permission: WorldCharacterPermission,
   ): boolean | Promise<boolean>
+  /**
+   * Whether the owner ever revoked this permission from this character.
+   *
+   * Optional: a host without an authority ledger cannot tell "never granted"
+   * from "taken away", and callers must treat that as never revoked.
+   */
+  wasPermissionRevoked?(
+    worldId: string,
+    employeeId: string,
+    permission: WorldCharacterPermission,
+  ): boolean | Promise<boolean>
   updateAuthority?(input: {
     worldId: string
     targetEmployeeId: string

--- a/packages/server/src/services/world-runtime-permission-resolver.ts
+++ b/packages/server/src/services/world-runtime-permission-resolver.ts
@@ -1,4 +1,4 @@
-import type { AgentPermissionMode } from '@dsh-cyber/contracts'
+import type { AgentPermissionMode, WorldCharacterPermission } from '@dsh-cyber/contracts'
 
 import type { WorldPermissionRequestService, WorldAuthorityPort } from './world-permission-request-service.js'
 import type { WorldRootService } from './world-root-service.js'
@@ -29,31 +29,60 @@ export interface ResolveWorldRuntimePermissionInput {
 
 /**
  * Resolves the DSH conversation sandbox and the character's world workspace.
- * The role's three-level conversation permission controls both the DSH tool
- * sandbox and access to the current World's workspace. Legacy World authority
- * inputs remain accepted by the constructor only for composition compatibility.
+ *
+ * The role's three-level runtime permission decides what a turn may do. On top
+ * of that, a World Permission the owner has explicitly **revoked** is enforced:
+ * revoking 读取当前世界文件 was recorded, audited and reported as done while the
+ * runtime kept receiving the world's real files, which made the control a lie.
+ *
+ * Only a revocation counts, never a missing grant. Characters have been
+ * recruited with an empty grant set all along, so absence means nobody ever
+ * said anything about files — treating it as a denial would lock every
+ * existing character out of its own world on the first start after upgrading.
  */
 export class WorldRuntimePermissionResolver {
   readonly #roots: WorldRootService
+  readonly #authority: WorldAuthorityPort | undefined
 
   constructor(options: { roots: WorldRootService; authority?: WorldAuthorityPort; worldPermissions?: WorldPermissionRequestService }) {
     this.#roots = options.roots
+    this.#authority = options.authority
   }
 
   async resolve(input: ResolveWorldRuntimePermissionInput): Promise<WorldRuntimePermissionResolution> {
     const root = await this.#roots.ensure(input.worldId)
     const requested = input.requestedMode ?? 'read-only'
-    const fileAccess: WorldFileAccess = requested === 'read-only' ? 'read' : 'write'
-    const permissionMode: AgentPermissionMode = requested === 'danger-full-access'
-      // Full host access is reachable only through an explicit current-session
-      // owner grant. The grant itself is already bound to world, session and
-      // character IDs before this resolver is called.
-      ? input.ownerHostAccess === true
-        ? 'danger-full-access'
-        : 'read-only'
-      : requested
-    const workspacePath = root.filesPath
+    const readDenied = await this.#denied(input.worldId, input.employeeId, 'world.files.read')
+    const writeDenied = readDenied || await this.#denied(input.worldId, input.employeeId, 'world.files.write')
+
+    const fileAccess: WorldFileAccess = readDenied
+      ? 'none'
+      : writeDenied || requested === 'read-only' ? 'read' : 'write'
+    // A revoked read is the owner's own decision about this world's files, and
+    // it is not overridden by a host-access grant: the way to undo it is to
+    // grant the permission back, not to escalate around it.
+    const permissionMode: AgentPermissionMode = readDenied
+      ? 'read-only'
+      : requested === 'danger-full-access'
+        ? input.ownerHostAccess === true ? 'danger-full-access' : 'read-only'
+        : requested === 'workspace-write' && !writeDenied ? 'workspace-write' : 'read-only'
+    // Without world.files.read the runtime is anchored at an empty
+    // host-managed workspace instead of the world's real files. Handing both
+    // cases the same directory is what made the permission inert.
+    const workspacePath = fileAccess === 'none' ? root.restrictedFilesPath : root.filesPath
     return { worldId: input.worldId, employeeId: input.employeeId, fileAccess, permissionMode, workspacePath }
+  }
+
+  /**
+   * A permission the owner took away and has not given back.
+   *
+   * Both halves matter: the ledger says a removal happened, and the current
+   * grant list says whether it was later restored.
+   */
+  async #denied(worldId: string, employeeId: string, permission: WorldCharacterPermission): Promise<boolean> {
+    if (this.#authority?.wasPermissionRevoked === undefined) return false
+    if (await this.#authority.hasPermission(worldId, employeeId, permission)) return false
+    return await this.#authority.wasPermissionRevoked(worldId, employeeId, permission)
   }
 
   async resolveForCharacter(input: ResolveWorldRuntimePermissionInput): Promise<WorldRuntimePermissionResolution> {

--- a/packages/server/src/services/world-runtime-permission-resolver.ts
+++ b/packages/server/src/services/world-runtime-permission-resolver.ts
@@ -61,7 +61,11 @@ export class WorldRuntimePermissionResolver {
     // A revoked read is the owner's own decision about this world's files, and
     // it is not overridden by a host-access grant: the way to undo it is to
     // grant the permission back, not to escalate around it.
-    const permissionMode: AgentPermissionMode = readDenied
+    // A write revocation is just as specific as a read revocation. Leaving a
+    // confirmed danger-full-access lane active here would let the runtime
+    // write the same world directory by absolute path, making the visible
+    // world.files.write revocation ineffective.
+    const permissionMode: AgentPermissionMode = readDenied || writeDenied
       ? 'read-only'
       : requested === 'danger-full-access'
         ? input.ownerHostAccess === true ? 'danger-full-access' : 'read-only'

--- a/packages/server/tests/world-file-access.test.ts
+++ b/packages/server/tests/world-file-access.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp } from 'node:fs/promises'
+import { mkdtemp, readdir } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -104,6 +104,136 @@ async function chat(origin: string, worldId: string, employeeId: string, permiss
     ...(permissionMode === undefined ? {} : { permissionMode }),
   }))
 }
+
+/** Grants or revokes a World Permission the way the owner's UI does. */
+async function setWorldPermissions(
+  origin: string,
+  worldId: string,
+  employeeId: string,
+  permissions: string[],
+  role: 'member' | 'administrator' = 'member',
+) {
+  const result = await json(origin, `/api/worlds/${worldId}/authorities/${employeeId}`, send('PUT', {
+    role,
+    permissionGrants: permissions,
+    reason: 'file-permission-test',
+  }))
+  expect(result.response.status).toBe(200)
+}
+
+describe('the World file permissions the owner can see and toggle', () => {
+  it('lets the owner edit permissions in a world that has no administrator', async () => {
+    const { origin, world, characterId } = await start()
+    const result = await json(origin, `/api/worlds/${world.id}/authorities/${characterId}`, send('PUT', {
+      role: 'member',
+      permissionGrants: ['world.files.read', 'world.files.write'],
+      reason: 'no-administrator-world',
+    }))
+    // The bootstrapped world has no administrator, and the store refused every
+    // authority write in that state — as a generic 500. Only a write that
+    // removes the last administrator breaks the invariant.
+    expect(result.response.status).toBe(200)
+  })
+
+  it('anchors a character whose read permission the owner revoked', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read', 'world.files.write'])
+    await setWorldPermissions(origin, world.id, characterId, [])
+    await chat(origin, world.id, characterId)
+
+    const turn = runtime.turns.at(-1)!
+    // The owner can revoke 读取当前世界文件 in the roster, or say "取消小读的读
+    // 文件权限" in chat. It was recorded, audited and reported as done while
+    // the runtime kept receiving the world's real files.
+    expect(turn.workspacePath).toContain('restricted-workspace')
+    expect(await readdir(turn.workspacePath)).toEqual([])
+  })
+
+  it('keeps a character whose write permission the owner revoked out of write mode', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setDefaultPermission(origin, characterId, 'workspace-write')
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read', 'world.files.write'])
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await chat(origin, world.id, characterId)
+
+    const turn = runtime.turns.at(-1)!
+    expect(turn.workspacePath).not.toContain('restricted-workspace')
+    expect(turn.permissionMode).toBe('read-only')
+  })
+
+  it('restores access when the owner grants the permission back', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await setWorldPermissions(origin, world.id, characterId, [])
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await chat(origin, world.id, characterId)
+
+    // The ledger still holds the removal. What decides is the current grant.
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+  })
+
+  it('leaves a character nobody ever said anything about alone', async () => {
+    const { origin, server, runtime, world, characterId } = await start()
+    // Recruiting has always written an empty grant set, so absence is not a
+    // decision. Reading it as one would lock every existing character out of
+    // its own world on the first start after an upgrade.
+    // Recruiting derives the grants its runtime mode implies, and nothing has
+            // ever been taken away.
+    expect(server.store.wasWorldCharacterPermissionRevoked(world.id, characterId, 'world.files.read')).toBe(false)
+    await chat(origin, world.id, characterId)
+
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+  })
+
+  it('takes effect on a session that is already running', async () => {
+    const { origin, runtime, world, characterId } = await start()
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await chat(origin, world.id, characterId)
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+
+    await setWorldPermissions(origin, world.id, characterId, [])
+    await chat(origin, world.id, characterId)
+
+    // A revocation the owner has to restart the app to enforce is not a
+    // revocation. The runtime's cwd is fixed when its process starts, so the
+    // lane has to be recycled when the workspace changes underneath it.
+    expect(runtime.turns.at(-1)!.workspacePath).toContain('restricted-workspace')
+  })
+
+  it('does not let a revoked read be escalated around with a host grant', async () => {
+    const { origin, server, runtime, world, characterId } = await start()
+    const session = server.store.createSession({
+      workspaceId: world.workspaceId,
+      worldId: world.id,
+      kind: 'direct',
+      title: '越权测试',
+      participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: characterId, kind: 'employee' }],
+    })
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    await setWorldPermissions(origin, world.id, characterId, [])
+    const issued = await json(origin, `/api/worlds/${world.id}/runtime-access-grants`, send('POST', {
+      scope: 'session',
+      sessionId: session.id,
+      employeeIds: [characterId],
+      confirmed: true,
+    }))
+    expect(issued.response.status).toBe(201)
+
+    await json(origin, `/api/worlds/${world.id}/chat`, send('POST', {
+      prompt: '你好',
+      employeeIds: [characterId],
+      sessionId: session.id,
+      permissionMode: 'danger-full-access',
+      clientTurnId: 'turn-escalate',
+      runtimeAccessGrantId: issued.body.grant.id,
+    }))
+
+    // Two explicit owner decisions; the one about this world's files is the
+    // specific one. Undoing it means granting the permission back.
+    expect(runtime.turns.at(-1)!.permissionMode).toBe('read-only')
+    expect(runtime.turns.at(-1)!.workspacePath).toContain('restricted-workspace')
+  })
+})
 
 describe('role runtime access', () => {
   it('defaults a role to read-only in the real World workspace', async () => {

--- a/packages/server/tests/world-file-access.test.ts
+++ b/packages/server/tests/world-file-access.test.ts
@@ -233,6 +233,38 @@ describe('the World file permissions the owner can see and toggle', () => {
     expect(runtime.turns.at(-1)!.permissionMode).toBe('read-only')
     expect(runtime.turns.at(-1)!.workspacePath).toContain('restricted-workspace')
   })
+
+  it('does not let a revoked write be escalated around with a host grant', async () => {
+    const { origin, server, runtime, world, characterId } = await start()
+    const session = server.store.createSession({
+      workspaceId: world.workspaceId,
+      worldId: world.id,
+      kind: 'direct',
+      title: '写权限越权测试',
+      participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: characterId, kind: 'employee' }],
+    })
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read', 'world.files.write'])
+    await setWorldPermissions(origin, world.id, characterId, ['world.files.read'])
+    const issued = await json(origin, `/api/worlds/${world.id}/runtime-access-grants`, send('POST', {
+      scope: 'session',
+      sessionId: session.id,
+      employeeIds: [characterId],
+      confirmed: true,
+    }))
+    expect(issued.response.status).toBe(201)
+
+    await json(origin, `/api/worlds/${world.id}/chat`, send('POST', {
+      prompt: '尝试修改世界文件',
+      employeeIds: [characterId],
+      sessionId: session.id,
+      permissionMode: 'danger-full-access',
+      clientTurnId: 'turn-write-escalate',
+      runtimeAccessGrantId: issued.body.grant.id,
+    }))
+
+    expect(runtime.turns.at(-1)!.permissionMode).toBe('read-only')
+    expect(runtime.turns.at(-1)!.workspacePath).not.toContain('restricted-workspace')
+  })
 })
 
 describe('role runtime access', () => {


### PR DESCRIPTION
整合并审阅外部 PR #83，保留原作者提交。

补充修复：撤销世界写权限后，即使会话存在已确认的完全访问授权，也必须降级为只读，避免通过绝对路径绕过权限撤销。

验证：
- `pnpm typecheck`
- `world-file-access`、`sqlite-store`、`harness-adapter` 共 58 项测试通过
- `role-runtime-permission` 浏览器 E2E 通过

外部 fork 未发布受保护分支要求的 `CI / required` 状态，因此通过本仓库集成 PR 进入 `main`。
