### PR TITLE
fix: 提供真实可点击的数字人员工聚焦入口

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,7 @@
 - 触发：Harness 淘汰 idle lane 时先从 Map 删除，再异步等待 runtime.close。现象：关闭 Promise 未完成期间的两个新会话分别创建 lane，短暂突破每角色最多两条通道。固定处理：EmployeeWorker 记录 closing lane reservation，任何创建都以 `lanes.size + closingLanes` 校验容量；close 回调恢复后再次校验，worker 关闭后不得复活 lane。验证：用 deferred close 制造两个并发新会话，断言存活 runtime 峰值不超过 2，所有任务仍能完成或明确中止。
 - 触发：Pixi 画布挂载后左右面板宽度变化，但浏览器窗口尺寸没有变化。现象：renderer 仍使用旧容器宽度，世界视图右侧出现黑边或裁切，切换 Dock 后更明显。固定处理：用 `ResizeObserver` 监听实际画布宿主，显式调用 renderer resize，更新 stage hit area，再按新视口重新计算 cover camera；不能只依赖 Pixi 的 `resizeTo: window`。验证：单元测试改变宿主宽度后断言 renderer 尺寸和 cover scale 更新；浏览器在 1440×900、1920×1080、3840×2160 截图中检查画布铺满且无黑边。
 - 触发：世界 Overview 的 Pixi WebGL 尚未释放时，Employee Focus 在 React render 或同一帧内探测/创建 Three WebGL；或能力探测主动调用 `WEBGL_lose_context`。现象：SwiftShader、软件渲染器和部分低配 Windows 驱动会整页黑屏或主线程冻结，VRM 无法进入也无法自动降级。固定处理：Focus 首帧先使用静态 Sprite，Overview 完成聚焦后卸载 Pixi 并以当前主题底图保持连续；至少延后一帧再探测硬件 WebGL，探测不得主动丢失上下文；Headless、SwiftShader、llvmpipe、减弱动态效果直接使用静态模式。退出 Focus 必须销毁 Three RAF、Observer、Mixer、材质、纹理和上下文后再恢复地图。验证：Playwright 的软件 WebGL/减少动态效果场景不下载 VRM chunk 且不冻结；硬件浏览器验证 VRM 按需加载、退出后 Canvas 为 0、再次进入仅 1 个 Canvas。
+- 触发：浏览器 E2E 通过 `.sr-only` 镜像按钮、`evaluate(element.click())` 或强制点击进入功能。现象：自动化通过，但真实页面没有可发现、可点击的入口，用户刷新后无法进入。固定处理：核心功能必须在正常视觉流中提供原生 `button`/`a`，同时具备清晰文案、岗位上下文、hover 与 `focus-visible`；测试只能点击同一个真实可见控件，禁止隐藏镜像、坐标猜测、`force` 或脚本触发作为成功证据。验证：E2E 先断言入口 visible/enabled 后普通 click，再断言目标区域；并在用户真实本地数据页面重复“可见入口 → 点击 → 目标界面 → 返回后入口仍存在”，记录截图与 console error/warn。
 
 ## 市场安装与启用闭环
 

