### PR TITLE
feat-moss-tts-true-streaming

### DIFF
--- a/docs/adr/0009-voice-context-avatar-runtime-v2.md
+++ b/docs/adr/0009-voice-context-avatar-runtime-v2.md
@@ -1,0 +1,121 @@
+# ADR 0009：Voice、Context 与 Avatar Runtime V2
+
+- 状态：Accepted
+- 日期：2026-08-31
+- 替代/扩展：`digital-human-avatar-runtime-v1.md` 的语音流、上下文预算与 3D 入口部分
+
+## 背景
+
+DSH Cyber 已经具备本地 STT/VAD、MOSS/Kokoro TTS、角色级语音档案、2D/VRM Renderer、角色长期记忆和世界知识检索。当前主要问题不是缺少更多按钮，而是三条运行链路缺少统一的性能与演进边界：
+
+- MOSS ONNX 内部虽做增量 codec decode，Sidecar 却在返回前重新拼成整段 PCM；
+- 长期记忆以里程碑和字符数预算注入，缺少 thread checkpoint、token budget、滚动摘要、缓存与命中诊断；
+- 地图/2D/3D 已有入口，但角色没有 VRM 时仍可点击 3D，形象管理入口与运行准备状态不够直接。
+
+V2 的目标是复用既有 Conversation、Agent Runtime、World Runtime 与 Renderer Registry，而不是再造 Voice Agent、Memory Agent 或 3D World 三套平行系统。
+
+## 决策一：语音是 Agent Runtime 的流式输入输出层
+
+```text
+LLM text.delta
+  -> StreamingSentenceChunker
+  -> TextToSpeechProvider
+  -> AudioChunk AsyncIterable
+  -> DSHV PCM stream
+  -> Web Audio queue + speech activity
+  -> VRM/Sprite speech controller
+```
+
+- MOSS Sidecar 直接发送每次 codec 增量解码得到的 PCM，不再等待完整波形或 WAV。
+- Sidecar 协议使用 `audio(sequence, sampleRate, pcm)` 与独立 `done(sequence)`；Node Provider 将 `done` 映射为零长度 `final` 帧。
+- Kokoro 与 MOSS 共用宿主 `AsyncQueue`，Provider 只负责模型协议，HTTP 路由和 UI 不知道模型实现。
+- Barge-in 继续杀掉当前 TTS 进程/请求和 Audio Queue，但不自动取消 Agent WorkTurn。
+- 单次播报被打断后立即在后台重建并预热 MOSS Sidecar；应用退出、模型删除和显式 dispose 才保持关闭，避免下一轮重新承担完整冷启动。
+- MOSS 保持默认自然语音包；未安装、失败或不满足性能策略时降级到 Kokoro，再降级到系统中文声音。
+- 音频帧、模型和 Python Runtime 不进入首屏；模型只在语音设置、试听、自动播报或 Voice Mode 预热时加载。
+
+### 性能门禁
+
+- Warm TTFA：P50 < 600ms，P95 < 800ms；
+- RTF P95 < 1；
+- 未启用语音时不加载 MOSS/Kokoro，不创建 AudioContext；
+- 推理只在 Sidecar/Worker，Node/React 主线程不得出现语音推理 Long Task；
+- Benchmark 必须报告 cold start、TTFA、chunk 数、潜在断流、RTF、进程树 RAM 和整机 CPU 占比。
+
+## 决策二：上下文由预算规划器组合，不由各服务无限拼接
+
+DSH 保留现有事实源，但在 Harness 调用前增加 Provider-neutral 的 `ContextBudgetPlanner`：
+
+```text
+固定层：system + persona + authority + permission + skill recipes
+工作层：当前用户请求 + 最近消息窗口 + 当前 WorkTurn/approval facts
+压缩层：thread rolling summary/checkpoint
+检索层：employee episodic memory + world knowledge
+保留层：模型输出预算 + tool/result safety margin
+```
+
+- 所有预算以 token 估算为主，字符数只作为无法获得 tokenizer 时的保守 fallback。
+- 短期记忆按 conversation/thread 隔离，长期记忆按 employee/world/scope 隔离；私聊记忆不得进入群聊。
+- 当软阈值到达时后台生成滚动摘要；硬阈值到达时必须压缩或裁剪，不能把超长 Prompt 交给 Provider 失败。
+- 摘要是有来源范围和版本的 checkpoint，不覆盖原始消息；需要时可以从 SQLite 重建。
+- 检索缓存键至少包含 `scope + sourceRevision + normalizedQuery + budgetProfile`，消息/里程碑/知识 revision 改变后自动失效。
+- 先使用本地关键词/BM25/FTS 热路径；向量或模型重写是可选 Adapter，不进入每轮必经路径。
+- 每轮记录 `inputBudget / usedTokens / cacheHit / memoriesConsidered / memoriesInjected / summaryVersion / trimReason`，详细数据只进入诊断和轨迹，不塞进聊天。
+
+参考实现只借鉴边界：LangGraph 区分 thread checkpoint 与 long-term store，并提供 trim/summary；Letta 把长期可见资料建模为可挂载 memory blocks；OpenHands Condenser 区分 soft/hard condensation。DSH 不引入它们的 Agent loop。
+
+## 决策三：地图、2D、3D 是同一角色焦点的 Renderer 切换
+
+当前入口位于世界右栏的 `地图 / 2D / 3D` 分段控件；选择 2D 或 3D 后，点击左侧私聊会自动切换到该角色，群聊则将最新发言者置于中心并展示其他参与者。
+
+V2 交互收敛为：
+
+1. `地图`：世界概览与设施交互；
+2. `2D`：所有角色立即可用的低成本 Focus；
+3. `3D`：角色已发布 VRM 时一键进入；没有 VRM 时不显示空白失败，而是在原位展示“添加 3D 形象”，直接打开该角色的形象管理；
+4. 会话切换只更换 Focus 角色，不要求重复选择 2D/3D；
+5. hover/聚焦 3D 控件只预取轻量能力和资源清单，真正 Three/VRM chunk 在确认进入后加载；
+6. 3D 加载期间保留 2D Sprite bridge，失败、低 FPS、软件 WebGL、减弱动态效果自动回退 2D；
+7. 角色档案保存形象 revision 与能力清单，世界和会话不保存 Renderer 私有状态。
+
+VRM 1.0 继续作为首选 3D 角色格式，因为其规范直接覆盖 humanoid、表情、a/i/u/e/o 口型、视线和 SpringBone。TalkingHead/HeadAudio 只作为 AudioWorklet、viseme queue 和动作调度参考，不替换现有 Renderer Registry。
+
+## 防止代码继续膨胀
+
+- `EmployeeFocusMode` 只做页面组合，语音设置、播放控制、模型包管理和 Avatar 模式状态逐步迁移到独立 feature/controller；
+- Provider 不 import React、SQLite 或具体 HTTP 路由；
+- `ContextBudgetPlanner` 不读取供应商私有 token API，通过 TokenEstimator Port 获取估算；
+- Renderer Adapter 不改变会话、任务、产物或世界事实；
+- 新能力必须有合同测试、性能门禁和浏览器真实入口测试，禁止隐藏按钮或脚本点击冒充完成。
+
+## 分阶段交付
+
+### Phase A：Voice Streaming
+
+- MOSS codec chunk 协议、共享 AsyncQueue、零长度 final 帧；
+- TTFA/chunk/断流/RAM/CPU Benchmark；
+- 浏览器连续播放、停止、Barge-in 和 2D/VRM speaking 验收。
+
+### Phase B：Context Budget + Cache
+
+- ContextBudgetPlanner、TokenEstimator、预算档位和诊断；
+- thread rolling summary/checkpoint；
+- memory/knowledge retrieval cache 与 revision 失效；
+- 长会话性能与隐私隔离 E2E。
+
+### Phase C：Avatar Entry V2
+
+- 3D 能力状态与“添加 3D 形象”原位入口；
+- 角色形象管理直达、预热策略和加载进度；
+- Renderer 控制器从 EmployeeFocusMode 拆分；
+- 2D/3D/地图跨会话、群聊和低配降级 E2E。
+
+## 参考
+
+- [OpenMOSS/MOSS-TTS-Nano](https://github.com/OpenMOSS/MOSS-TTS-Nano)
+- [LangGraph memory](https://langchain-ai.github.io/langgraph/how-tos/memory/manage-conversation-history/)
+- [OpenHands context condenser](https://github.com/OpenHands/software-agent-sdk/blob/main/openhands-sdk/openhands/sdk/context/condenser/base.py)
+- [Letta memory blocks](https://docs.letta.com/tutorials/attaching-detaching-blocks/)
+- [VRM features](https://vrm.dev/en/vrm/vrm_features/)
+- [met4citizen/TalkingHead](https://github.com/met4citizen/talkinghead)
+- [met4citizen/HeadAudio](https://github.com/met4citizen/HeadAudio)

--- a/docs/architecture/digital-human-avatar-runtime-v1.md
+++ b/docs/architecture/digital-human-avatar-runtime-v1.md
@@ -6,7 +6,7 @@ DSH Cyber 的数字人不应绑定某一个 TTS、头像生成或 3D 供应商�
 
 当前实现已经落地本地 Voice Conversation、`expression + gesture` 动作合同、VRM 1.0 运行时和本地形象版本管理。中文 TTS 使用 sherpa-onnx Node Runtime + Kokoro 82M int8，提供 55 个女声与 45 个男声；STT 使用 Streaming Paraformer int8，Silero VAD 负责可靠分段，独立快速能量门负责 150ms 内 Barge-in。模型按需加载到 Worker Thread，不进入浏览器包或阻塞 Node 主循环。用户可选择关闭、手动或自动播报，配置按角色持久化；自动模式消费 `text.delta`，经 SentenceChunker 尽早生成首句。麦克风音频和回复内容默认不落盘、不上传。
 
-世界概览与数字人不再是两个 Tab。地图角色是入口：用户在 Overview 点击角色，地图镜头先聚焦，随后进入同一世界内的 Employee Focus；退出 Focus 时销毁 Three 资源并恢复地图。Focus 继承当前世界主题底图、角色、运行状态和最终回复，不创建默认“行动舱”或另一套事实源。
+世界概览与数字人属于同一世界右栏，通过紧凑的“地图 / 2D / 3D”视图控件切换，不提升为重复的全局页签。进入 2D/3D 后，选择私聊会直接切换对应角色；群聊将最新发言者放在中心并展示其他参与者。Focus 继承当前世界主题底图、角色、运行状态和最终回复，不创建默认“行动舱”或另一套事实源。
 
 ## 开源方案调研
 
@@ -63,7 +63,7 @@ WebGL/Canvas/Video presentation
 
 - 角色设置已经新增形象管理：支持本地 PNG/JPEG/WebP、自包含 VRM 1.0 和普通 GLB 预览；普通 GLB 缺少 `VRMC_vrm`、Humanoid 或身份元数据时不能发布为交互数字人。
 - 上传只生成预览，显式发布才创建新的角色 Profile revision；恢复旧形象同样创建新 revision，历史不可改写。
-- Overview 点击地图角色进入 Employee Focus；Focus 使用当前世界主题，不再提供地图/数字人模式 Tab。
+- 世界右栏提供“地图 / 2D / 3D”视图控件；会话切换直接更新 Employee Focus，选择保持在当前世界本地偏好中。
 - Renderer Registry 已提供 `sprite-2d`、`vrm-3d` 和供应商无关的 `LiveAvatarRendererPort`。核心没有绑定 HeyGen 或其他云供应商。
 - `three`、`@pixiv/three-vrm`、`@pixiv/three-vrm-animation` 位于独立懒加载 chunk，首屏 HTML 不预加载。
 - VRM Runtime 已拆分 Motion、Expression、LookAt、Blink、Speech、Animation、Performance 和 Resource Controller；状态来自 `WorldRuntimeSnapshot`，不是 UI 自行推断成功。
@@ -89,5 +89,5 @@ WebGL/Canvas/Video presentation
 - 主入口 JavaScript 约 299 kB，主 CSS 约 275 kB；相对引入 VRM 前只增加少量编排代码。
 - VRM Runtime 为约 916 kB 的独立懒加载 chunk（gzip 约 232 kB），只在硬件 WebGL 的 VRM Focus 或显式 3D 预览中下载。
 - 构建门禁会解析 `index.html`，若首屏预加载 Three/VRM 或懒加载 chunk 超过 950 kB 则失败。
-- 浏览器端移除了约 25 MB ONNX WASM 和 Transformers/Kokoro JS。当前实测：TTS 冷加载约 1.92s，短中文首音频约 0.77–0.86s，RTF P50 约 1.15；Streaming Paraformer 冷加载约 1.49s，测试音频首个 partial 计算约 53ms、Final 约 387ms；稳定语音到 Barge-in 事件约 64ms。
+- 浏览器端移除了约 25 MB ONNX WASM 和 Transformers/Kokoro JS。当前实测：MOSS-TTS-Nano CPU Sidecar 冷加载约 4.24s，Warm 首音频 P50 约 0.50s/P95 约 0.54s，RTF P50 约 0.56；Kokoro 继续作为快速降级。Streaming Paraformer 冷加载约 1.49s，测试音频首个 partial 计算约 53ms、Final 约 387ms；稳定语音到 Barge-in 事件约 64ms。
 - Playwright 覆盖 Overview → Focus、执行/说话状态、退出/重入、三种视口、减少动态效果和软件 WebGL 降级；Vitest 使用 `three-vrm` 的真实 `VRMLoaderPlugin` 解析发布合同夹具并驱动各 Controller。

--- a/packages/server/runtime/moss-tts-sidecar.py
+++ b/packages/server/runtime/moss-tts-sidecar.py
@@ -4,9 +4,13 @@ import argparse
 import base64
 import json
 import sys
-import tempfile
 import types
 from pathlib import Path
+
+import numpy as np
+
+
+STREAM_DECODE_FRAME_BATCH = 8
 
 
 def install_lightweight_import_stubs(output_root: Path) -> None:
@@ -46,6 +50,75 @@ def install_lightweight_import_stubs(output_root: Path) -> None:
     sys.modules.setdefault("text_normalization_pipeline", normalization)
 
 
+def emit_audio(request_id: str, sequence: int, waveform: np.ndarray, sample_rate: int) -> None:
+    pcm = np.asarray(waveform, dtype=np.float32).reshape(-1).tobytes()
+    print(json.dumps({
+        "type": "audio",
+        "id": request_id,
+        "sequence": sequence,
+        "sampleRate": sample_rate,
+        "pcmBase64": base64.b64encode(pcm).decode("ascii"),
+    }), flush=True)
+
+
+def stream_synthesize(runtime, request_id: str, text: str, voice: str) -> int:
+    runtime.manifest["generation_defaults"]["max_new_frames"] = min(240, max(32, len(text) * 5))
+    prepared = runtime.prepare_synthesis_text(
+        text=text,
+        voice=voice,
+        enable_wetext=False,
+        enable_normalize_tts_text=False,
+    )
+    prepared_text = str(prepared["text"])
+    prompt_audio_codes = runtime.resolve_prompt_audio_codes(voice=voice, prompt_audio_path=None)
+    text_chunks = runtime.split_voice_clone_text(prepared_text, max_tokens=75)
+    sample_rate = int(runtime.codec_meta["codec_config"]["sample_rate"])
+    sequence = 0
+
+    for chunk_index, chunk_text in enumerate(text_chunks):
+        text_token_ids = runtime.encode_text(chunk_text)
+        request_rows = runtime.build_voice_clone_request_rows(prompt_audio_codes, text_token_ids)
+        pending_frames: list[list[int]] = []
+        runtime.codec_streaming_session.reset()
+
+        def decode_pending(force: bool) -> None:
+            nonlocal sequence
+            while pending_frames and (force or len(pending_frames) >= STREAM_DECODE_FRAME_BATCH):
+                frame_count = len(pending_frames) if force else STREAM_DECODE_FRAME_BATCH
+                frame_chunk = pending_frames[:frame_count]
+                del pending_frames[:frame_count]
+                decoded = runtime.codec_streaming_session.run_frames(frame_chunk)
+                if decoded is None:
+                    continue
+                audio, audio_length = decoded
+                if audio_length <= 0:
+                    continue
+                waveform = np.asarray(audio[0, :, :audio_length], dtype=np.float32).mean(axis=0)
+                emit_audio(request_id, sequence, waveform, sample_rate)
+                sequence += 1
+
+        def on_frame(_generated_frames: list[list[int]], _step_index: int, frame: list[int]) -> None:
+            pending_frames.append(list(frame))
+            decode_pending(False)
+
+        try:
+            runtime.generate_audio_frames(request_rows, on_frame=on_frame)
+            decode_pending(True)
+        finally:
+            runtime.codec_streaming_session.reset()
+
+        if chunk_index < len(text_chunks) - 1:
+            pause_seconds = runtime.estimate_voice_clone_inter_chunk_pause_seconds(chunk_text)
+            pause_samples = max(0, int(round(sample_rate * pause_seconds)))
+            if pause_samples > 0:
+                emit_audio(request_id, sequence, np.zeros((pause_samples,), dtype=np.float32), sample_rate)
+                sequence += 1
+
+    if sequence == 0:
+        raise RuntimeError("MOSS 语音没有生成音频")
+    return sequence
+
+
 def main() -> None:
     sys.stdin.reconfigure(encoding="utf-8", errors="strict")
     sys.stdout.reconfigure(encoding="utf-8", errors="strict")
@@ -76,28 +149,8 @@ def main() -> None:
             voice = str(request.get("voice") or (voices[0] if voices else "Junhao"))
             if not text:
                 raise ValueError("播报文字不能为空")
-            with tempfile.NamedTemporaryFile(suffix=".wav", dir=output_root, delete=False) as temporary:
-                output_path = Path(temporary.name)
-            try:
-                result = runtime.synthesize(
-                    text=text,
-                    voice=voice,
-                    output_audio_path=output_path,
-                    streaming=True,
-                    enable_wetext=False,
-                    enable_normalize_tts_text=False,
-                    max_new_frames=min(240, max(32, len(text) * 5)),
-                )
-                waveform = result["waveform"]
-                if getattr(waveform, "ndim", 1) == 2:
-                    waveform = waveform.mean(axis=1)
-                pcm = waveform.astype("float32", copy=False).tobytes()
-                print(json.dumps({
-                    "type": "audio", "id": request_id, "sampleRate": int(result["sample_rate"]),
-                    "pcmBase64": base64.b64encode(pcm).decode("ascii"), "voice": voice,
-                }), flush=True)
-            finally:
-                output_path.unlink(missing_ok=True)
+            sequence = stream_synthesize(runtime, request_id, text, voice)
+            print(json.dumps({"type": "done", "id": request_id, "sequence": sequence, "voice": voice}), flush=True)
         except Exception as error:
             print(json.dumps({"type": "error", "id": locals().get("request_id", "unknown"), "message": str(error)}, ensure_ascii=False), flush=True)
 

--- a/packages/server/src/voice/async-queue.ts
+++ b/packages/server/src/voice/async-queue.ts
@@ -1,0 +1,39 @@
+export class AsyncQueue<T> implements AsyncIterable<T> {
+  #items: T[] = []
+  #waiting: Array<{ resolve(value: IteratorResult<T>): void; reject(error: unknown): void }> = []
+  #closed = false
+  #error: unknown
+
+  push(value: T): void {
+    if (this.#closed) return
+    const waiter = this.#waiting.shift()
+    if (waiter !== undefined) waiter.resolve({ value, done: false })
+    else this.#items.push(value)
+  }
+
+  close(): void {
+    if (this.#closed) return
+    this.#closed = true
+    for (const waiter of this.#waiting.splice(0)) waiter.resolve({ value: undefined, done: true })
+  }
+
+  fail(error: unknown): void {
+    if (this.#closed) return
+    this.#items = []
+    this.#error = error
+    this.#closed = true
+    for (const waiter of this.#waiting.splice(0)) waiter.reject(error)
+  }
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return {
+      next: async () => {
+        const value = this.#items.shift()
+        if (value !== undefined) return { value, done: false }
+        if (this.#error !== undefined) throw this.#error
+        if (this.#closed) return { value: undefined, done: true }
+        return new Promise<IteratorResult<T>>((resolve, reject) => this.#waiting.push({ resolve, reject }))
+      },
+    }
+  }
+}

--- a/packages/server/src/voice/tts/moss-tts-provider.ts
+++ b/packages/server/src/voice/tts/moss-tts-provider.ts
@@ -5,15 +5,21 @@ import { join } from 'node:path'
 import { createInterface, type Interface } from 'node:readline'
 
 import type { AudioChunk, TextToSpeechCapabilities, TextToSpeechProvider, TtsRequest, VoiceRuntimeState } from '@dsh-cyber/contracts'
+import { AsyncQueue } from '../async-queue.js'
 
-type PendingRequest = { resolve(value: MossAudio): void; reject(error: unknown): void; timeout: ReturnType<typeof setTimeout> }
-type MossAudio = { sampleRate: number; pcm: Float32Array; voice: string }
+type PendingRequest = {
+  queue: AsyncQueue<AudioChunk>
+  timeout: ReturnType<typeof setTimeout>
+  detachAbort(): void
+  sampleRate: number
+  nextSequence: number
+}
 type MossTtsProviderOptions = { executable?: string; sidecar?: string; requestTimeoutMs?: number; startupTimeoutMs?: number }
 
 export class MossTtsProvider implements TextToSpeechProvider {
   readonly id = 'moss-tts-nano-local'
   readonly kind = 'moss' as const
-  readonly capabilities: TextToSpeechCapabilities = { streaming: false, pcm: true, viseme: false, voiceClone: false }
+  readonly capabilities: TextToSpeechCapabilities = { streaming: true, pcm: true, viseme: false, voiceClone: false }
   #state: VoiceRuntimeState = 'cold'
   #process: ChildProcessWithoutNullStreams | undefined
   #readline: Interface | undefined
@@ -35,35 +41,34 @@ export class MossTtsProvider implements TextToSpeechProvider {
     await this.#ensureProcess()
     if (request.signal?.aborted === true) throw abortError('MOSS 语音生成已取消')
     this.#state = 'busy'
-    const audio = await new Promise<MossAudio>((resolve, reject) => {
-      const timeout = setTimeout(() => {
-        this.#pending.delete(request.requestId)
-        this.#terminate(abortError('MOSS 语音生成超时'))
-        reject(abortError('MOSS 语音生成超时'))
-      }, this.options.requestTimeoutMs ?? 60_000)
-      this.#pending.set(request.requestId, { resolve, reject, timeout })
-      const abort = () => this.cancel(request.requestId)
-      request.signal?.addEventListener('abort', abort, { once: true })
-      const voice = request.voiceId.startsWith('moss:') ? request.voiceId.slice('moss:'.length) : this.#voices[0] ?? 'Junhao'
-      this.#process!.stdin.write(`${JSON.stringify({ id: request.requestId, text: request.text, voice })}\n`, (error) => {
-        if (error !== null && error !== undefined) reject(error)
-      })
+    const queue = new AsyncQueue<AudioChunk>()
+    const abort = () => this.cancel(request.requestId)
+    request.signal?.addEventListener('abort', abort, { once: true })
+    const timeout = setTimeout(() => this.#terminate(abortError('MOSS 语音生成超时')), this.options.requestTimeoutMs ?? 60_000)
+    this.#pending.set(request.requestId, {
+      queue,
+      timeout,
+      detachAbort: () => request.signal?.removeEventListener('abort', abort),
+      sampleRate: 48_000,
+      nextSequence: 0,
     })
-    this.#state = 'ready'
-    yield { sequence: 0, pcm: audio.pcm, sampleRate: audio.sampleRate, durationMs: audio.pcm.length / audio.sampleRate * 1000, final: true }
+    const voice = request.voiceId.startsWith('moss:') ? request.voiceId.slice('moss:'.length) : this.#voices[0] ?? 'Junhao'
+    this.#process!.stdin.write(`${JSON.stringify({ id: request.requestId, text: request.text, voice })}\n`, (error) => {
+      if (error !== null && error !== undefined) this.#terminate(error)
+    })
+    try {
+      for await (const chunk of queue) yield chunk
+    } finally {
+      if (this.#pending.has(request.requestId)) this.cancel(request.requestId)
+      else this.#finishRequest(request.requestId)
+    }
   }
 
   cancel(requestId?: string): void {
     const error = abortError('MOSS 语音生成已取消')
-    if (requestId !== undefined) {
-      const pending = this.#pending.get(requestId)
-      if (pending === undefined) return
-      clearTimeout(pending.timeout); this.#pending.delete(requestId); pending.reject(error)
-    } else {
-      for (const pending of this.#pending.values()) { clearTimeout(pending.timeout); pending.reject(error) }
-      this.#pending.clear()
-    }
+    if (requestId !== undefined && !this.#pending.has(requestId)) return
     this.#terminate(error)
+    if (requestId !== undefined) void this.prepare().catch(() => undefined)
   }
 
   async dispose(): Promise<void> {
@@ -118,13 +123,39 @@ export class MossTtsProvider implements TextToSpeechProvider {
     if (id === undefined) return
     const pending = this.#pending.get(id)
     if (pending === undefined) return
-    clearTimeout(pending.timeout)
-    this.#pending.delete(id)
-    if (message.type === 'error') { pending.reject(new Error(typeof message.message === 'string' ? message.message : 'MOSS 语音生成失败')); return }
-    if (message.type !== 'audio' || typeof message.pcmBase64 !== 'string' || typeof message.sampleRate !== 'number') { pending.reject(new Error('MOSS 语音运行时返回无效数据')); return }
+    if (message.type === 'error') {
+      pending.queue.fail(new Error(typeof message.message === 'string' ? message.message : 'MOSS 语音生成失败'))
+      this.#finishRequest(id)
+      return
+    }
+    if (message.type === 'done') {
+      const sequence = Number.isInteger(message.sequence) ? message.sequence as number : pending.nextSequence
+      pending.queue.push({ sequence, pcm: new Float32Array(0), sampleRate: pending.sampleRate, durationMs: 0, final: true })
+      pending.queue.close()
+      this.#finishRequest(id)
+      return
+    }
+    if (message.type !== 'audio' || typeof message.pcmBase64 !== 'string' || typeof message.sampleRate !== 'number') {
+      pending.queue.fail(new Error('MOSS 语音运行时返回无效数据'))
+      this.#finishRequest(id)
+      return
+    }
     const buffer = Buffer.from(message.pcmBase64, 'base64')
     const view = new Float32Array(buffer.buffer, buffer.byteOffset, Math.floor(buffer.byteLength / 4))
-    pending.resolve({ sampleRate: message.sampleRate, pcm: new Float32Array(view), voice: typeof message.voice === 'string' ? message.voice : '' })
+    const sequence = Number.isInteger(message.sequence) ? message.sequence as number : pending.nextSequence
+    const pcm = new Float32Array(view)
+    pending.sampleRate = message.sampleRate
+    pending.nextSequence = sequence + 1
+    pending.queue.push({ sequence, pcm, sampleRate: message.sampleRate, durationMs: pcm.length / message.sampleRate * 1000, final: false })
+  }
+
+  #finishRequest(id: string): void {
+    const pending = this.#pending.get(id)
+    if (pending === undefined) return
+    clearTimeout(pending.timeout)
+    pending.detachAbort()
+    this.#pending.delete(id)
+    if (this.#process !== undefined && this.#pending.size === 0) this.#state = 'ready'
   }
 
   #terminate(error: unknown): void {
@@ -132,7 +163,11 @@ export class MossTtsProvider implements TextToSpeechProvider {
     this.#process?.kill(); this.#process = undefined
     this.#ready = undefined
     this.#state = 'cold'
-    for (const pending of this.#pending.values()) { clearTimeout(pending.timeout); pending.reject(error) }
+    for (const pending of this.#pending.values()) {
+      clearTimeout(pending.timeout)
+      pending.detachAbort()
+      pending.queue.fail(error)
+    }
     this.#pending.clear()
   }
 }

--- a/packages/server/src/voice/tts/sherpa-kokoro-tts-provider.ts
+++ b/packages/server/src/voice/tts/sherpa-kokoro-tts-provider.ts
@@ -2,6 +2,7 @@ import { createRequire } from 'node:module'
 import { join } from 'node:path'
 
 import type { AudioChunk, TextToSpeechCapabilities, TextToSpeechProvider, TtsRequest, VoiceRuntimeState } from '@dsh-cyber/contracts'
+import { AsyncQueue } from '../async-queue.js'
 
 interface SherpaModule {
   OfflineTts: { createAsync(config: unknown): Promise<SherpaTts> }
@@ -143,46 +144,6 @@ export class SherpaKokoroTtsProvider implements TextToSpeechProvider {
 
 function chunk(sequence: number, pcm: Float32Array, sampleRate: number, final: boolean): AudioChunk {
   return { sequence, pcm, sampleRate, durationMs: pcm.length / sampleRate * 1000, final }
-}
-
-class AsyncQueue<T> implements AsyncIterable<T> {
-  #items: T[] = []
-  #waiting: Array<{ resolve(value: IteratorResult<T>): void; reject(error: unknown): void }> = []
-  #closed = false
-  #error: unknown
-
-  push(value: T): void {
-    if (this.#closed) return
-    const waiter = this.#waiting.shift()
-    if (waiter !== undefined) waiter.resolve({ value, done: false })
-    else this.#items.push(value)
-  }
-
-  close(): void {
-    if (this.#closed) return
-    this.#closed = true
-    for (const waiter of this.#waiting.splice(0)) waiter.resolve({ value: undefined, done: true })
-  }
-
-  fail(error: unknown): void {
-    if (this.#closed) return
-    this.#items = []
-    this.#error = error
-    this.#closed = true
-    for (const waiter of this.#waiting.splice(0)) waiter.reject(error)
-  }
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return {
-      next: async () => {
-        const value = this.#items.shift()
-        if (value !== undefined) return { value, done: false }
-        if (this.#error !== undefined) throw this.#error
-        if (this.#closed) return { value: undefined, done: true }
-        return new Promise<IteratorResult<T>>((resolve, reject) => this.#waiting.push({ resolve, reject }))
-      },
-    }
-  }
 }
 
 function abortError(message: string): Error {

--- a/packages/server/tests/moss-tts-provider.test.ts
+++ b/packages/server/tests/moss-tts-provider.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { MossTtsProvider } from '../src/voice/tts/moss-tts-provider.js'
 
@@ -17,8 +17,12 @@ describe('MossTtsProvider sidecar protocol', () => {
       const lines = createInterface({ input: process.stdin });
       lines.on('line', (line) => {
         const request = JSON.parse(line);
-        const pcm = new Float32Array([0, 0.25, -0.25, 0]);
-        process.stdout.write(JSON.stringify({ type: 'audio', id: request.id, sampleRate: 24000, voice: request.voice, pcmBase64: Buffer.from(pcm.buffer).toString('base64') }) + '\\n');
+        if (request.text === '等待') return;
+        const chunks = [new Float32Array([0, 0.25]), new Float32Array([-0.25, 0])];
+        for (let sequence = 0; sequence < chunks.length; sequence += 1) {
+          process.stdout.write(JSON.stringify({ type: 'audio', id: request.id, sequence, sampleRate: 24000, pcmBase64: Buffer.from(chunks[sequence].buffer).toString('base64') }) + '\\n');
+        }
+        process.stdout.write(JSON.stringify({ type: 'done', id: request.id, sequence: chunks.length, voice: request.voice }) + '\\n');
       });
     `, 'utf8')
     const provider = new MossTtsProvider(root, { executable: process.execPath, sidecar, startupTimeoutMs: 2_000, requestTimeoutMs: 2_000 })
@@ -27,9 +31,22 @@ describe('MossTtsProvider sidecar protocol', () => {
     expect(provider.voices).toEqual(['Junhao'])
     const chunks = []
     for await (const chunk of provider.synthesize({ requestId: 'moss-test', text: '你好', voiceId: 'moss:Junhao', speed: 1 })) chunks.push(chunk)
-    expect(chunks).toHaveLength(1)
-    expect(chunks[0]).toMatchObject({ sampleRate: 24_000, final: true, sequence: 0 })
-    expect(Array.from(chunks[0]!.pcm ?? [])).toEqual([0, 0.25, -0.25, 0])
+    expect(chunks).toHaveLength(3)
+    expect(chunks.map((chunk) => ({ sequence: chunk.sequence, final: chunk.final }))).toEqual([
+      { sequence: 0, final: false },
+      { sequence: 1, final: false },
+      { sequence: 2, final: true },
+    ])
+    expect(chunks.flatMap((chunk) => Array.from(chunk.pcm ?? []))).toEqual([0, 0.25, -0.25, 0])
+
+    const controller = new AbortController()
+    const interrupted = (async () => {
+      for await (const _chunk of provider.synthesize({ requestId: 'moss-interrupt', text: '等待', voiceId: 'moss:Junhao', speed: 1, signal: controller.signal })) { /* consume */ }
+    })()
+    await new Promise((resolve) => setTimeout(resolve, 20))
+    controller.abort()
+    await expect(interrupted).rejects.toMatchObject({ name: 'AbortError' })
+    await vi.waitFor(() => expect(provider.state).toBe('ready'), { timeout: 2_000 })
     await provider.dispose()
   })
 })

--- a/packages/web/src/features/voice/PcmFrameStream.ts
+++ b/packages/web/src/features/voice/PcmFrameStream.ts
@@ -1,0 +1,37 @@
+export interface PcmFrame {
+  sequence: number
+  sampleRate: number
+  pcm: Float32Array
+  final: boolean
+}
+
+export async function* readPcmFrames(stream: ReadableStream<Uint8Array>): AsyncIterable<PcmFrame> {
+  const reader = stream.getReader()
+  let pending = new Uint8Array(0)
+  for (;;) {
+    const result = await reader.read()
+    if (result.done) break
+    const combined = new Uint8Array(pending.length + result.value.length)
+    combined.set(pending)
+    combined.set(result.value, pending.length)
+    pending = combined
+    while (pending.length >= 20) {
+      const header = new DataView(pending.buffer, pending.byteOffset, 20)
+      if (String.fromCharCode(...pending.subarray(0, 4)) !== 'DSHV') throw new Error('本地语音流格式无效')
+      const sampleCount = header.getUint32(12, true)
+      const frameBytes = 20 + sampleCount * 4
+      if (pending.length < frameBytes) break
+      const payload = new DataView(pending.buffer, pending.byteOffset + 20, sampleCount * 4)
+      const pcm = new Float32Array(sampleCount)
+      for (let index = 0; index < sampleCount; index += 1) pcm[index] = payload.getFloat32(index * 4, true)
+      yield {
+        sequence: header.getUint32(4, true),
+        sampleRate: header.getUint32(8, true),
+        pcm,
+        final: (header.getUint32(16, true) & 1) === 1,
+      }
+      pending = pending.slice(frameBytes)
+    }
+  }
+  if (pending.length !== 0) throw new Error('本地语音流提前结束')
+}

--- a/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
+++ b/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
@@ -161,6 +161,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
     utteranceRef.current = undefined
     setSpeaking(false)
     setVoiceBusy(false)
+    setVoiceNotice(undefined)
   }, [speechSupported])
 
   const speak = useCallback(async (text: string) => {
@@ -176,7 +177,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
           speed: voiceSpeed,
           onStatus: setVoiceNotice,
           onStart: () => { setVoiceBusy(false); setSpeaking(true) },
-          onEnd: () => { setVoiceBusy(false); setSpeaking(false) },
+          onEnd: () => { setVoiceBusy(false); setSpeaking(false); setVoiceNotice(undefined) },
         })
       } catch (cause) {
         setVoiceBusy(false)
@@ -186,7 +187,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
           const fallbackVoiceId = compatibleKokoroVoices[0]!.id
           setVoiceNotice('自然语音暂不可用，已切换快速语音')
           try {
-            await playKokoroSpeech({ text, voiceId: fallbackVoiceId, speed: voiceSpeed, onStatus: setVoiceNotice, onStart: () => setSpeaking(true), onEnd: () => setSpeaking(false) })
+            await playKokoroSpeech({ text, voiceId: fallbackVoiceId, speed: voiceSpeed, onStatus: setVoiceNotice, onStart: () => setSpeaking(true), onEnd: () => { setSpeaking(false); setVoiceNotice(undefined) } })
             return
           } catch (fallbackError) {
             cause = fallbackError
@@ -256,7 +257,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
       onStart: () => { setVoiceBusy(false); setSpeaking(true) },
       onEnd: () => {
         streamPendingRef.current = Math.max(0, streamPendingRef.current - 1)
-        if (streamCompleteRef.current && streamPendingRef.current === 0) setSpeaking(false)
+        if (streamCompleteRef.current && streamPendingRef.current === 0) { setSpeaking(false); setVoiceNotice(undefined) }
       },
       })
     }).catch((cause: unknown) => {

--- a/packages/web/src/features/world/avatar/speech/KokoroSpeechAdapter.ts
+++ b/packages/web/src/features/world/avatar/speech/KokoroSpeechAdapter.ts
@@ -1,3 +1,6 @@
+import { readPcmFrames } from '../../../voice/PcmFrameStream.js'
+import { setSpeechAmplitude } from './speech-playback-state.js'
+
 export interface KokoroVoiceOption {
   id: `kokoro:${number}`
   speakerId: number
@@ -116,6 +119,10 @@ export async function appendKokoroSpeech(input: {
     let started = false
     for await (const frame of readPcmFrames(response.body)) {
       if (requestGeneration !== generation) return
+      if (frame.pcm.length === 0) {
+        if (frame.final && started) scheduleFinalMarker(context, nextStartAt, requestGeneration, input.onEnd)
+        continue
+      }
       const buffer = context.createBuffer(1, frame.pcm.length, frame.sampleRate)
       buffer.getChannelData(0).set(frame.pcm)
       const source = context.createBufferSource()
@@ -201,6 +208,21 @@ function cleanupAudio(): void {
   stopAmplitudeMonitor()
 }
 
+function scheduleFinalMarker(context: AudioContext, startAt: number, requestGeneration: number, onEnd: () => void): void {
+  const buffer = context.createBuffer(1, 1, context.sampleRate)
+  const source = context.createBufferSource()
+  source.buffer = buffer
+  source.connect(context.destination)
+  activeSources.add(source)
+  source.onended = () => {
+    activeSources.delete(source)
+    source.disconnect()
+    if (requestGeneration === generation) onEnd()
+    if (activeSources.size === 0) stopAmplitudeMonitor()
+  }
+  source.start(Math.max(context.currentTime + 0.005, startAt))
+}
+
 function getAnalyser(context: AudioContext): AnalyserNode {
   if (analyser !== undefined) return analyser
   analyser = context.createAnalyser(); analyser.fftSize = 512; analyser.smoothingTimeConstant = 0.32; analyser.connect(context.destination)
@@ -232,30 +254,3 @@ function getAudioContext(): AudioContext {
   audioContext ??= new AudioContext()
   return audioContext
 }
-
-interface PcmFrame { sequence: number; sampleRate: number; pcm: Float32Array; final: boolean }
-
-async function* readPcmFrames(stream: ReadableStream<Uint8Array>): AsyncIterable<PcmFrame> {
-  const reader = stream.getReader()
-  let pending = new Uint8Array(0)
-  for (;;) {
-    const result = await reader.read()
-    if (result.done) break
-    const combined = new Uint8Array(pending.length + result.value.length)
-    combined.set(pending); combined.set(result.value, pending.length); pending = combined
-    while (pending.length >= 20) {
-      const header = new DataView(pending.buffer, pending.byteOffset, 20)
-      if (String.fromCharCode(...pending.subarray(0, 4)) !== 'DSHV') throw new Error('本地语音流格式无效')
-      const sampleCount = header.getUint32(12, true)
-      const frameBytes = 20 + sampleCount * 4
-      if (pending.length < frameBytes) break
-      const payload = new DataView(pending.buffer, pending.byteOffset + 20, sampleCount * 4)
-      const pcm = new Float32Array(sampleCount)
-      for (let index = 0; index < sampleCount; index += 1) pcm[index] = payload.getFloat32(index * 4, true)
-      yield { sequence: header.getUint32(4, true), sampleRate: header.getUint32(8, true), pcm, final: (header.getUint32(16, true) & 1) === 1 }
-      pending = pending.slice(frameBytes)
-    }
-  }
-  if (pending.length !== 0) throw new Error('本地语音流提前结束')
-}
-import { setSpeechAmplitude } from './speech-playback-state.js'

--- a/packages/web/tests/pcm-frame-stream.test.ts
+++ b/packages/web/tests/pcm-frame-stream.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest'
+
+import { readPcmFrames } from '../src/features/voice/PcmFrameStream.js'
+
+describe('PCM frame stream', () => {
+  it('parses chunked audio and an empty final frame', async () => {
+    const bytes = concatenate([
+      encodeFrame(0, new Float32Array([0.25, -0.5]), false),
+      encodeFrame(1, new Float32Array(0), true),
+    ])
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(bytes.slice(0, 7))
+        controller.enqueue(bytes.slice(7, 25))
+        controller.enqueue(bytes.slice(25))
+        controller.close()
+      },
+    })
+
+    const frames = []
+    for await (const frame of readPcmFrames(stream)) frames.push(frame)
+
+    expect(frames.map((frame) => ({ sequence: frame.sequence, final: frame.final, samples: frame.pcm.length }))).toEqual([
+      { sequence: 0, final: false, samples: 2 },
+      { sequence: 1, final: true, samples: 0 },
+    ])
+    expect(Array.from(frames[0]!.pcm)).toEqual([0.25, -0.5])
+  })
+
+  it('rejects a truncated frame', async () => {
+    const stream = new ReadableStream<Uint8Array>({ start(controller) { controller.enqueue(encodeFrame(0, new Float32Array([1]), false).slice(0, 21)); controller.close() } })
+    await expect(async () => { for await (const _frame of readPcmFrames(stream)) { /* consume */ } }).rejects.toThrow('本地语音流提前结束')
+  })
+})
+
+function encodeFrame(sequence: number, pcm: Float32Array, final: boolean): Uint8Array {
+  const bytes = new Uint8Array(20 + pcm.length * 4)
+  bytes.set([68, 83, 72, 86])
+  const view = new DataView(bytes.buffer)
+  view.setUint32(4, sequence, true)
+  view.setUint32(8, 48_000, true)
+  view.setUint32(12, pcm.length, true)
+  view.setUint32(16, final ? 1 : 0, true)
+  for (let index = 0; index < pcm.length; index += 1) view.setFloat32(20 + index * 4, pcm[index]!, true)
+  return bytes
+}
+
+function concatenate(parts: readonly Uint8Array[]): Uint8Array {
+  const output = new Uint8Array(parts.reduce((total, part) => total + part.length, 0))
+  let offset = 0
+  for (const part of parts) { output.set(part, offset); offset += part.length }
+  return output
+}

--- a/scripts/benchmark-moss-tts.mjs
+++ b/scripts/benchmark-moss-tts.mjs
@@ -29,12 +29,23 @@ for (const sample of samples) {
     const startedAt = performance.now()
     let firstAudioMs
     let durationMs = 0
+    let audioChunks = 0
+    let lastArrivalMs
+    let previousChunkDurationMs = 0
+    let maxPotentialStarvationMs = 0
     for await (const chunk of provider.synthesize({ requestId: crypto.randomUUID(), text: sample.text, voiceId: 'moss:Junhao', speed: 1 })) {
-      firstAudioMs ??= performance.now() - startedAt
+      if ((chunk.pcm?.length ?? 0) > 0) {
+        const arrivalMs = performance.now() - startedAt
+        firstAudioMs ??= arrivalMs
+        if (lastArrivalMs !== undefined) maxPotentialStarvationMs = Math.max(maxPotentialStarvationMs, arrivalMs - lastArrivalMs - previousChunkDurationMs)
+        lastArrivalMs = arrivalMs
+        previousChunkDurationMs = chunk.durationMs
+        audioChunks += 1
+      }
       durationMs += chunk.durationMs
     }
     const elapsedMs = performance.now() - startedAt
-    results.push({ kind: sample.kind, iteration, firstAudioMs: firstAudioMs ?? elapsedMs, elapsedMs, audioDurationMs: durationMs, realtimeFactor: elapsedMs / durationMs })
+    results.push({ kind: sample.kind, iteration, audioChunks, maxPotentialStarvationMs, firstAudioMs: firstAudioMs ?? elapsedMs, elapsedMs, audioDurationMs: durationMs, realtimeFactor: elapsedMs / durationMs })
   }
 }
 const memoryMb = await childMemoryMb(provider.processId)
@@ -43,16 +54,26 @@ const measurementElapsedMs = performance.now() - measurementStartedAt
 const cpuTimeMs = cpuStartedMs === undefined || cpuFinishedMs === undefined ? undefined : Math.max(0, cpuFinishedMs - cpuStartedMs)
 const logicalCpuCount = availableParallelism()
 const cpuPercent = cpuTimeMs === undefined ? undefined : cpuTimeMs / measurementElapsedMs * 100
+const firstAudioMs = distribution(results.map((item) => item.firstAudioMs))
+const maxPotentialStarvationMs = distribution(results.map((item) => item.maxPotentialStarvationMs))
+const realtimeFactor = distribution(results.map((item) => item.realtimeFactor))
+const gates = {
+  firstAudioP95Under800Ms: firstAudioMs.p95 < 800,
+  realtimeFactorP95UnderOne: realtimeFactor.p95 < 1,
+  streamedEveryRequest: results.every((item) => item.audioChunks > 1),
+  starvationP95Under80Ms: maxPotentialStarvationMs.p95 < 80,
+  memoryUnder2048Mb: memoryMb === undefined ? undefined : memoryMb < 2_048,
+}
 const output = {
   provider: 'moss-tts-nano-100m-onnx', device: `${process.platform}-${process.arch}-cpu`, coldStartMs,
-  firstAudioMs: distribution(results.map((item) => item.firstAudioMs)),
-  realtimeFactor: distribution(results.map((item) => item.realtimeFactor)),
+  firstAudioMs, maxPotentialStarvationMs, realtimeFactor,
   memoryMb, cpuTimeMs, cpuPercent, logicalCpuCount,
   cpuMachinePercent: cpuPercent === undefined ? undefined : cpuPercent / logicalCpuCount,
-  blocksMainThread: false, results,
+  blocksMainThread: false, gates, results,
 }
 await provider.dispose()
 process.stdout.write(`${JSON.stringify(output, null, 2)}\n`)
+if (Object.values(gates).some((value) => value === false)) process.exitCode = 1
 
 function distribution(values) { return { p50: percentile(values, 0.5), p95: percentile(values, 0.95) } }
 function percentile(values, ratio) { const ordered = [...values].sort((a, b) => a - b); return ordered[Math.min(ordered.length - 1, Math.ceil(ordered.length * ratio) - 1)] }


### PR DESCRIPTION
## 目标

完成 Voice Runtime V2 第一阶段：把 MOSS-TTS-Nano 从“内部增量解码、外部整段返回”改为真正 PCM chunk 流，并为后续 Context Budget/Cache 与 3D 入口优化建立 ADR 边界。

## 实现

- Sidecar 每 8 个生成帧增量 codec decode，并立即发送 PCM chunk
- Node Provider 通过共享 AsyncQueue 暴露 AudioChunk AsyncIterable
- 独立 done 协议映射为零长度 final 帧，Web Audio 按 playback clock 结束 speaking/口型
- Kokoro/MOSS 共用队列基础设施，PCM 帧解析器从世界组件迁移到 voice feature
- 单次打断后后台重建并预热 MOSS；dispose/删除模型仍真正关闭
- Benchmark 增加 chunk 数、潜在断流、进程树 RAM、整机 CPU 与硬门禁
- ADR 0009 定义 Voice、Context、Avatar Runtime V2 的分阶段边界

## 性能数据（Windows x64 CPU）

- Cold start：4.15s
- Warm TTFA：P50 489ms / P95 528ms
- 每请求 PCM chunk：4-15
- 潜在断流：P95 0ms
- RTF：P50 0.55 / P95 0.59
- RAM：1,619MB
- 12 逻辑线程整机平均 CPU：59.4%
- 所有性能门禁通过

## 验证

- pnpm test：189 files，802 passed，1 skipped
- digital-human-world E2E：6/6 passed
- Browser：真实 MOSS 试听进入 speaking，chunk 排队连续播放，停止后状态/提示清理，console 0 error/warn
- build budget：主包与 VRM lazy chunk 均通过

## 后续

下一 PR 按 ADR 0009 实现 ContextBudgetPlanner、TokenEstimator、rolling summary checkpoint 与 revision-aware retrieval cache；再下一 PR 优化 3D 能力状态和“添加 3D 形象”直达入口。
