### PR TITLE
fix: extend Creative Workshop model timeout

### DIFF
--- a/packages/server/src/routes/package-routes.ts
+++ b/packages/server/src/routes/package-routes.ts
@@ -17,6 +17,8 @@ import type { WorldMarketplaceService } from '../services/world-marketplace-serv
 import type { WorldPackageInstanceService } from '../services/world-package-instance-service.js'
 import type { WorldAccessService } from '../services/world-access-service.js'
 
+const CREATIVE_WORKSHOP_MODEL_TIMEOUT_MS = 240_000
+
 export interface PackageRoutesDependencies {
   store: SqliteStore
   packageManager: PackageManager
@@ -35,7 +37,13 @@ export function registerPackageRoutes(router: Router, dependencies: PackageRoute
   const workshop = new CreativeWorkshopService(store, packageManager)
   const workshopDrafts = new CreativeWorkshopDraftService(store)
   const workshopDraftGenerator = dependencies.workshopDraftGenerator
-    ?? new CreativeWorkshopDraftGenerator(store, credentials, workshopDrafts, { skillCatalog })
+    ?? new CreativeWorkshopDraftGenerator(store, credentials, workshopDrafts, {
+      skillCatalog,
+      // A complete structured world + role draft is a much heavier request than
+      // host-side routing/classification. Keep ModelJsonCall's fast 20s default
+      // for planners while giving Creative Workshop a dedicated four-minute budget.
+      timeoutMs: CREATIVE_WORKSHOP_MODEL_TIMEOUT_MS,
+    })
 
   router.get(/^\/api\/workspaces\/([^/]+)\/packages$/, ({ response, params }) => {
     const workspaceId = params[0]!


### PR DESCRIPTION
## Problem
Creative Workshop draft generation can legitimately take longer than the shared host-side `ModelJsonCall` default of 20 seconds. Slow structured-output models such as `sensenova-6.8-flash-lite` were being aborted locally even though the model and local service were otherwise healthy.

## Fix
- Give the production Creative Workshop draft generator a dedicated **240 second (4 minute)** timeout.
- Keep the shared `ModelJsonCall` default at **20 seconds** so group planners, routing/classification calls, and other lightweight host decisions still fail fast.
- Preserve test/custom generator injection behavior.

This is intentionally scoped to Creative Workshop only.

Base: `main@514d7057b9efaa8adfa7195b9c2f0997c932954b`

Merge after Required CI is green.