--- a/docs/03-Luna模型执行计划书.md
+++ b/docs/03-Luna模型执行计划书.md
@@ -42,3 +42,10 @@ pnpm exec playwright test e2e/digital-human-world.spec.ts
 ```
 
 视觉验收继续覆盖 1440×900、1920×1080、3840×2160；构建门禁要求主入口不引用 Three/VRM，VRM 懒加载 chunk 不超过 950 kB。
+
+### Employee Focus 可见入口修正
+
+- 原数字人 E2E 使用隐藏按钮脚本触发，不能证明真实用户可以进入；该验收方式已废止。
+- 世界 HUD 的“当前会话”现在直接展示可点击的角色与岗位，点击后进入对应 Employee Focus；地图人物点击继续作为空间快捷方式。
+- E2E 必须对真实入口执行 `visible + enabled + 普通 click`，并验证 Focus 和返回路径；禁止 `force`、隐藏镜像和 `evaluate().click()`。
+- 已在本地真实股票分析团队数据页面完成点击验证，控制台 error/warn 为 0。

--- a/e2e/digital-human-world.spec.ts
+++ b/e2e/digital-human-world.spec.ts
@@ -83,7 +83,20 @@ test('keeps overview and employee focus continuous while loading and disposing V
 
   const screenshotRoot = join(process.cwd(), 'artifacts', 'employee-focus')
   await mkdir(screenshotRoot, { recursive: true })
-  await page.screenshot({ path: join(screenshotRoot, 'overview-1440x900.png'), fullPage: false })
+  for (const viewport of [
+    { width: 1_440, height: 900, label: '1440x900' },
+    { width: 1_920, height: 1_080, label: '1920x1080' },
+    { width: 3_840, height: 2_160, label: '3840x2160' },
+  ]) {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height })
+    const entry = page.getByRole('button', { name: `进入${employeeName}员工聚焦`, exact: true })
+    await expect(entry).toBeVisible()
+    await expect(entry).toBeEnabled()
+    const entryPanel = page.locator('.world-runtime-dock__focus')
+    expect(await entryPanel.evaluate((element) => element.scrollWidth <= element.clientWidth + 1)).toBe(true)
+    await page.screenshot({ path: join(screenshotRoot, `focus-entry-${viewport.label}.png`), fullPage: false })
+  }
+  await page.setViewportSize({ width: 1_440, height: 900 })
   await enterFocus(page)
   const focus = page.getByRole('region', { name: `${employeeName}员工聚焦` })
   await expect(focus).toBeVisible()
@@ -180,7 +193,10 @@ test('previews an uploaded portrait, publishes a new avatar revision, and restor
 })
 
 async function enterFocus(page: Page): Promise<void> {
-  await page.getByRole('button', { name: `${employeeName}世界角色` }).evaluate((element) => (element as HTMLButtonElement).click())
+  const entry = page.getByRole('button', { name: `进入${employeeName}员工聚焦`, exact: true })
+  await expect(entry).toBeVisible()
+  await expect(entry).toBeEnabled()
+  await entry.click()
   await expect(page.getByRole('region', { name: `${employeeName}员工聚焦` })).toBeVisible()
 }
 

--- a/packages/web/src/features/world/WorldRuntimeDock.tsx
+++ b/packages/web/src/features/world/WorldRuntimeDock.tsx
@@ -6,6 +6,7 @@ import {
   Minus,
   Plus,
   PersonSimpleWalk,
+  UserFocus,
 } from '@phosphor-icons/react'
 import { useEffect, useRef, useState } from 'react'
 import type { WorkSession, World, WorldInteractionAction, WorldRuntimeSnapshot, WorldZoomCommand } from '@dsh-cyber/contracts'
@@ -74,7 +75,9 @@ export function WorldRuntimeDock({ demoMode, world, employees, liveEnabled = tru
   const peerInitiator = employees.find((employee) => employee.id === peerInitiatorId)
   const selectedObject = renderedSnapshot.objects.find((object) => object.id === selectedObjectId)
   const selectedObjectManifest = runtime.manifest.scenes.find((scene) => scene.id === renderedSnapshot.sceneId)?.interactables.find((object) => object.id === selectedObjectId)
-  const focusedNames = conversationEmployeeIds.map((employeeId) => employees.find((employee) => employee.id === employeeId)?.displayName).filter((name): name is string => name !== undefined)
+  const conversationEmployees = conversationEmployeeIds
+    .map((employeeId) => employees.find((employee) => employee.id === employeeId))
+    .filter((employee): employee is CyberEmployee => employee !== undefined)
   const focusedEmployee = employees.find((employee) => employee.id === focusEmployeeId)
   const focusedEntity = renderedSnapshot.entities.find((entity) => entity.id === focusEmployeeId)
 
@@ -201,7 +204,26 @@ export function WorldRuntimeDock({ demoMode, world, employees, liveEnabled = tru
           </div>
           {focusedEmployee === undefined ? null : <EmployeeFocusMode world={world} employee={focusedEmployee} {...(focusedEntity === undefined ? {} : { entity: focusedEntity })} connected={runtime.connected} staticMode={staticMode} {...(latestUtterance === undefined ? {} : { latestUtterance })} onStaticModeChange={setStaticMode} onBack={leaveEmployeeFocus} onOpenDossier={() => onOpenDossier(focusedEmployee.id)} onOpenTrace={onOpenTrace} onOpenConversation={() => onSelectEmployee(focusedEmployee.id)} />}
 
-          {focusEmployeeId !== undefined || focusedNames.length === 0 ? null : <div className="world-runtime-dock__focus" aria-label="当前会话成员"><span>当前会话</span><strong>{focusedNames.join('、')}</strong></div>}
+          {focusEmployeeId !== undefined || conversationEmployees.length === 0 ? null : (
+            <div className="world-runtime-dock__focus" aria-label="当前会话成员">
+              <span>当前会话 · 点击角色进入数字人</span>
+              <div className="world-runtime-dock__focus-list">
+                {conversationEmployees.map((employee) => (
+                  <button
+                    key={employee.id}
+                    type="button"
+                    aria-label={`进入${employee.displayName}员工聚焦`}
+                    title={`${employee.displayName} · ${employee.role}`}
+                    onClick={() => enterEmployeeFocus(employee.id)}
+                  >
+                    <UserFocus size={14} aria-hidden="true" />
+                    <strong>{employee.displayName}</strong>
+                    <small>· {employee.role}</small>
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
 
           {focusEmployeeId !== undefined || selectedEmployee === undefined || contextTarget?.kind !== 'employee' || contextTarget.id !== selectedEmployee.id ? null : <EmployeeInteractionMenu employee={selectedEmployee} position={contextTarget.position} onClose={() => setContextTarget(undefined)} onTalk={() => void interactWithEmployee('talk')} onAssignTask={() => void interactWithEmployee('assign-task')} onMeeting={() => void interactWithEmployee('start-meeting')} onPeerCollaboration={() => { setPeerError(undefined); setPeerInitiatorId(selectedEmployee.id) }} />}
           {focusEmployeeId !== undefined || selectedObject === undefined || selectedObjectManifest === undefined || contextTarget?.kind !== 'object' || contextTarget.id !== selectedObject.id ? null : <ObjectInteractionMenu object={selectedObject} manifest={selectedObjectManifest} position={contextTarget.position} {...(selectedEmployee === undefined ? {} : { selectedEmployee })} onClose={() => setContextTarget(undefined)} onAction={(action) => void actOnObject(action)} />}

--- a/packages/web/src/features/world/world-runtime.css
+++ b/packages/web/src/features/world/world-runtime.css
@@ -154,9 +154,15 @@
 .world-runtime-dock__view-switch { position: absolute; z-index: 28; top: 12px; left: 50%; translate: -50% 0; min-height: 36px; display: flex; align-items: center; padding: 2px; border: 1px solid var(--border-strong); border-radius: 999px; background: color-mix(in srgb, var(--surface-0) 94%, transparent); box-shadow: var(--shadow-sm); }
 .world-runtime-dock__view-switch button { min-height: 30px; display: inline-flex; align-items: center; gap: 6px; padding: 0 12px; border: 0; border-radius: 999px; color: var(--accent-strong); background: color-mix(in srgb, var(--accent) 8%, transparent); font: inherit; font-size: 12px; cursor: pointer; }
 .world-runtime-dock__view-switch button:hover, .world-runtime-dock__view-switch button:focus-visible { color: var(--text); background: color-mix(in srgb, var(--accent) 14%, transparent); outline: 2px solid color-mix(in srgb, var(--accent) 28%, transparent); outline-offset: 1px; }
-.world-runtime-dock__focus { position: absolute; z-index: 10; left: 12px; top: 12px; max-width: min(320px, calc(100% - 120px)); display: grid; gap: 2px; padding: 8px 10px; border: 1px solid rgba(117,137,149,.3); border-radius: 4px; background: rgba(7,13,17,.84); backdrop-filter: blur(10px); pointer-events: none; }
+.world-runtime-dock__focus { position: absolute; z-index: 10; left: 12px; top: 12px; max-width: min(540px, calc(100% - 120px)); display: grid; gap: 6px; padding: 8px 10px; border: 1px solid rgba(117,137,149,.3); border-radius: 4px; background: rgba(7,13,17,.9); }
 .world-runtime-dock__focus span { color: #7f8e96; font-size: 12px; }
-.world-runtime-dock__focus strong { overflow: hidden; color: #dbe4e8; font-size: 12px; white-space: nowrap; text-overflow: ellipsis; }
+.world-runtime-dock__focus-list { display: flex; flex-wrap: wrap; gap: 4px; }
+.world-runtime-dock__focus-list button { min-width: 0; min-height: 40px; display: flex; align-items: center; gap: 4px; padding: 0 8px; border: 1px solid rgba(117,137,149,.24); border-radius: 4px; color: #dbe4e8; background: rgba(18,25,30,.88); cursor: pointer; transition: color 120ms var(--ease-smooth), border-color 120ms var(--ease-smooth), background-color 120ms var(--ease-smooth); }
+.world-runtime-dock__focus-list button:hover { color: var(--accent-strong); border-color: color-mix(in srgb, var(--accent) 58%, var(--border)); background: color-mix(in srgb, var(--accent) 10%, var(--surface-1)); }
+.world-runtime-dock__focus-list button:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.world-runtime-dock__focus-list button svg { flex: none; color: var(--accent); }
+.world-runtime-dock__focus-list strong, .world-runtime-dock__focus-list small { overflow: hidden; max-width: 170px; font-size: 12px; white-space: nowrap; text-overflow: ellipsis; }
+.world-runtime-dock__focus-list small { color: #8e9ba3; }
 .world-runtime-dock__controls { position: absolute; z-index: 10; right: 12px; bottom: 12px; display: flex; border: 1px solid rgba(117,137,149,.34); border-radius: 4px; background: rgba(7,13,17,.88); backdrop-filter: blur(10px); overflow: hidden; }
 .world-runtime-dock__controls button { width: 38px; height: 36px; display: grid; place-items: center; padding: 0; border: 0; border-right: 1px solid rgba(117,137,149,.22); color: #9ba9b1; background: transparent; }
 .world-runtime-dock__controls button:last-child { border-right: 0; }


### PR DESCRIPTION
## 问题

PR #97 的 Employee Focus 只能通过地图人物进入；人物不在当前镜头时没有可发现入口。原 E2E 又使用隐藏 `.sr-only` 按钮配合 `evaluate().click()`，导致自动化通过但真实用户无法点击。

## 修复

- 世界 HUD 的“当前会话”显示可见角色按钮，角色名字后保留岗位。
- 普通点击角色按钮直接执行地图聚焦并进入对应 Employee Focus。
- 保留地图人物点击作为空间快捷入口。
- E2E 删除隐藏脚本触发，改为 `visible + enabled + 普通 click`。
- 新增 1440×900、1920×1080、3840×2160 入口截图和溢出检查。
- 将“禁止隐藏测试钩子冒充可用入口”写入工程与设计护栏。

## 验证

- `pnpm typecheck`
- `pnpm build`
- 数字人 E2E：3 passed；入口核心流程单测：1 passed
- Renderer Registry Vitest：3 passed
- 在本地真实股票投资分析团队页面验证：三个角色入口均 visible/enabled；点击林思琪后 Focus 可见，返回后入口仍存在；console warn/error 为 0