### PR TITLE
fix: 让语音对话真正能用（本地模型、语速、音源、麦克风提示）

### DIFF
--- a/e2e/digital-human-world.spec.ts
+++ b/e2e/digital-human-world.spec.ts
@@ -255,7 +255,9 @@ test('keeps the chosen 2D view across conversations and centers the latest group
   await voiceEngine.selectOption('moss-tts-nano-100m-onnx')
   await expect(voiceModels.getByRole('button', { name: '下载并安装' })).toBeVisible()
   await voiceEngine.selectOption('dots-tts-soar-2b')
-  await expect(voiceModels.getByText('高级模型', { exact: true })).toBeVisible()
+  // "高级模型" read as a premium tier. The truth is narrower and more useful:
+  // this engine cannot run on this machine in this version.
+  await expect(voiceModels.getByText('本机暂不支持', { exact: true })).toBeVisible()
   await voiceEngine.selectOption('kokoro-int8-multi-lang-v1_1')
   await expect(focus.getByLabel('角色声音', { exact: true }).locator('option')).toHaveCount(103)
   await focus.getByLabel('角色声音', { exact: true }).selectOption('system:voice-zh-a')

--- a/e2e/digital-human-world.spec.ts
+++ b/e2e/digital-human-world.spec.ts
@@ -356,6 +356,63 @@ test('turns streaming voice partials into the existing conversation message flow
   await expect(focus.getByRole('button', { name: '开始语音对话' })).toBeVisible()
 })
 
+test('speaks a composer voice turn once in both renderer modes and leaves typed replies silent', async ({ page }) => {
+  test.setTimeout(120_000)
+  await installVoiceConversationMock(page, '语音模式联合回归')
+  const streamRequests: Array<{ text?: string; provider?: string }> = []
+  await page.route('**/api/local-tts/models', async (route) => route.fulfill({
+    status: 200,
+    contentType: 'application/json',
+    body: JSON.stringify({ models: [
+      { id: 'moss-tts-nano-100m-onnx', provider: 'moss', displayName: 'MOSS-TTS-Nano', version: '100M', license: 'Apache-2.0', byteLength: 1, state: 'not-installed', tier: 'default', recommended: true, runtime: 'onnx-cpu', summary: '测试语音包。' },
+      { id: 'kokoro-int8-multi-lang-v1_1', provider: 'kokoro', displayName: 'Kokoro 快速语音', version: '1.1', license: 'Apache-2.0', byteLength: 1, state: 'ready', tier: 'fast', runtime: 'onnx-cpu', summary: '测试备用语音。' },
+    ] }),
+  }))
+  await page.route('**/api/local-tts/stream', async (route) => {
+    try { streamRequests.push(JSON.parse(route.request().postData() ?? '{}') as { text?: string; provider?: string }) } catch { streamRequests.push({}) }
+    // The focus and composer owners both reach this boundary if ownership is
+    // broken. A fast failure is enough to count requests without requiring a
+    // real local model or pretending that a microphone/device was verified.
+    await route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ error: { message: '测试环境未安装本地语音包' } }) })
+  })
+  await page.goto(origin)
+  runtime.release()
+  await page.getByRole('button', { name: `与${employeeName}私聊`, exact: true }).click()
+  const focus = page.getByRole('region', { name: `${employeeName}员工聚焦` })
+  await expect(focus).toBeVisible()
+  await focus.getByRole('button', { name: '语音设置' }).click()
+  await focus.getByLabel('播报模式').selectOption('auto')
+  await focus.getByRole('button', { name: '语音设置' }).click()
+
+  const composer = page.locator('.composer-zone')
+  const expectedReplyText = `${employeeName} 已完成员工聚焦交互验证。`
+  for (const [index, mode] of (['2D', '3D'] as const).entries()) {
+    await selectCharacterView(page, mode, employeeName)
+    const microphone = composer.getByRole('button', { name: '开始语音对话' })
+    await expect(microphone).toBeVisible()
+    await microphone.click()
+    await expect(composer.getByRole('button', { name: '结束语音对话' })).toBeVisible()
+    await expect(page.getByText('语音模式联合回归', { exact: true }).first()).toBeVisible({ timeout: 10_000 })
+    await expect.poll(() => streamRequests.filter((request) => request.text === expectedReplyText).length).toBe(index + 1)
+    await composer.getByRole('button', { name: '结束语音对话' }).click()
+    await expect(composer.getByRole('button', { name: '开始语音对话' })).toBeVisible()
+  }
+
+  // Turn off the focused panel's independent auto mode so this assertion is
+  // specifically about the composer origin. A typed turn must not inherit the
+  // preceding voice turn's ownership or generate another TTS request.
+  await focus.getByRole('button', { name: '语音设置' }).click()
+  await focus.getByLabel('播报模式').selectOption('off')
+  await focus.getByRole('button', { name: '语音设置' }).click()
+  const beforeTyped = streamRequests.length
+  const composerInput = page.getByRole('textbox', { name: '给当前世界的角色发送消息' })
+  await composerInput.fill('这是键盘输入，不应自动播报')
+  await composer.getByRole('button', { name: '发送', exact: true }).click()
+  await expect.poll(() => runtime.requests.length).toBeGreaterThan(2)
+  await page.waitForTimeout(250)
+  expect(streamRequests.length, `键盘 turn 不得继承 voice turn 的播报所有权：${JSON.stringify(streamRequests)}`).toBe(beforeTyped)
+})
+
 test('previews an uploaded portrait, publishes a new avatar revision, and restores VRM history', async ({ page }) => {
   await page.goto(origin)
   const dock = page.getByRole('region', { name: '世界与角色侧边栏' })
@@ -461,8 +518,8 @@ async function installSpeechMock(page: Page): Promise<void> {
   })
 }
 
-async function installVoiceConversationMock(page: Page): Promise<void> {
-  await page.addInitScript(() => {
+async function installVoiceConversationMock(page: Page, finalText = '帮我检查昨天的服务日志'): Promise<void> {
+  await page.addInitScript((spokenText) => {
     class MockWebSocket {
       static OPEN = 1
       readyState = 1
@@ -484,9 +541,9 @@ async function installVoiceConversationMock(page: Page): Promise<void> {
           this.emit({ type: 'session-started', sessionId: 'voice-test' })
           this.emit({ type: 'listening', sessionId: 'voice-test' })
           window.setTimeout(() => this.emit({ type: 'speech-start', sessionId: 'voice-test', utteranceId: 'voice-test:0' }), 100)
-          window.setTimeout(() => this.emit({ type: 'partial', sessionId: 'voice-test', utteranceId: 'voice-test:0', text: '帮我检查昨天' }), 250)
-          window.setTimeout(() => this.emit({ type: 'partial', sessionId: 'voice-test', utteranceId: 'voice-test:0', text: '帮我检查昨天的服务日志' }), 500)
-          window.setTimeout(() => this.emit({ type: 'final', sessionId: 'voice-test', utteranceId: 'voice-test:0', text: '帮我检查昨天的服务日志' }), 1_300)
+          window.setTimeout(() => this.emit({ type: 'partial', sessionId: 'voice-test', utteranceId: 'voice-test:0', text: spokenText.slice(0, Math.max(1, Math.floor(spokenText.length / 2))) }), 250)
+          window.setTimeout(() => this.emit({ type: 'partial', sessionId: 'voice-test', utteranceId: 'voice-test:0', text: spokenText }), 500)
+          window.setTimeout(() => this.emit({ type: 'final', sessionId: 'voice-test', utteranceId: 'voice-test:0', text: spokenText }), 1_300)
         }
       }
       close() { this.readyState = 3; this.onclose?.() }
@@ -510,7 +567,7 @@ async function installVoiceConversationMock(page: Page): Promise<void> {
     Object.defineProperty(window, 'AudioWorkletNode', { configurable: true, value: MockAudioWorkletNode })
     Object.defineProperty(window, 'AudioContext', { configurable: true, value: MockAudioContext })
     Object.defineProperty(navigator, 'mediaDevices', { configurable: true, value: { getUserMedia: async () => fakeStream } })
-  })
+  }, finalText)
 }
 
 async function lastSpokenVoice(page: Page): Promise<string> {

--- a/e2e/digital-human-world.spec.ts
+++ b/e2e/digital-human-world.spec.ts
@@ -260,6 +260,7 @@ test('keeps the chosen 2D view across conversations and centers the latest group
   await expect(voiceModels.getByText('本机暂不支持', { exact: true })).toBeVisible()
   await voiceEngine.selectOption('kokoro-int8-multi-lang-v1_1')
   await expect(focus.getByLabel('角色声音', { exact: true }).locator('option')).toHaveCount(103)
+  const firstVoiceSaved = page.waitForResponse((response) => response.request().method() === 'PUT' && response.url().includes(`/api/employees/${employeeId}/profile`) && response.status() === 201)
   await focus.getByLabel('角色声音', { exact: true }).selectOption('system:voice-zh-a')
   await expect(focus.getByRole('slider', { name: '语速' })).toHaveValue('1.1')
   await focus.getByRole('slider', { name: '语速' }).fill('1.25')
@@ -267,7 +268,6 @@ test('keeps the chosen 2D view across conversations and centers the latest group
   await focus.getByRole('button', { name: '试听声音' }).click()
   await expect.poll(() => lastSpokenRate(page)).toBe(1.25)
   await focus.getByRole('button', { name: '停止播报' }).click()
-  const firstVoiceSaved = page.waitForResponse((response) => response.request().method() === 'PUT' && response.url().includes(`/api/employees/${employeeId}/profile`) && response.status() === 201)
   await focus.getByRole('button', { name: '语音设置' }).click()
   await firstVoiceSaved
   await expect.poll(async () => page.evaluate(async (id) => {
@@ -316,10 +316,10 @@ test('keeps the chosen 2D view across conversations and centers the latest group
   await expect(twoDimensionalTab).toHaveAttribute('aria-selected', 'true')
   await focus.getByRole('button', { name: '语音设置' }).click()
   await expect(focus.getByLabel('角色声音', { exact: true }).locator('option')).toHaveCount(103)
+  const secondVoiceSaved = page.waitForResponse((response) => response.request().method() === 'PUT' && response.url().includes('/api/employees/') && response.url().endsWith('/profile') && response.status() === 201)
   await focus.getByLabel('角色声音', { exact: true }).selectOption('system:voice-zh-b')
   await expect(focus.getByRole('slider', { name: '语速' })).toHaveValue('1.1')
   await focus.getByRole('slider', { name: '语速' }).fill('0.9')
-  const secondVoiceSaved = page.waitForResponse((response) => response.request().method() === 'PUT' && response.url().includes('/api/employees/') && response.url().endsWith('/profile') && response.status() === 201)
   await focus.getByRole('button', { name: '语音设置' }).click()
   await secondVoiceSaved
 

--- a/packages/contracts/src/voice.ts
+++ b/packages/contracts/src/voice.ts
@@ -91,6 +91,14 @@ export interface TextToSpeechProvider {
   dispose(): Promise<void>
 }
 
+/** One selectable voice inside a model pack. */
+export interface VoiceModelVoice {
+  id: string
+  label: string
+  gender?: 'female' | 'male' | 'neutral'
+  lang?: string
+}
+
 export interface VoiceModelDescriptor {
   id: string
   provider: VoiceProviderKind
@@ -109,6 +117,14 @@ export interface VoiceModelDescriptor {
   installedPath?: string
   sha256?: string
   error?: string
+  /**
+   * The voices this pack can actually speak with.
+   *
+   * Reported by the running provider rather than hardcoded in the UI: a pack
+   * ships whatever speakers it ships, and the settings panel offering exactly
+   * one of them made a multi-voice model look like a single-voice one.
+   */
+  voices?: VoiceModelVoice[]
 }
 
 export interface VoicePerformanceMetrics {

--- a/packages/contracts/src/voice.ts
+++ b/packages/contracts/src/voice.ts
@@ -99,6 +99,18 @@ export interface VoiceModelVoice {
   lang?: string
 }
 
+/**
+ * Canonical external representation for an MOSS speaker.
+ *
+ * The UI and persisted profile use `moss:Name`; the Python sidecar uses only
+ * `Name`. Accepting both forms at boundaries prevents `moss:moss:Name` from
+ * leaking into either representation.
+ */
+export function normalizeMossVoiceId(value: string): string {
+  const name = value.trim().replace(/^(?:moss:)+/iu, '').trim()
+  return `moss:${name || 'Junhao'}`
+}
+
 export interface VoiceModelDescriptor {
   id: string
   provider: VoiceProviderKind

--- a/packages/server/src/services/local-tts-asset-service.ts
+++ b/packages/server/src/services/local-tts-asset-service.ts
@@ -10,7 +10,7 @@ import { EnvHttpProxyAgent, fetch as proxyAwareFetch } from 'undici'
 import { ServiceError } from './service-error.js'
 import { SherpaKokoroTtsProvider } from '../voice/tts/sherpa-kokoro-tts-provider.js'
 import { MossTtsProvider } from '../voice/tts/moss-tts-provider.js'
-import type { AudioChunk, VoiceModelDescriptor, VoiceModelVoice } from '@dsh-cyber/contracts'
+import { normalizeMossVoiceId, type AudioChunk, type VoiceModelDescriptor, type VoiceModelVoice } from '@dsh-cyber/contracts'
 
 interface SherpaManifest {
   schemaVersion: 2
@@ -318,13 +318,16 @@ export class LocalTtsAssetService {
         voices?: Array<string | { id?: unknown; label?: unknown; name?: unknown; gender?: unknown }>
       }
       const raw = Array.isArray(manifest.voices) ? manifest.voices : []
+      const seen = new Set<string>()
       const voices = raw.flatMap((entry): VoiceModelVoice[] => {
-        if (typeof entry === 'string') return entry.trim() === '' ? [] : [{ id: `moss:${entry}`, label: entry }]
-        const id = typeof entry.id === 'string' ? entry.id : undefined
-        if (id === undefined || id.trim() === '') return []
-        const label = typeof entry.label === 'string' ? entry.label : typeof entry.name === 'string' ? entry.name : id
-        const gender = entry.gender === 'female' || entry.gender === 'male' ? entry.gender : undefined
-        return [{ id: `moss:${id}`, label, ...(gender === undefined ? {} : { gender }) }]
+        const rawId = typeof entry === 'string' ? entry : typeof entry.id === 'string' ? entry.id : undefined
+        if (rawId === undefined || rawId.trim() === '') return []
+        const id = normalizeMossVoiceId(rawId)
+        if (seen.has(id)) return []
+        seen.add(id)
+        const label = typeof entry === 'string' ? entry.trim() : typeof entry.label === 'string' && entry.label.trim() !== '' ? entry.label.trim() : typeof entry.name === 'string' && entry.name.trim() !== '' ? entry.name.trim() : id.slice('moss:'.length)
+        const gender = typeof entry === 'string' ? undefined : entry.gender === 'female' || entry.gender === 'male' ? entry.gender : undefined
+        return [{ id, label, ...(gender === undefined ? {} : { gender }) }]
       })
       // A pack that names no speakers still has one; without this an installed,
       // working engine would offer nothing at all.

--- a/packages/server/src/services/local-tts-asset-service.ts
+++ b/packages/server/src/services/local-tts-asset-service.ts
@@ -10,7 +10,7 @@ import { EnvHttpProxyAgent, fetch as proxyAwareFetch } from 'undici'
 import { ServiceError } from './service-error.js'
 import { SherpaKokoroTtsProvider } from '../voice/tts/sherpa-kokoro-tts-provider.js'
 import { MossTtsProvider } from '../voice/tts/moss-tts-provider.js'
-import type { AudioChunk, VoiceModelDescriptor } from '@dsh-cyber/contracts'
+import type { AudioChunk, VoiceModelDescriptor, VoiceModelVoice } from '@dsh-cyber/contracts'
 
 interface SherpaManifest {
   schemaVersion: 2
@@ -31,6 +31,7 @@ export interface LocalTtsAudio {
 const MODEL_DIR = 'kokoro-int8-multi-lang-v1_1'
 const voiceDownloadDispatcher = new EnvHttpProxyAgent()
 const MOSS_MODEL_ID = 'moss-tts-nano-100m-onnx'
+const MOSS_DEFAULT_VOICE: VoiceModelVoice = { id: 'moss:Junhao', label: '君豪 · 自然男声', gender: 'male' }
 const MOSS_TTS_REVISION = 'f52645cb467506d8e18e746ddd59482685b74e58'
 const MOSS_CODEC_REVISION = 'ceff0d0749bfb3fa2d61149794ec6feef0d1e1ae'
 
@@ -112,6 +113,7 @@ export class LocalTtsAssetService {
     const mossInstalled = await fileExists(join(mossRoot, 'manifest.json'))
     const mossOperation = this.#modelOperations.get(MOSS_MODEL_ID)
     const mossState = mossOperation?.state ?? (mossInstalled ? 'installed' : 'not-installed')
+    const mossVoices = mossInstalled ? await this.#readMossVoices(mossRoot) : []
     return [
       {
         id: 'moss-tts-nano-100m-onnx', provider: 'moss', displayName: 'MOSS-TTS-Nano', version: '100M-ONNX',
@@ -120,6 +122,10 @@ export class LocalTtsAssetService {
         summary: '默认自然语音包。中文自然度更高，首次使用时按需安装。',
         requirements: ['约 1 GB 磁盘空间', '运行约占 1.7 GB 内存', '建议 4 GB 可用内存'],
         ...(mossInstalled ? { installedPath: mossRoot } : {}),
+        // Whatever the installed pack actually ships. The settings panel used
+        // to offer exactly one hardcoded name, so a multi-speaker model looked
+        // like a single-voice one.
+        ...(mossVoices.length === 0 ? {} : { voices: mossVoices }),
         ...(mossOperation === undefined ? {} : {
           progress: { phase: mossOperation.phase, completedBytes: mossOperation.completedBytes, totalBytes: mossOperation.totalBytes },
           ...(mossOperation.error === undefined ? {} : { error: mossOperation.error }),
@@ -158,7 +164,24 @@ export class LocalTtsAssetService {
   }
 
   async installModel(modelId: string): Promise<VoiceModelDescriptor> {
-    if (modelId !== MOSS_MODEL_ID) throw new ServiceError('invalid', 'voice_model_not_installable', '当前高级语音模型尚未提供本机安装包')
+    // Every refusal used to say the same thing, including for Kokoro — which
+    // is installable, just from the command line. Telling a user that a pack
+    // "尚未提供本机安装包" when the real answer is one command is worse than
+    // saying nothing.
+    if (modelId === MODEL_DIR) {
+      throw new ServiceError(
+        'invalid',
+        'voice_model_cli_install',
+        'Kokoro 语音包目前通过命令行安装：在项目目录运行 pnpm tts:install，完成后回到这里刷新。',
+      )
+    }
+    if (modelId !== MOSS_MODEL_ID) {
+      throw new ServiceError(
+        'invalid',
+        'voice_model_not_installable',
+        '这个引擎需要独立的高级运行环境，当前版本还不能在本机安装。',
+      )
+    }
     const existing = this.#modelOperations.get(modelId)
     if (existing === undefined || existing.state === 'error') {
       const operation: ModelInstallOperation = {
@@ -209,14 +232,26 @@ export class LocalTtsAssetService {
     const text = normalizeTtsText(input.text)
     if (text.length === 0 || text.length > 1_000) throw new ServiceError('invalid', 'local_tts_text_invalid', '播报内容长度必须在 1 到 1000 个字符之间')
     if (!Number.isInteger(input.speakerId) || input.speakerId < 3 || input.speakerId > 102) throw new ServiceError('invalid', 'local_tts_voice_invalid', '请选择有效的中文声音')
-    if (!Number.isFinite(input.speed) || input.speed < 0.7 || input.speed > 1.3) throw new ServiceError('invalid', 'local_tts_speed_invalid', '语速必须在 0.7 到 1.3 之间')
+    // The ceiling was 1.3 in four independent places. Raising the slider alone
+    // would have turned "too slow" into a rejected request.
+    if (!Number.isFinite(input.speed) || input.speed < 0.7 || input.speed > 2) throw new ServiceError('invalid', 'local_tts_speed_invalid', '语速必须在 0.7 到 2 之间')
 
     let release!: () => void
     const previous = this.#generationTail
     this.#generationTail = new Promise<void>((resolve) => { release = resolve })
     await previous
     try {
-      if ((await this.status()).installed !== true) throw new ServiceError('not-found', 'local_tts_not_installed', '本地中文语音包未安装，请运行 pnpm tts:install')
+      // Ask about the pack the caller actually chose. Gating every request on
+      // the Kokoro install meant a user who installed only MOSS from the
+      // settings panel had a working pack the server refused to use, and was
+      // then told to install a different one they had never asked for.
+      if (input.provider === 'moss') {
+        if (!(await fileExists(join(this.#root, 'models', MOSS_MODEL_ID, 'manifest.json')))) {
+          throw new ServiceError('not-found', 'local_tts_not_installed', '自然语音包未安装，请在语音设置中下载 MOSS-TTS-Nano')
+        }
+      } else if ((await this.status()).installed !== true) {
+        throw new ServiceError('not-found', 'local_tts_not_installed', '本地中文语音包未安装，请运行 pnpm tts:install')
+      }
       const provider = input.provider === 'moss'
         ? (this.#mossProvider ??= new MossTtsProvider(join(this.#root, 'models', MOSS_MODEL_ID)))
         : this.#provider
@@ -267,6 +302,38 @@ export class LocalTtsAssetService {
       await rm(staging, { recursive: true, force: true })
     }
   }
+
+  /**
+   * The speakers an installed MOSS pack offers.
+   *
+   * Read from the pack's own manifest rather than from a list in the UI: a
+   * newer pack with more speakers should simply show more of them, and a pack
+   * that names its speakers should show those names. The settings panel used
+   * to hardcode exactly one, so a multi-speaker model looked like a
+   * single-voice one.
+   */
+  async #readMossVoices(root: string): Promise<VoiceModelVoice[]> {
+    try {
+      const manifest = JSON.parse(await readFile(join(root, 'manifest.json'), 'utf8')) as {
+        voices?: Array<string | { id?: unknown; label?: unknown; name?: unknown; gender?: unknown }>
+      }
+      const raw = Array.isArray(manifest.voices) ? manifest.voices : []
+      const voices = raw.flatMap((entry): VoiceModelVoice[] => {
+        if (typeof entry === 'string') return entry.trim() === '' ? [] : [{ id: `moss:${entry}`, label: entry }]
+        const id = typeof entry.id === 'string' ? entry.id : undefined
+        if (id === undefined || id.trim() === '') return []
+        const label = typeof entry.label === 'string' ? entry.label : typeof entry.name === 'string' ? entry.name : id
+        const gender = entry.gender === 'female' || entry.gender === 'male' ? entry.gender : undefined
+        return [{ id: `moss:${id}`, label, ...(gender === undefined ? {} : { gender }) }]
+      })
+      // A pack that names no speakers still has one; without this an installed,
+      // working engine would offer nothing at all.
+      return voices.length > 0 ? voices : [MOSS_DEFAULT_VOICE]
+    } catch {
+      return [MOSS_DEFAULT_VOICE]
+    }
+  }
+
 }
 
 async function fileExists(path: string): Promise<boolean> {
@@ -359,9 +426,37 @@ function abortError(): Error {
   return error
 }
 
+/**
+ * An interpreter that exists on this machine.
+ *
+ * The install used the bare name `python`, which macOS has not shipped since
+ * 12.3 — so the final step of a one-gigabyte download failed with a spawn
+ * error and the pack was never written. On Windows the opposite is true:
+ * `python3` is a Store stub that opens the app store instead of running.
+ */
+async function resolvePython(signal: AbortSignal): Promise<string> {
+  const configured = process.env.DSH_CYBER_PYTHON?.trim()
+  const candidates = configured !== undefined && configured !== ''
+    ? [configured]
+    : process.platform === 'win32' ? ['python', 'python3'] : ['python3', 'python']
+  for (const candidate of candidates) {
+    try {
+      await runProcess(candidate, ['--version'], signal)
+      return candidate
+    } catch {
+      // Try the next name.
+    }
+  }
+  throw new ServiceError(
+    'not-found',
+    'local_tts_python_missing',
+    `未找到可用的 Python（已尝试 ${candidates.join('、')}）。请安装 Python 3，或用 DSH_CYBER_PYTHON 指定解释器路径。`,
+  )
+}
+
 async function installMossPythonRuntime(root: string, signal: AbortSignal): Promise<void> {
   const venvRoot = join(root, 'runtime', '.venv')
-  const python = process.env.DSH_CYBER_PYTHON?.trim() || 'python'
+  const python = await resolvePython(signal)
   await runProcess(python, ['-m', 'venv', venvRoot], signal)
   const runtimePython = process.platform === 'win32' ? join(venvRoot, 'Scripts', 'python.exe') : join(venvRoot, 'bin', 'python')
   await runProcess(runtimePython, [

--- a/packages/server/src/voice/tts/moss-tts-provider.ts
+++ b/packages/server/src/voice/tts/moss-tts-provider.ts
@@ -53,7 +53,9 @@ export class MossTtsProvider implements TextToSpeechProvider {
       nextSequence: 0,
     })
     const voice = request.voiceId.startsWith('moss:') ? request.voiceId.slice('moss:'.length) : this.#voices[0] ?? 'Junhao'
-    this.#process!.stdin.write(`${JSON.stringify({ id: request.requestId, text: request.text, voice })}\n`, (error) => {
+    // Speed was dropped here, so the slider moved and nothing changed: the
+    // sidecar resamples the result when it is given one.
+    this.#process!.stdin.write(`${JSON.stringify({ id: request.requestId, text: request.text, voice, speed: request.speed })}\n`, (error) => {
       if (error !== null && error !== undefined) this.#terminate(error)
     })
     try {

--- a/packages/server/src/voice/tts/moss-tts-provider.ts
+++ b/packages/server/src/voice/tts/moss-tts-provider.ts
@@ -4,7 +4,7 @@ import { fileURLToPath } from 'node:url'
 import { join } from 'node:path'
 import { createInterface, type Interface } from 'node:readline'
 
-import type { AudioChunk, TextToSpeechCapabilities, TextToSpeechProvider, TtsRequest, VoiceRuntimeState } from '@dsh-cyber/contracts'
+import { normalizeMossVoiceId, type AudioChunk, type TextToSpeechCapabilities, type TextToSpeechProvider, type TtsRequest, type VoiceRuntimeState } from '@dsh-cyber/contracts'
 import { AsyncQueue } from '../async-queue.js'
 
 type PendingRequest = {
@@ -52,7 +52,9 @@ export class MossTtsProvider implements TextToSpeechProvider {
       sampleRate: 48_000,
       nextSequence: 0,
     })
-    const voice = request.voiceId.startsWith('moss:') ? request.voiceId.slice('moss:'.length) : this.#voices[0] ?? 'Junhao'
+    const voice = request.voiceId.trim() === ''
+      ? this.#voices[0] ?? 'Junhao'
+      : normalizeMossVoiceId(request.voiceId).slice('moss:'.length)
     // Speed is deliberately absent: the sidecar synthesises at its own rate
     // and has no parameter for it, so playback rate is where MOSS speed is
     // applied (see KokoroSpeechAdapter). Sending it here would look like it

--- a/packages/server/src/voice/tts/moss-tts-provider.ts
+++ b/packages/server/src/voice/tts/moss-tts-provider.ts
@@ -53,9 +53,11 @@ export class MossTtsProvider implements TextToSpeechProvider {
       nextSequence: 0,
     })
     const voice = request.voiceId.startsWith('moss:') ? request.voiceId.slice('moss:'.length) : this.#voices[0] ?? 'Junhao'
-    // Speed was dropped here, so the slider moved and nothing changed: the
-    // sidecar resamples the result when it is given one.
-    this.#process!.stdin.write(`${JSON.stringify({ id: request.requestId, text: request.text, voice, speed: request.speed })}\n`, (error) => {
+    // Speed is deliberately absent: the sidecar synthesises at its own rate
+    // and has no parameter for it, so playback rate is where MOSS speed is
+    // applied (see KokoroSpeechAdapter). Sending it here would look like it
+    // did something.
+    this.#process!.stdin.write(`${JSON.stringify({ id: request.requestId, text: request.text, voice })}\n`, (error) => {
       if (error !== null && error !== undefined) this.#terminate(error)
     })
     try {
@@ -66,11 +68,29 @@ export class MossTtsProvider implements TextToSpeechProvider {
     }
   }
 
+  /**
+   * Stops caring about one request, or shuts everything down.
+   *
+   * Cancelling one used to kill the Python runtime and start it again, so
+   * every barge-in cost a full model reload before the character could answer
+   * — which is most of what made a spoken conversation impossible. The sidecar
+   * has no cancellation protocol and cannot be interrupted mid-utterance, so
+   * the request is abandoned instead: it finishes into nothing, which costs a
+   * second of CPU rather than a restart, and the next reply starts straight
+   * away.
+   */
   cancel(requestId?: string): void {
     const error = abortError('MOSS 语音生成已取消')
-    if (requestId !== undefined && !this.#pending.has(requestId)) return
-    this.#terminate(error)
-    if (requestId !== undefined) void this.prepare().catch(() => undefined)
+    if (requestId === undefined) {
+      this.#terminate(error)
+      return
+    }
+    const pending = this.#pending.get(requestId)
+    if (pending === undefined) return
+    // The consumer is told; the sidecar is left to finish into nothing, since
+    // it has no way to be interrupted mid-utterance.
+    pending.queue.fail(error)
+    this.#finishRequest(requestId)
   }
 
   async dispose(): Promise<void> {

--- a/packages/server/src/voice/voice-session-manager.ts
+++ b/packages/server/src/voice/voice-session-manager.ts
@@ -111,9 +111,21 @@ export class VoiceSessionManager {
     this.#events.emit('event', event)
   }
 
+  /**
+   * Tells everybody who was listening that the recogniser has gone.
+   *
+   * The failure used to be emitted once with no session id, and the websocket
+   * forwards only events that name a session — so a worker crash reached
+   * nobody and the browser sat on "正在听…" until the page was reloaded. A
+   * failure the user cannot see is worse than one they can.
+   */
   #failAll(error: Error): void {
     for (const pending of this.#pending.values()) { clearTimeout(pending.timer); pending.reject(error) }
     this.#pending.clear()
-    this.#events.emit('event', { type: 'error', message: error.message } satisfies VoiceSessionEvent)
+    for (const sessionId of this.#activeSessions) {
+      this.#events.emit('event', { type: 'error', sessionId, message: error.message } satisfies VoiceSessionEvent)
+    }
+    this.#activeSessions.clear()
+    this.#fastSpeech.clear()
   }
 }

--- a/packages/server/tests/local-tts-asset-service.test.ts
+++ b/packages/server/tests/local-tts-asset-service.test.ts
@@ -43,6 +43,31 @@ describe('LocalTtsAssetService', () => {
     ]))
   })
 
+  it('normalizes MOSS manifest voices and supplies a safe default when empty', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-moss-voices-'))
+    const mossRoot = join(stateRoot, 'tts', 'sherpa', 'models', 'moss-tts-nano-100m-onnx')
+    await mkdir(mossRoot, { recursive: true })
+    await writeFile(join(mossRoot, 'manifest.json'), JSON.stringify({ voices: [
+      'Junhao',
+      'moss:Junhao',
+      { id: 'moss:Lin', label: '林 · 自然女声', gender: 'female' },
+      { id: 'Lin', name: '重复项' },
+    ] }))
+    const service = new LocalTtsAssetService(stateRoot)
+    const model = (await service.models()).find((item) => item.provider === 'moss')
+    expect(model?.state).toBe('ready')
+    expect(model?.voices).toEqual([
+      { id: 'moss:Junhao', label: 'Junhao' },
+      { id: 'moss:Lin', label: '林 · 自然女声', gender: 'female' },
+    ])
+
+    // The service's public model id remains stable; an installed pack with no
+    // declared voices still receives one selectable default.
+    await writeFile(join(mossRoot, 'manifest.json'), JSON.stringify({ voices: [] }))
+    const emptyModel = (await service.models()).find((item) => item.provider === 'moss')
+    expect(emptyModel?.voices).toEqual([{ id: 'moss:Junhao', label: '君豪 · 自然男声', gender: 'male' }])
+  })
+
   it('fails closed for an unpinned or incomplete voice runtime', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-local-tts-invalid-'))
     const root = join(stateRoot, 'tts', 'sherpa')

--- a/packages/server/tests/moss-tts-provider.test.ts
+++ b/packages/server/tests/moss-tts-provider.test.ts
@@ -29,6 +29,8 @@ describe('MossTtsProvider sidecar protocol', () => {
     await provider.prepare()
     expect(provider.state).toBe('ready')
     expect(provider.voices).toEqual(['Junhao'])
+    const warmPid = provider.processId
+    expect(warmPid).toEqual(expect.any(Number))
     const chunks = []
     for await (const chunk of provider.synthesize({ requestId: 'moss-test', text: '你好', voiceId: 'moss:Junhao', speed: 1 })) chunks.push(chunk)
     expect(chunks).toHaveLength(3)
@@ -47,6 +49,45 @@ describe('MossTtsProvider sidecar protocol', () => {
     controller.abort()
     await expect(interrupted).rejects.toMatchObject({ name: 'AbortError' })
     await vi.waitFor(() => expect(provider.state).toBe('ready'), { timeout: 2_000 })
+    expect(provider.processId).toBe(warmPid)
+
+    const nextChunks = []
+    for await (const chunk of provider.synthesize({ requestId: 'moss-next', text: '你好', voiceId: 'moss:Junhao', speed: 1 })) nextChunks.push(chunk)
+    expect(nextChunks.length).toBeGreaterThan(0)
+    expect(provider.processId).toBe(warmPid)
+    await provider.dispose()
+    expect(provider.processId).toBeUndefined()
+  })
+
+  it('terminates and recovers the runtime after a request timeout', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-moss-timeout-'))
+    const sidecar = join(root, 'timeout-sidecar.mjs')
+    await writeFile(sidecar, `
+      import { createInterface } from 'node:readline';
+      process.stdout.write(JSON.stringify({ type: 'ready', voices: ['Junhao'] }) + '\\n');
+      const lines = createInterface({ input: process.stdin });
+      lines.on('line', (line) => {
+        const request = JSON.parse(line);
+        if (request.text === 'timeout') return;
+        process.stdout.write(JSON.stringify({ type: 'audio', id: request.id, sequence: 0, sampleRate: 24000, pcmBase64: Buffer.from(new Float32Array([0.2]).buffer).toString('base64') }) + '\\n');
+        process.stdout.write(JSON.stringify({ type: 'done', id: request.id, sequence: 1 }) + '\\n');
+      });
+    `, 'utf8')
+    const provider = new MossTtsProvider(root, { executable: process.execPath, sidecar, startupTimeoutMs: 2_000, requestTimeoutMs: 30 })
+    await provider.prepare()
+    const firstPid = provider.processId
+    const timedOut = (async () => {
+      for await (const _chunk of provider.synthesize({ requestId: 'moss-timeout', text: 'timeout', voiceId: 'moss:Junhao', speed: 1 })) { /* consume */ }
+    })()
+    await expect(timedOut).rejects.toMatchObject({ name: 'AbortError' })
+    expect(provider.processId).toBeUndefined()
+
+    await provider.prepare()
+    expect(provider.processId).toEqual(expect.any(Number))
+    expect(provider.processId).not.toBe(firstPid)
+    const recovered = []
+    for await (const chunk of provider.synthesize({ requestId: 'moss-recovered', text: '恢复', voiceId: 'moss:Junhao', speed: 1 })) recovered.push(chunk)
+    expect(recovered.some((chunk) => chunk.final)).toBe(true)
     await provider.dispose()
   })
 })

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -101,6 +101,7 @@ import { characterAvatarUrl, readCharacterAvatarProfile } from './features/world
 import { subscribeWorldLive } from './world-live-client.js'
 import { publishStreamingSpeech } from './features/voice/streaming-speech-bus.js'
 import { resolveEmployeeVoiceProfile } from './features/voice/employee-voice-profile.js'
+import { forgetVoiceTurn, registerVoiceTurn, speechContextForTurn, type SpeechInputSurface } from './features/voice/SpeechCoordinator.js'
 
 const SettingsDialog = lazy(async () => ({ default: (await import('./components/SettingsDialog.js')).SettingsDialog }))
 const WorldSideDock = lazy(async () => ({ default: (await import('./components/WorldSideDock.js')).WorldSideDock }))
@@ -207,6 +208,7 @@ export default function App() {
   const sessionByQueueKeyRef = useRef(new Map<string, string>())
   const queueKeyBySessionRef = useRef(new Map<string, string>())
   const pendingTurnsRef = useRef<PendingChatTurn[]>([])
+  const speechContentByTurnRef = useRef(new Map<string, string>())
   const worldLoadRequestRef = useRef(0)
   const transcriptLoadRequestRef = useRef(0)
   const modelMutationRevisionRef = useRef(0)
@@ -734,6 +736,15 @@ export default function App() {
         }
 
         const streamId = `stream-${traceTurnId}`
+        const speechContext = speechContextForTurn(effectiveClientTurnId)
+        const publishSpeech = (kind: 'start' | 'delta' | 'complete' | 'cancel', content?: string) => publishStreamingSpeech({
+          kind,
+          employeeId: envelope.agentId,
+          turnId: traceTurnId,
+          sessionId: envelope.sessionId,
+          ...(content === undefined ? {} : { content }),
+          ...(speechContext === undefined ? {} : speechContext),
+        })
         const upsertStream = (content: string, replaceContent: boolean) => {
           setStreamingReplies((current) => {
             const previous = current[streamId]
@@ -759,17 +770,29 @@ export default function App() {
 
         if (envelope.event.kind === 'turn.started') {
           upsertStream('', true)
-          publishStreamingSpeech({ kind: 'start', employeeId: envelope.agentId, turnId: traceTurnId })
+          speechContentByTurnRef.current.set(traceTurnId, '')
+          publishSpeech('start')
         }
         if (envelope.event.kind === 'text.delta' && envelope.event.content !== undefined) {
           upsertStream(envelope.event.content, false)
-          publishStreamingSpeech({ kind: 'delta', employeeId: envelope.agentId, turnId: traceTurnId, content: envelope.event.content })
+          speechContentByTurnRef.current.set(traceTurnId, `${speechContentByTurnRef.current.get(traceTurnId) ?? ''}${envelope.event.content}`)
+          publishSpeech('delta', envelope.event.content)
         }
         if (envelope.event.kind === 'assistant.message' && envelope.event.content?.trim()) {
           upsertStream(envelope.event.content, true)
+          // Some runtimes only emit the assembled assistant.message. Keep the
+          // speech bus useful for those providers without changing the chat
+          // stream contract: the final event is still emitted at turn end,
+          // while this delta gives consumers the text they need to speak.
+          if ((speechContentByTurnRef.current.get(traceTurnId) ?? '').length === 0) {
+            speechContentByTurnRef.current.set(traceTurnId, envelope.event.content)
+            publishSpeech('delta', envelope.event.content)
+          }
         }
         if (envelope.event.kind === 'turn.completed' || envelope.event.kind === 'turn.failed') {
-          publishStreamingSpeech({ kind: envelope.event.kind === 'turn.completed' ? 'complete' : 'cancel', employeeId: envelope.agentId, turnId: traceTurnId })
+          publishSpeech(envelope.event.kind === 'turn.completed' ? 'complete' : 'cancel')
+          speechContentByTurnRef.current.delete(traceTurnId)
+          forgetVoiceTurn(effectiveClientTurnId)
           if (envelope.event.kind === 'turn.failed' && envelope.event.metadata.interrupted === true) {
             patchPendingTurn(effectiveClientTurnId, { status: 'interrupted' })
           } else if (envelope.event.kind === 'turn.failed') {
@@ -1637,7 +1660,7 @@ export default function App() {
     return () => clearInterval(timer)
   }, [activeWorld, demoMode, refreshPendingDecisions])
 
-  const send = useCallback((prompt: string, attachments: ChatAttachment[], queueMode: 'normal' | 'next' = 'normal'): Promise<void> => {
+  const send = useCallback((prompt: string, attachments: ChatAttachment[], queueMode: 'normal' | 'next' = 'normal', speechSurface?: SpeechInputSurface): Promise<void> => {
     const world = activeWorld
     if (world === undefined) return Promise.resolve()
     const explicitEmployeeIds = conversationIntent?.employeeIds
@@ -1679,6 +1702,12 @@ export default function App() {
       sessionByQueueKeyRef.current.set(queueKey, capturedSessionId)
       queueKeyBySessionRef.current.set(capturedSessionId, queueKey)
     }
+    if (speechSurface !== undefined) registerVoiceTurn({
+      clientTurnId,
+      worldId: world.id,
+      conversationKey: queueKey,
+      surface: speechSurface,
+    })
 
     const pendingTurn: PendingChatTurn = {
       id: clientTurnId,
@@ -2304,6 +2333,7 @@ export default function App() {
             messages={chatMessages}
             employees={employees}
             dossiers={dossiers}
+            {...(activeConversationKey === undefined ? {} : { speechConversationKey: activeConversationKey })}
             installedPlugins={installedPluginCommands}
             models={selectableModels}
             modelAssignments={modelAssignments}
@@ -2411,7 +2441,7 @@ export default function App() {
                     if (employee !== undefined) directEmployee(employee)
                   }}
                   onManageAvatar={(employeeId) => { setManagingEmployeeSection('profile'); setManagingEmployeeAvatarFocus(true); setManagingEmployeeId(employeeId) }}
-                  onVoiceFinal={(text) => send(text, [])}
+                  onVoiceFinal={(text) => send(text, [], 'normal', 'focus')}
           onStartGroup={(employeeIds, session) => {
           const selected = employees.filter((employee) => employeeIds.includes(employee.id))
           if (selected.length < 2) return
@@ -3035,14 +3065,15 @@ function participantIdsFromMessages(messages: WorkMessage[]): string[] {
   return ids
 }
 
-function latestEmployeeUtterances(messages: WorkMessage[]): Array<{ messageId: string; employeeId: string; text: string }> {
+function latestEmployeeUtterances(messages: WorkMessage[]): Array<{ messageId: string; employeeId: string; text: string; clientTurnId?: string }> {
   const seen = new Set<string>()
-  const result: Array<{ messageId: string; employeeId: string; text: string }> = []
+  const result: Array<{ messageId: string; employeeId: string; text: string; clientTurnId?: string }> = []
   for (let index = messages.length - 1; index >= 0; index -= 1) {
     const message = messages[index]
     if (message === undefined || message.kind !== 'assistant' || message.senderKind !== 'employee' || !message.content.trim() || seen.has(message.senderId)) continue
     seen.add(message.senderId)
-    result.push({ messageId: message.id, employeeId: message.senderId, text: message.content })
+    const clientTurnId = metadataText(message.metadata.clientTurnId)
+    result.push({ messageId: message.id, employeeId: message.senderId, text: message.content, ...(clientTurnId === undefined ? {} : { clientTurnId }) })
   }
   return result
 }

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -1829,9 +1829,11 @@ export default function App() {
       }
     }
 
-    if (demoMode) void turnQueueRef.current.enqueue(queueKey, runTurn, clientTurnId)
-    else void runTurn()
-    return Promise.resolve()
+    // Returned rather than discarded: the voice control awaits this to decide
+    // whether the message got through, and resolving immediately told it every
+    // attempt had succeeded — so a failed send looked exactly like a delivered
+    // one and the microphone went straight back to listening.
+    return demoMode ? turnQueueRef.current.enqueue(queueKey, runTurn, clientTurnId) : runTurn()
   }, [
     activeConversationKey,
     activePermissionKey,

--- a/packages/web/src/components/ChatWorkbench.tsx
+++ b/packages/web/src/components/ChatWorkbench.tsx
@@ -30,6 +30,7 @@ import { ConversationPermissionControl, type ConversationPermissionMode } from '
 import { ModelPicker } from '../features/models/ModelPicker.js'
 import { MessageSpeechButton } from '../features/voice/MessageSpeechButton.js'
 import { ComposerReplySpeaker } from '../features/voice/ComposerReplySpeaker.js'
+import type { SpeechInputSurface } from '../features/voice/SpeechCoordinator.js'
 import { VoiceConversationControl } from '../features/voice/VoiceConversationControl.js'
 
 const MarkdownMessage = lazy(async () => ({ default: (await import('./MarkdownMessage.js')).MarkdownMessage }))
@@ -56,7 +57,7 @@ interface ChatWorkbenchProps {
   draft: string
   focusRequest?: number
   onDraftChange(value: string): void
-  onSend(prompt: string, attachments: ChatAttachment[], queueMode?: 'normal' | 'next'): Promise<void>
+  onSend(prompt: string, attachments: ChatAttachment[], queueMode?: 'normal' | 'next', speechSurface?: SpeechInputSurface): Promise<void>
   onUploadAttachment(file: File): Promise<ChatAttachment>
   onOpenDossier(employeeId: string): void
   onOpenArtifact(artifactId?: string): void
@@ -78,9 +79,11 @@ interface ChatWorkbenchProps {
   onRequestFullAccess?(): void
   onCancelQueuedTurn?(turnId: string): Promise<void>
   onStopTurn?(turnId: string): Promise<void>
+  /** Stable queue identity used to reject late speech from another session. */
+  speechConversationKey?: string
 }
 
-export function ChatWorkbench({ demoMode, world, session, intent, participantIds = [], messages, employees, dossiers = {}, installedPlugins = [], models = [], modelAssignments = [], modelProfileId, onChangeModelProfile, sending = false, pendingCount = 0, queuedCount = 0, queueItems = [], draft, focusRequest = 0, onDraftChange, onSend, onUploadAttachment, onOpenDossier, onOpenArtifact, onRetryCompletionJob, onCompletionJobSettled, onRecruit, onOpenPluginMarket, onOpenHistory, hasOlderMessages = false, loadingOlderMessages = false, onLoadOlderMessages, approvals = [], onDecideApproval, permissionRequests = [], onDecideWorldPermissionRequest, permissionMode = 'read-only', onChangePermissionMode, onRequestFullAccess, onCancelQueuedTurn, onStopTurn }: ChatWorkbenchProps) {
+export function ChatWorkbench({ demoMode, world, session, intent, participantIds = [], messages, employees, dossiers = {}, installedPlugins = [], models = [], modelAssignments = [], modelProfileId, onChangeModelProfile, sending = false, pendingCount = 0, queuedCount = 0, queueItems = [], draft, focusRequest = 0, onDraftChange, onSend, onUploadAttachment, onOpenDossier, onOpenArtifact, onRetryCompletionJob, onCompletionJobSettled, onRecruit, onOpenPluginMarket, onOpenHistory, hasOlderMessages = false, loadingOlderMessages = false, onLoadOlderMessages, approvals = [], onDecideApproval, permissionRequests = [], onDecideWorldPermissionRequest, permissionMode = 'read-only', onChangePermissionMode, onRequestFullAccess, onCancelQueuedTurn, onStopTurn, speechConversationKey }: ChatWorkbenchProps) {
   const { t } = useI18n()
   const inputRef = useRef<HTMLTextAreaElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
@@ -94,7 +97,6 @@ export function ChatWorkbench({ demoMode, world, session, intent, participantIds
   const [rememberingMessageId, setRememberingMessageId] = useState<string>()
   const [submittedKnowledgeMessageIds, setSubmittedKnowledgeMessageIds] = useState<Set<string>>(() => new Set())
   const [knowledgeError, setKnowledgeError] = useState<string>()
-  const [spokeAloud, setSpokeAloud] = useState(false)
   const [copiedMessageId, setCopiedMessageId] = useState<string>()
   const [copyError, setCopyError] = useState<string>()
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
@@ -490,11 +492,8 @@ export function ChatWorkbench({ demoMode, world, session, intent, participantIds
             <CommandPicker commands={installedPlugins} draft={draft} onDraftChange={onDraftChange} {...(onOpenPluginMarket === undefined ? {} : { onOpenMarket: onOpenPluginMarket })} onFocus={() => inputRef.current?.focus()} />
           </div>
           <div className="composer__actions-right">
-            {/* Armed by speaking, not by typing: a user who has just talked
-                expects to be answered out loud, and one who is typing does
-                not want the room to start making noise. */}
-            <ComposerReplySpeaker {...(directEmployee === undefined ? { employeeId: undefined } : { employeeId: directEmployee.id })} dossiers={dossiers} enabled={spokeAloud} />
-            <VoiceConversationControl variant="compact" employeeName={directEmployee?.displayName ?? '当前会话角色'} disabled={employees.length === 0} onFinal={async (text) => { setSpokeAloud(true); await onSend(text, [], nextQueueMode) }} />
+            <ComposerReplySpeaker {...(directEmployee === undefined ? { employeeId: undefined } : { employeeId: directEmployee.id })} {...(session?.id === undefined ? {} : { sessionId: session.id })} {...(speechConversationKey === undefined ? {} : { conversationKey: speechConversationKey })} dossiers={dossiers} />
+            <VoiceConversationControl variant="compact" employeeName={directEmployee?.displayName ?? '当前会话角色'} disabled={employees.length === 0} onFinal={async (text) => { await onSend(text, [], nextQueueMode, 'composer') }} />
             <button className={`send-button${showStopButton ? ' send-button--stop' : ''}`} type="button" aria-label={showStopButton ? '停止当前回复' : insertsNext ? '插入对话' : sending ? '正在回复中，发送新消息' : '发送'} title={showStopButton ? '停止当前回复' : insertsNext ? '插入对话' : '发送'} disabled={showStopButton ? false : uploading || employees.length === 0 || (!draft.trim() && attachments.length === 0)} onClick={() => { if (showStopButton && activeTurn !== undefined && onStopTurn !== undefined) void onStopTurn(activeTurn.id); else void submit() }}>{showStopButton ? <Stop size={19} weight="bold" /> : sending && !insertsNext ? <CircleNotch size={19} className="spin" /> : <PaperPlaneRight size={19} weight="fill" />}{showStopButton || queuedCount === 0 ? null : <span className="send-button__queue" aria-label={`${queuedCount} 条插入对话`}>{queuedCount}</span>}</button>
           </div>
         </div>

--- a/packages/web/src/components/ChatWorkbench.tsx
+++ b/packages/web/src/components/ChatWorkbench.tsx
@@ -29,6 +29,7 @@ import { ContextMenu, type ContextMenuPosition } from './ContextMenu.js'
 import { ConversationPermissionControl, type ConversationPermissionMode } from './ConversationPermissionControl.js'
 import { ModelPicker } from '../features/models/ModelPicker.js'
 import { MessageSpeechButton } from '../features/voice/MessageSpeechButton.js'
+import { ComposerReplySpeaker } from '../features/voice/ComposerReplySpeaker.js'
 import { VoiceConversationControl } from '../features/voice/VoiceConversationControl.js'
 
 const MarkdownMessage = lazy(async () => ({ default: (await import('./MarkdownMessage.js')).MarkdownMessage }))
@@ -93,6 +94,7 @@ export function ChatWorkbench({ demoMode, world, session, intent, participantIds
   const [rememberingMessageId, setRememberingMessageId] = useState<string>()
   const [submittedKnowledgeMessageIds, setSubmittedKnowledgeMessageIds] = useState<Set<string>>(() => new Set())
   const [knowledgeError, setKnowledgeError] = useState<string>()
+  const [spokeAloud, setSpokeAloud] = useState(false)
   const [copiedMessageId, setCopiedMessageId] = useState<string>()
   const [copyError, setCopyError] = useState<string>()
   const [showScrollToBottom, setShowScrollToBottom] = useState(false)
@@ -488,7 +490,11 @@ export function ChatWorkbench({ demoMode, world, session, intent, participantIds
             <CommandPicker commands={installedPlugins} draft={draft} onDraftChange={onDraftChange} {...(onOpenPluginMarket === undefined ? {} : { onOpenMarket: onOpenPluginMarket })} onFocus={() => inputRef.current?.focus()} />
           </div>
           <div className="composer__actions-right">
-            <VoiceConversationControl variant="compact" employeeName={directEmployee?.displayName ?? '当前会话角色'} disabled={employees.length === 0} onFinal={(text) => onSend(text, [], nextQueueMode)} />
+            {/* Armed by speaking, not by typing: a user who has just talked
+                expects to be answered out loud, and one who is typing does
+                not want the room to start making noise. */}
+            <ComposerReplySpeaker {...(directEmployee === undefined ? { employeeId: undefined } : { employeeId: directEmployee.id })} dossiers={dossiers} enabled={spokeAloud} />
+            <VoiceConversationControl variant="compact" employeeName={directEmployee?.displayName ?? '当前会话角色'} disabled={employees.length === 0} onFinal={async (text) => { setSpokeAloud(true); await onSend(text, [], nextQueueMode) }} />
             <button className={`send-button${showStopButton ? ' send-button--stop' : ''}`} type="button" aria-label={showStopButton ? '停止当前回复' : insertsNext ? '插入对话' : sending ? '正在回复中，发送新消息' : '发送'} title={showStopButton ? '停止当前回复' : insertsNext ? '插入对话' : '发送'} disabled={showStopButton ? false : uploading || employees.length === 0 || (!draft.trim() && attachments.length === 0)} onClick={() => { if (showStopButton && activeTurn !== undefined && onStopTurn !== undefined) void onStopTurn(activeTurn.id); else void submit() }}>{showStopButton ? <Stop size={19} weight="bold" /> : sending && !insertsNext ? <CircleNotch size={19} className="spin" /> : <PaperPlaneRight size={19} weight="fill" />}{showStopButton || queuedCount === 0 ? null : <span className="send-button__queue" aria-label={`${queuedCount} 条插入对话`}>{queuedCount}</span>}</button>
           </div>
         </div>

--- a/packages/web/src/features/voice/ComposerReplySpeaker.tsx
+++ b/packages/web/src/features/voice/ComposerReplySpeaker.tsx
@@ -1,53 +1,64 @@
 import { useEffect, useRef } from 'react'
 import type { EmployeeDossier } from '@dsh-cyber/contracts'
 
+import { claimSpeech, type SpeechClaim } from './SpeechCoordinator.js'
 import { subscribeStreamingSpeech } from './streaming-speech-bus.js'
 import { speakAsCharacter, stopCharacterSpeech } from './speak-as-character.js'
 
 /**
- * Speaks replies for somebody talking through the chat composer.
+ * Speaks replies for a voice turn started in the chat composer.
  *
- * The composer has a microphone, so a user can talk to a character from the
- * chat surface — but nothing there ever subscribed to the streaming speech
- * bus, so the character answered in silence. Only the world's character panel
- * did, which meant a spoken conversation worked in one place and half-worked
- * in the other.
- *
- * Deliberately simpler than the panel's pipeline: it speaks a reply when the
- * reply is finished, rather than streaming sentence by sentence as it arrives.
- * That costs the time between the first word and the last, and it avoids a
- * second copy of the chunking, generation-counting and barge-in bookkeeping
- * that would then have to be kept in step with the original. The panel remains
- * the place to go for a low-latency spoken conversation.
- *
- * Renders nothing.
+ * This is deliberately a fallback owner. The focused character panel claims
+ * the same turn when it is streaming, so this component can stay mounted in
+ * the hidden chat drawer without creating a second playback pipeline.
  */
 
 interface ComposerReplySpeakerProps {
   /** The character being spoken to, when the conversation has exactly one. */
   employeeId: string | undefined
+  /** Current durable session, used to reject a late event from another chat. */
+  sessionId?: string
+  /** Queue identity also covers a newly-created session before it is durable. */
+  conversationKey?: string
   dossiers: Record<string, EmployeeDossier>
-  /** Off unless the user has actually spoken; typing does not want audio. */
-  enabled: boolean
 }
 
-export function ComposerReplySpeaker({ employeeId, dossiers, enabled }: ComposerReplySpeakerProps) {
+export function ComposerReplySpeaker({ employeeId, sessionId, conversationKey, dossiers }: ComposerReplySpeakerProps) {
   const spokenTurnsRef = useRef(new Set<string>())
   const bufferRef = useRef(new Map<string, string>())
+  const claimsRef = useRef(new Map<string, SpeechClaim>())
+  const dossiersRef = useRef(dossiers)
+  dossiersRef.current = dossiers
+
+  const stopOwnedSpeech = () => {
+    if (claimsRef.current.size === 0) return
+    for (const claim of claimsRef.current.values()) claim.release()
+    claimsRef.current.clear()
+    stopCharacterSpeech()
+  }
 
   useEffect(() => {
-    if (!enabled || employeeId === undefined) return
+    if (employeeId === undefined) return
     return subscribeStreamingSpeech((event) => {
-      if (event.employeeId !== employeeId) return
+      if (event.employeeId !== employeeId || event.source !== 'voice' || event.surface !== 'composer') return
+      if (sessionId !== undefined && event.sessionId !== undefined && event.sessionId !== sessionId) return
+      if (conversationKey !== undefined && event.conversationKey !== undefined && event.conversationKey !== conversationKey) return
+
       if (event.kind === 'start') {
         bufferRef.current.set(event.turnId, '')
-        // A new reply supersedes whatever was still being read out.
-        stopCharacterSpeech()
+        // A later voice turn supersedes a composer fallback that is still
+        // playing. The coordinator keeps this scoped to our own claim.
+        stopOwnedSpeech()
         return
       }
       if (event.kind === 'cancel') {
         bufferRef.current.delete(event.turnId)
-        stopCharacterSpeech()
+        const claim = claimsRef.current.get(event.turnId)
+        if (claim !== undefined) {
+          claim.release()
+          claimsRef.current.delete(event.turnId)
+          stopCharacterSpeech()
+        }
         return
       }
       if (event.kind === 'delta' && event.content !== undefined) {
@@ -57,22 +68,37 @@ export function ComposerReplySpeaker({ employeeId, dossiers, enabled }: Composer
       if (event.kind !== 'complete') return
       const text = bufferRef.current.get(event.turnId) ?? event.content ?? ''
       bufferRef.current.delete(event.turnId)
-      // A turn can complete more than once across reconnects; reading the same
-      // reply twice is worse than not reading it.
       if (text.trim() === '' || spokenTurnsRef.current.has(event.turnId)) return
+
+      const claim = claimSpeech({
+        employeeId,
+        turnId: event.clientTurnId ?? event.turnId,
+        owner: 'composer-fallback',
+      })
+      // Focus streaming owns this turn when it is present. Do not start a
+      // second full-reply playback just because the composer also saw it.
+      if (claim === undefined) return
       spokenTurnsRef.current.add(event.turnId)
-      if (spokenTurnsRef.current.size > 64) {
-        spokenTurnsRef.current.delete(spokenTurnsRef.current.values().next().value as string)
+      if (spokenTurnsRef.current.size > 128) {
+        const oldest = spokenTurnsRef.current.values().next().value
+        if (typeof oldest === 'string') spokenTurnsRef.current.delete(oldest)
       }
+      claimsRef.current.set(event.turnId, claim)
       void speakAsCharacter({
         employeeId,
         text,
-        ...(dossiers[employeeId]?.profile === undefined ? {} : { profile: dossiers[employeeId]!.profile }),
-      }).catch(() => undefined)
+        ...(dossiersRef.current[employeeId]?.profile === undefined ? {} : { profile: dossiersRef.current[employeeId]!.profile }),
+      }).catch(() => undefined).finally(() => {
+        claim.release()
+        if (claimsRef.current.get(event.turnId)?.token === claim.token) claimsRef.current.delete(event.turnId)
+      })
     })
-  }, [dossiers, employeeId, enabled])
+  }, [conversationKey, employeeId, sessionId])
 
-  useEffect(() => () => stopCharacterSpeech(), [])
+  useEffect(() => () => {
+    stopOwnedSpeech()
+    bufferRef.current.clear()
+  }, [conversationKey, employeeId, sessionId])
 
   return null
 }

--- a/packages/web/src/features/voice/ComposerReplySpeaker.tsx
+++ b/packages/web/src/features/voice/ComposerReplySpeaker.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useRef } from 'react'
+import type { EmployeeDossier } from '@dsh-cyber/contracts'
+
+import { subscribeStreamingSpeech } from './streaming-speech-bus.js'
+import { speakAsCharacter, stopCharacterSpeech } from './speak-as-character.js'
+
+/**
+ * Speaks replies for somebody talking through the chat composer.
+ *
+ * The composer has a microphone, so a user can talk to a character from the
+ * chat surface — but nothing there ever subscribed to the streaming speech
+ * bus, so the character answered in silence. Only the world's character panel
+ * did, which meant a spoken conversation worked in one place and half-worked
+ * in the other.
+ *
+ * Deliberately simpler than the panel's pipeline: it speaks a reply when the
+ * reply is finished, rather than streaming sentence by sentence as it arrives.
+ * That costs the time between the first word and the last, and it avoids a
+ * second copy of the chunking, generation-counting and barge-in bookkeeping
+ * that would then have to be kept in step with the original. The panel remains
+ * the place to go for a low-latency spoken conversation.
+ *
+ * Renders nothing.
+ */
+
+interface ComposerReplySpeakerProps {
+  /** The character being spoken to, when the conversation has exactly one. */
+  employeeId: string | undefined
+  dossiers: Record<string, EmployeeDossier>
+  /** Off unless the user has actually spoken; typing does not want audio. */
+  enabled: boolean
+}
+
+export function ComposerReplySpeaker({ employeeId, dossiers, enabled }: ComposerReplySpeakerProps) {
+  const spokenTurnsRef = useRef(new Set<string>())
+  const bufferRef = useRef(new Map<string, string>())
+
+  useEffect(() => {
+    if (!enabled || employeeId === undefined) return
+    return subscribeStreamingSpeech((event) => {
+      if (event.employeeId !== employeeId) return
+      if (event.kind === 'start') {
+        bufferRef.current.set(event.turnId, '')
+        // A new reply supersedes whatever was still being read out.
+        stopCharacterSpeech()
+        return
+      }
+      if (event.kind === 'cancel') {
+        bufferRef.current.delete(event.turnId)
+        stopCharacterSpeech()
+        return
+      }
+      if (event.kind === 'delta' && event.content !== undefined) {
+        bufferRef.current.set(event.turnId, (bufferRef.current.get(event.turnId) ?? '') + event.content)
+        return
+      }
+      if (event.kind !== 'complete') return
+      const text = bufferRef.current.get(event.turnId) ?? event.content ?? ''
+      bufferRef.current.delete(event.turnId)
+      // A turn can complete more than once across reconnects; reading the same
+      // reply twice is worse than not reading it.
+      if (text.trim() === '' || spokenTurnsRef.current.has(event.turnId)) return
+      spokenTurnsRef.current.add(event.turnId)
+      if (spokenTurnsRef.current.size > 64) {
+        spokenTurnsRef.current.delete(spokenTurnsRef.current.values().next().value as string)
+      }
+      void speakAsCharacter({
+        employeeId,
+        text,
+        ...(dossiers[employeeId]?.profile === undefined ? {} : { profile: dossiers[employeeId]!.profile }),
+      }).catch(() => undefined)
+    })
+  }, [dossiers, employeeId, enabled])
+
+  useEffect(() => () => stopCharacterSpeech(), [])
+
+  return null
+}

--- a/packages/web/src/features/voice/MessageSpeechButton.tsx
+++ b/packages/web/src/features/voice/MessageSpeechButton.tsx
@@ -1,7 +1,8 @@
 import { SpeakerHigh, Stop } from '@phosphor-icons/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import type { EmployeeProfile } from '@dsh-cyber/contracts'
 
+import { claimSpeech, type SpeechClaim } from './SpeechCoordinator.js'
 import { speakAsCharacter, stopCharacterSpeech } from './speak-as-character.js'
 
 interface MessageSpeechButtonProps {
@@ -15,10 +16,18 @@ export function MessageSpeechButton({ employeeId, employeeName, profile, text }:
   const [playing, setPlaying] = useState(false)
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string>()
+  const claimRef = useRef<SpeechClaim | undefined>(undefined)
+  const sequenceRef = useRef(0)
 
-  useEffect(() => () => stopCharacterSpeech(), [])
+  useEffect(() => () => {
+    claimRef.current?.release()
+    claimRef.current = undefined
+    stopCharacterSpeech()
+  }, [])
 
   const stop = () => {
+    claimRef.current?.release()
+    claimRef.current = undefined
     stopCharacterSpeech()
     setPlaying(false)
     setBusy(false)
@@ -27,17 +36,27 @@ export function MessageSpeechButton({ employeeId, employeeName, profile, text }:
   const play = async () => {
     setError(undefined)
     setBusy(true)
+    const claim = claimSpeech({ employeeId, turnId: `manual-message:${employeeId}:${++sequenceRef.current}`, owner: 'manual' })
+    if (claim === undefined) {
+      setBusy(false)
+      return
+    }
+    claimRef.current = claim
     try {
       await speakAsCharacter({
         employeeId,
         text,
         ...(profile === undefined ? {} : { profile }),
         onStart: () => { setBusy(false); setPlaying(true) },
-        onEnd: () => { setBusy(false); setPlaying(false) },
+        onEnd: () => { claim.release(); if (claimRef.current?.token === claim.token) claimRef.current = undefined; setBusy(false); setPlaying(false) },
       })
+      claim.release()
+      if (claimRef.current?.token === claim.token) claimRef.current = undefined
       setBusy(false)
       setPlaying(false)
     } catch (cause) {
+      claim.release()
+      if (claimRef.current?.token === claim.token) claimRef.current = undefined
       setBusy(false)
       setPlaying(false)
       setError(cause instanceof Error ? cause.message : '语音播放失败')

--- a/packages/web/src/features/voice/MessageSpeechButton.tsx
+++ b/packages/web/src/features/voice/MessageSpeechButton.tsx
@@ -1,11 +1,8 @@
 import { SpeakerHigh, Stop } from '@phosphor-icons/react'
 import { useEffect, useState } from 'react'
-import type { EmployeeProfile, VoiceModelDescriptor } from '@dsh-cyber/contracts'
+import type { EmployeeProfile } from '@dsh-cyber/contracts'
 
-import { api } from '../../api.js'
-import { playKokoroSpeech, playMossSpeech, stopKokoroSpeech } from '../world/avatar/speech/KokoroSpeechAdapter.js'
-import { speechTextFromMessage } from '../world/digital-human-motion.js'
-import { resolveEmployeeVoiceProfile } from './employee-voice-profile.js'
+import { speakAsCharacter, stopCharacterSpeech } from './speak-as-character.js'
 
 interface MessageSpeechButtonProps {
   employeeId: string
@@ -19,75 +16,27 @@ export function MessageSpeechButton({ employeeId, employeeName, profile, text }:
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string>()
 
-  useEffect(() => () => {
-    stopKokoroSpeech()
-    window.speechSynthesis?.cancel()
-  }, [])
+  useEffect(() => () => stopCharacterSpeech(), [])
 
   const stop = () => {
-    stopKokoroSpeech()
-    window.speechSynthesis?.cancel()
+    stopCharacterSpeech()
     setPlaying(false)
     setBusy(false)
   }
 
   const play = async () => {
-    const spokenText = speechTextFromMessage(text)
-    if (spokenText.length === 0) { setError('这条回复没有可播报的文字'); return }
-    const voice = resolveEmployeeVoiceProfile(employeeId, profile?.gender, profile?.voiceProfile)
-    let effectiveProvider = voice.provider
-    if (effectiveProvider === 'auto') {
-      try {
-        const catalog = await api<{ models: VoiceModelDescriptor[] }>('/api/local-tts/models')
-        effectiveProvider = catalog.models.some((model) => model.provider === 'moss' && model.state === 'ready') ? 'moss' : 'kokoro'
-      } catch { effectiveProvider = 'kokoro' }
-    }
     setError(undefined)
     setBusy(true)
     try {
-      if (voice.voiceId.startsWith('system:') && 'speechSynthesis' in window && 'SpeechSynthesisUtterance' in window) {
-        const voiceUri = voice.voiceId.slice('system:'.length)
-        const systemVoice = window.speechSynthesis.getVoices().find((item) => item.voiceURI === voiceUri && /^zh(?:-|_)/iu.test(item.lang))
-        if (systemVoice !== undefined) {
-          const utterance = new SpeechSynthesisUtterance(spokenText)
-          utterance.voice = systemVoice
-          utterance.lang = systemVoice.lang
-          utterance.rate = voice.speed
-          utterance.pitch = voice.pitch
-          utterance.onstart = () => { setBusy(false); setPlaying(true) }
-          utterance.onend = () => { setBusy(false); setPlaying(false) }
-          utterance.onerror = () => { setBusy(false); setPlaying(false); setError('系统中文声音播放失败') }
-          window.speechSynthesis.cancel()
-          window.speechSynthesis.speak(utterance)
-          return
-        }
-      }
-      if (effectiveProvider === 'moss') {
-        try {
-          await playMossSpeech({
-            text: spokenText,
-            voiceId: voice.voiceId.startsWith('moss:') ? voice.voiceId : 'moss:Junhao',
-            speed: voice.speed,
-            onStatus: () => undefined,
-            onStart: () => { setBusy(false); setPlaying(true) },
-            onEnd: () => { setBusy(false); setPlaying(false) },
-          })
-          return
-        } catch {
-          effectiveProvider = 'kokoro'
-        }
-      }
-      const localVoice = voice.voiceId.startsWith('kokoro:')
-        ? voice
-        : resolveEmployeeVoiceProfile(employeeId, profile?.gender, { ...voice, provider: 'kokoro', voiceId: '' })
-      await playKokoroSpeech({
-        text: spokenText,
-        voiceId: localVoice.voiceId,
-        speed: localVoice.speed,
-        onStatus: () => undefined,
+      await speakAsCharacter({
+        employeeId,
+        text,
+        ...(profile === undefined ? {} : { profile }),
         onStart: () => { setBusy(false); setPlaying(true) },
         onEnd: () => { setBusy(false); setPlaying(false) },
       })
+      setBusy(false)
+      setPlaying(false)
     } catch (cause) {
       setBusy(false)
       setPlaying(false)

--- a/packages/web/src/features/voice/SpeechCoordinator.ts
+++ b/packages/web/src/features/voice/SpeechCoordinator.ts
@@ -1,0 +1,142 @@
+/**
+ * Shared speech ownership for every surface that can play a character reply.
+ *
+ * A streamed reply may be observed by the focused character panel, the chat
+ * composer fallback and a manual message control at the same time.  Playback
+ * is a side effect, so choosing an owner in each component independently is
+ * inherently racy.  This small registry keeps the decision at the turn
+ * boundary and lets the higher-priority surface pre-empt a lower one.
+ */
+
+export type SpeechInputSurface = 'composer' | 'focus'
+export type SpeechOwner = 'focus-stream' | 'composer-fallback' | 'manual'
+
+export interface VoiceTurnContext {
+  clientTurnId: string
+  worldId: string
+  conversationKey: string
+  surface: SpeechInputSurface
+}
+
+export interface StreamingSpeechContext {
+  source: 'voice'
+  surface: SpeechInputSurface
+  clientTurnId: string
+  worldId: string
+  conversationKey: string
+}
+
+export interface SpeechClaim {
+  readonly key: string
+  readonly token: string
+  readonly owner: SpeechOwner
+  release(): void
+  isActive(): boolean
+}
+
+interface ActiveClaim extends SpeechClaim {
+  readonly priority: number
+  readonly onReplaced?: () => void
+}
+
+const OWNER_PRIORITY: Record<SpeechOwner, number> = {
+  'focus-stream': 100,
+  'composer-fallback': 50,
+  manual: 20,
+}
+
+const activeClaims = new Map<string, ActiveClaim>()
+const voiceTurns = new Map<string, VoiceTurnContext>()
+let claimSequence = 0
+
+/** Register the origin of a turn before the request can emit runtime events. */
+export function registerVoiceTurn(context: VoiceTurnContext): void {
+  voiceTurns.set(context.clientTurnId, context)
+  // A turn that never reaches a terminal event must not grow this process-wide
+  // map forever.  Keep the most recent registrations; normal completion calls
+  // forgetVoiceTurn explicitly below.
+  while (voiceTurns.size > 512) {
+    const oldest = voiceTurns.keys().next().value
+    if (typeof oldest !== 'string') break
+    voiceTurns.delete(oldest)
+  }
+}
+
+export function speechContextForTurn(clientTurnId: string): StreamingSpeechContext | undefined {
+  const context = voiceTurns.get(clientTurnId)
+  if (context === undefined) return undefined
+  return {
+    source: 'voice',
+    surface: context.surface,
+    clientTurnId: context.clientTurnId,
+    worldId: context.worldId,
+    conversationKey: context.conversationKey,
+  }
+}
+
+export function forgetVoiceTurn(clientTurnId: string): void {
+  voiceTurns.delete(clientTurnId)
+}
+
+/**
+ * Claim one employee/turn pair.  A lower-priority claim is refused; a
+ * higher-priority claim replaces the old one and gets a chance to stop its
+ * playback.  Releasing is token-checked so a late completion from an old
+ * component cannot release a newer owner's claim.
+ */
+export function claimSpeech(input: {
+  employeeId: string
+  turnId: string
+  owner: SpeechOwner
+  priority?: number
+  onReplaced?: () => void
+}): SpeechClaim | undefined {
+  const key = speechKey(input.employeeId, input.turnId)
+  const priority = input.priority ?? OWNER_PRIORITY[input.owner]
+  const existing = activeClaims.get(key)
+  if (existing !== undefined) {
+    if (priority <= existing.priority) return undefined
+    activeClaims.delete(key)
+    existing.onReplaced?.()
+  }
+
+  const token = `speech-${++claimSequence}`
+  let active = true
+  const claim: ActiveClaim = {
+    key,
+    token,
+    owner: input.owner,
+    priority,
+    ...(input.onReplaced === undefined ? {} : { onReplaced: input.onReplaced }),
+    release: () => {
+      if (!active) return
+      active = false
+      if (activeClaims.get(key)?.token === token) activeClaims.delete(key)
+    },
+    isActive: () => active && activeClaims.get(key)?.token === token,
+  }
+  activeClaims.set(key, claim)
+  return claim
+}
+
+export function activeSpeechOwner(employeeId: string, turnId: string): SpeechOwner | undefined {
+  return activeClaims.get(speechKey(employeeId, turnId))?.owner
+}
+
+export function releaseSpeechForEmployee(employeeId: string): void {
+  for (const [key, claim] of activeClaims) {
+    if (!key.startsWith(`${employeeId}\u0000`)) continue
+    claim.release()
+  }
+}
+
+/** Test isolation hook; production code should release its own claims. */
+export function resetSpeechCoordinatorForTest(): void {
+  activeClaims.clear()
+  voiceTurns.clear()
+  claimSequence = 0
+}
+
+function speechKey(employeeId: string, turnId: string): string {
+  return `${employeeId}\u0000${turnId}`
+}

--- a/packages/web/src/features/voice/VoiceConversationControl.tsx
+++ b/packages/web/src/features/voice/VoiceConversationControl.tsx
@@ -26,8 +26,15 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
   const ownerIdRef = useRef(crypto.randomUUID())
 
   const prepare = useCallback(() => {
-    if (disabled || socketRef.current !== undefined || !('WebSocket' in window)) return
-    setState('warming'); setError(undefined)
+    if (disabled || !('WebSocket' in window)) return
+    // A previous failure must not outlive the attempt that caused it. The
+    // guard used to return before clearing the error, so once anything went
+    // wrong the notice stayed on screen for the rest of the session — and in
+    // the composer it is an absolutely positioned panel, so it sat over the
+    // send button until reload.
+    setError(undefined)
+    if (socketRef.current !== undefined) return
+    setState('warming')
     const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:'
     const socket = new WebSocket(`${protocol}//${location.host}/api/voice/session`)
     socket.binaryType = 'arraybuffer'
@@ -49,6 +56,12 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
         })
       } else if (event.type === 'error') {
         setError(event.message ?? '本地语音识别失败'); setState('failed')
+      } else if (event.type === 'speech-end') {
+        setState((current) => current === 'finalizing' ? current : 'listening')
+      } else if (event.type === 'stopped' || event.type === 'cancelled') {
+        // Without these the UI kept saying it was listening after the server
+        // had stopped, and the only way out was to press the button twice.
+        setPartial(''); setState((current) => current === 'failed' ? current : 'ready')
       }
     }
     socket.onerror = () => { setError('无法连接本地语音服务'); setState('failed') }
@@ -57,6 +70,12 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
 
   const start = useCallback(async () => {
     window.dispatchEvent(new CustomEvent('dsh:voice-exclusive', { detail: ownerIdRef.current }))
+    // A socket left over from a failed attempt cannot be reused: the server
+    // has already given up on that session, so retrying through it looks like
+    // the retry did nothing.
+    if (socketRef.current !== undefined && socketRef.current.readyState > WebSocket.OPEN) {
+      socketRef.current = undefined
+    }
     prepare()
     const socket = socketRef.current
     if (socket === undefined) return

--- a/packages/web/src/features/voice/VoiceConversationControl.tsx
+++ b/packages/web/src/features/voice/VoiceConversationControl.tsx
@@ -2,6 +2,7 @@ import { Microphone, StopCircle, Waveform } from '@phosphor-icons/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { stopKokoroSpeech } from '../world/avatar/speech/KokoroSpeechAdapter.js'
+import { currentSpeechAmplitude } from '../world/avatar/speech/speech-playback-state.js'
 import './voice-conversation-control.css'
 
 type VoiceUiState = 'cold' | 'warming' | 'ready' | 'listening' | 'speech' | 'finalizing' | 'failed'
@@ -92,6 +93,15 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
     source.connect(worklet); worklet.connect(muted); muted.connect(context.destination)
     worklet.port.onmessage = (event: MessageEvent<ArrayBuffer>) => {
       if (socket.readyState !== WebSocket.OPEN) return
+      // While the character is talking, its own voice comes back through the
+      // speakers and trips the recogniser, so it interrupts itself and the
+      // conversation collapses into a loop. Echo cancellation helps and does
+      // not finish the job on external speakers.
+      //
+      // Half-duplex would kill barge-in, which is the point of a microphone
+      // during a reply, so the bar is raised rather than closed: speak louder
+      // than the speaker and you get through.
+      if (!carriesSpeechOver(event.data, currentSpeechAmplitude())) return
       const packet = new ArrayBuffer(8 + event.data.byteLength)
       new DataView(packet).setFloat64(0, performance.now(), true)
       new Uint8Array(packet, 8).set(new Uint8Array(event.data))
@@ -137,6 +147,23 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
     </span>}
     {state === 'speech' ? <Waveform className="voice-conversation__wave" size={28} aria-hidden="true" /> : null}
   </div>
+}
+
+/**
+ * Whether a captured frame is the user rather than the character's own reply.
+ *
+ * With nothing playing every frame passes: the recogniser's own silence
+ * detection is better at deciding what is speech. While a reply is audible the
+ * frame has to be clearly louder than it, which is what a person does when
+ * they interrupt somebody.
+ */
+function carriesSpeechOver(frame: ArrayBuffer, playbackAmplitude: number | undefined): boolean {
+  if (playbackAmplitude === undefined || playbackAmplitude <= 0.01) return true
+  const samples = new Int16Array(frame)
+  let sum = 0
+  for (const sample of samples) sum += sample * sample
+  const rms = Math.sqrt(sum / Math.max(samples.length, 1)) / 32_768
+  return rms > playbackAmplitude * 1.8 + 0.02
 }
 
 function voiceLabel(state: VoiceUiState, employeeName: string): string {

--- a/packages/web/src/features/voice/VoiceConversationControl.tsx
+++ b/packages/web/src/features/voice/VoiceConversationControl.tsx
@@ -3,6 +3,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 
 import { stopKokoroSpeech } from '../world/avatar/speech/KokoroSpeechAdapter.js'
 import { currentSpeechAmplitude } from '../world/avatar/speech/speech-playback-state.js'
+import { calculateBargeInThreshold, isBargeInFrame, pcmRms, updateEchoBaseline } from './barge-in-threshold.js'
 import './voice-conversation-control.css'
 
 type VoiceUiState = 'cold' | 'warming' | 'ready' | 'listening' | 'speech' | 'finalizing' | 'failed'
@@ -25,6 +26,8 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
   const sourceRef = useRef<MediaStreamAudioSourceNode | undefined>(undefined)
   const workletRef = useRef<AudioWorkletNode | undefined>(undefined)
   const ownerIdRef = useRef(crypto.randomUUID())
+  const echoBaselineRef = useRef(0)
+  const bargeThresholdRef = useRef<number | undefined>(undefined)
 
   const prepare = useCallback(() => {
     if (disabled || !('WebSocket' in window)) return
@@ -47,7 +50,7 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
       if (event.type === 'prepared') setState((current) => current === 'listening' || current === 'speech' || current === 'finalizing' ? current : 'ready')
       else if (event.type === 'listening') setState('listening')
       else if (event.type === 'speech-start') {
-        stopKokoroSpeech(); window.speechSynthesis?.cancel(); onBargeIn?.(); setState('speech')
+        stopKokoroSpeech(); window.speechSynthesis?.cancel(); onBargeIn?.(); echoBaselineRef.current = 0; bargeThresholdRef.current = undefined; setState('speech')
       } else if (event.type === 'partial') {
         setPartial(event.text ?? ''); setState('speech')
       } else if (event.type === 'final' && event.text?.trim()) {
@@ -101,13 +104,18 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
       // Half-duplex would kill barge-in, which is the point of a microphone
       // during a reply, so the bar is raised rather than closed: speak louder
       // than the speaker and you get through.
-      if (!carriesSpeechOver(event.data, currentSpeechAmplitude())) return
+      const playbackAmplitude = currentSpeechAmplitude()
+      const frameRms = pcmRms(event.data)
+      echoBaselineRef.current = updateEchoBaseline(echoBaselineRef.current, frameRms, playbackAmplitude)
+      bargeThresholdRef.current = calculateBargeInThreshold(playbackAmplitude, echoBaselineRef.current, bargeThresholdRef.current)
+      if (!isBargeInFrame(event.data, playbackAmplitude, echoBaselineRef.current, bargeThresholdRef.current)) return
       const packet = new ArrayBuffer(8 + event.data.byteLength)
       new DataView(packet).setFloat64(0, performance.now(), true)
       new Uint8Array(packet, 8).set(new Uint8Array(event.data))
       socket.send(packet)
     }
     streamRef.current = stream; contextRef.current = context; sourceRef.current = source; workletRef.current = worklet
+    echoBaselineRef.current = 0; bargeThresholdRef.current = undefined
     socket.send(JSON.stringify({ type: 'start', endpointSilenceMs: 650 }))
     setState('listening'); setError(undefined)
   }, [prepare])
@@ -118,6 +126,7 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
     for (const track of streamRef.current?.getTracks() ?? []) track.stop()
     void contextRef.current?.close()
     workletRef.current = undefined; sourceRef.current = undefined; streamRef.current = undefined; contextRef.current = undefined
+    echoBaselineRef.current = 0; bargeThresholdRef.current = undefined
     setPartial(''); setState('ready')
   }, [])
 
@@ -147,23 +156,6 @@ export function VoiceConversationControl({ employeeName, disabled = false, varia
     </span>}
     {state === 'speech' ? <Waveform className="voice-conversation__wave" size={28} aria-hidden="true" /> : null}
   </div>
-}
-
-/**
- * Whether a captured frame is the user rather than the character's own reply.
- *
- * With nothing playing every frame passes: the recogniser's own silence
- * detection is better at deciding what is speech. While a reply is audible the
- * frame has to be clearly louder than it, which is what a person does when
- * they interrupt somebody.
- */
-function carriesSpeechOver(frame: ArrayBuffer, playbackAmplitude: number | undefined): boolean {
-  if (playbackAmplitude === undefined || playbackAmplitude <= 0.01) return true
-  const samples = new Int16Array(frame)
-  let sum = 0
-  for (const sample of samples) sum += sample * sample
-  const rms = Math.sqrt(sum / Math.max(samples.length, 1)) / 32_768
-  return rms > playbackAmplitude * 1.8 + 0.02
 }
 
 function voiceLabel(state: VoiceUiState, employeeName: string): string {

--- a/packages/web/src/features/voice/VoiceModelPackPicker.tsx
+++ b/packages/web/src/features/voice/VoiceModelPackPicker.tsx
@@ -12,6 +12,8 @@ interface VoiceModelPackPickerProps {
 
 export function VoiceModelPackPicker({ value, onActivate, onModelsChange }: VoiceModelPackPickerProps) {
   const [models, setModels] = useState<VoiceModelDescriptor[]>([])
+  // Chosen once the catalog arrives, from what can actually speak. Defaulting
+  // to a fixed id showed a pack that may never have been installed.
   const [selectedId, setSelectedId] = useState('moss-tts-nano-100m-onnx')
   const [error, setError] = useState<string>()
   const [busy, setBusy] = useState(false)
@@ -30,7 +32,11 @@ export function VoiceModelPackPicker({ value, onActivate, onModelsChange }: Voic
   useEffect(() => { void refresh() }, [refresh])
   useEffect(() => {
     const active = models.find((model) => model.provider === (value === 'auto' ? 'moss' : value))
-    if (active !== undefined) setSelectedId(active.id)
+    if (active !== undefined) { setSelectedId(active.id); return }
+    // Nothing configured yet: land on something that can speak rather than on
+    // a pack the user would have to download before anything happens.
+    const usable = models.find((model) => model.state === 'ready') ?? models[0]
+    if (usable !== undefined) setSelectedId(usable.id)
   }, [models, value])
   const hasActiveOperation = models.some((model) => model.state === 'downloading' || model.state === 'verifying')
   useEffect(() => {
@@ -60,7 +66,7 @@ export function VoiceModelPackPicker({ value, onActivate, onModelsChange }: Voic
   return <section className="voice-model-picker" aria-label="语音模型包">
     <label><span>语音引擎</span><select aria-label="语音引擎" value={selectedId} onChange={(event) => {
       setSelectedId(event.target.value)
-    }}>{models.map((model) => <option key={model.id} value={model.id}>{model.displayName}{model.recommended ? ' · 推荐' : ''}{model.state === 'ready' ? ' · 可用' : model.state === 'installed' ? ' · 已安装' : ''}</option>)}</select></label>
+    }}>{models.map((model) => <option key={model.id} value={model.id}>{model.displayName}{model.recommended ? ' · 推荐' : ''}{stateSuffix(model.state)}</option>)}</select></label>
     {selected === undefined ? <div className="voice-model-picker__loading" role="status">正在读取语音模型…</div> : <div className="voice-model-picker__detail" data-state={selected.state}>
       <span><strong>{selected.displayName}</strong><small>{selected.summary}</small></span>
       <dl><div><dt>模型大小</dt><dd>{selected.byteLength > 0 ? formatBytes(selected.byteLength) : '由高级运行环境决定'}</dd></div><div><dt>运行方式</dt><dd>{runtimeLabel(selected.runtime)}</dd></div></dl>
@@ -68,11 +74,37 @@ export function VoiceModelPackPicker({ value, onActivate, onModelsChange }: Voic
       {selected.state === 'downloading' || selected.state === 'verifying' ? <div className="voice-model-picker__progress" role="status" aria-live="polite"><progress max={selected.progress?.totalBytes ?? selected.byteLength} value={selected.progress?.completedBytes ?? 0} /><span><strong>{selected.state === 'verifying' ? '正在校验' : '正在下载'}</strong><small>{formatBytes(selected.progress?.completedBytes ?? 0)} / {formatBytes(selected.progress?.totalBytes ?? selected.byteLength)}</small></span><button type="button" aria-label="取消语音模型下载" onClick={() => void cancel()}><X size={15} /></button></div> : null}
       {selected.state === 'installed' ? <button type="button" className="voice-model-picker__activate" disabled>已安装，正在接入运行时</button> : null}
       {selected.state === 'ready' && selectedTtsProvider !== undefined ? <button type="button" className="voice-model-picker__activate" onClick={() => onActivate(selectedTtsProvider)}>使用这个引擎</button> : null}
-      {selected.state === 'unavailable' ? <div className="voice-model-picker__unavailable"><span>高级模型</span><small>{selected.requirements?.join(' · ') ?? '需要独立运行环境'}</small></div> : null}
-      {selected.state === 'error' ? <button type="button" className="voice-model-picker__retry" onClick={() => void install()}><ArrowClockwise size={15} />重试安装</button> : null}
+      {selected.state === 'unavailable' ? <div className="voice-model-picker__unavailable"><span>本机暂不支持</span><small>这个引擎需要独立的高级运行环境，当前版本还不能在本机启用：{selected.requirements?.join(' · ') ?? '需要独立运行环境'}</small></div> : null}
+      {selected.state === 'error' ? <div className="voice-model-picker__failure">
+        {/* The descriptor has carried the reason all along and nothing showed
+            it, so every install failure looked identical and unexplained. */}
+        {selected.error === undefined ? null : <small role="alert">{selected.error}</small>}
+        <button type="button" className="voice-model-picker__retry" onClick={() => void install()}><ArrowClockwise size={15} />重试安装</button>
+      </div> : null}
     </div>}
     {error === undefined ? null : <small className="voice-model-picker__error" role="alert">{error}</small>}
   </section>
+}
+
+/**
+ * What the engine list says about each entry.
+ *
+ * Every state needs a word. Marking only "可用" and "已安装" left the engines
+ * that need downloading — and the ones that cannot run here at all — looking
+ * exactly like the ones that work, so choosing one and getting silence was the
+ * only way to find out.
+ */
+function stateSuffix(state: VoiceModelDescriptor['state']): string {
+  switch (state) {
+    case 'ready': return ' · 可用'
+    case 'installed': return ' · 已安装'
+    case 'not-installed': return ' · 需要下载'
+    case 'downloading': return ' · 正在下载'
+    case 'verifying': return ' · 正在校验'
+    case 'loading': return ' · 正在载入'
+    case 'error': return ' · 安装失败'
+    case 'unavailable': return ' · 本机暂不支持'
+  }
 }
 
 function isTtsProvider(value: VoiceModelDescriptor['provider']): value is Exclude<EmployeeVoiceProfile['provider'], 'auto'> {

--- a/packages/web/src/features/voice/barge-in-threshold.ts
+++ b/packages/web/src/features/voice/barge-in-threshold.ts
@@ -1,0 +1,73 @@
+/**
+ * Pure signal policy for deciding whether a microphone frame is a real
+ * interruption rather than the character coming back through the speakers.
+ *
+ * Mic and speaker analyser values are both normalized RMS values, but their
+ * hardware paths are not calibrated to one another. Keep the policy adaptive,
+ * bounded and hysteretic so a loud speaker can never make the gate impossible.
+ */
+
+export const MIN_BARGE_IN_RMS = 0.06
+export const MAX_BARGE_IN_RMS = 0.78
+export const BARGE_IN_MULTIPLIER = 1.25
+export const BARGE_IN_MARGIN = 0.02
+export const BARGE_IN_HYSTERESIS = 0.015
+export const ECHO_BASELINE_FLOOR = 0.018
+
+export function calculateBargeInThreshold(
+  playbackAmplitude: number | undefined,
+  echoBaseline = 0,
+  previousThreshold?: number,
+): number {
+  const playback = finiteUnit(playbackAmplitude)
+  const baseline = finiteUnit(echoBaseline)
+  const candidate = clamp(
+    Math.max(ECHO_BASELINE_FLOOR, baseline) + playback * BARGE_IN_MULTIPLIER + BARGE_IN_MARGIN,
+    MIN_BARGE_IN_RMS,
+    MAX_BARGE_IN_RMS,
+  )
+  if (previousThreshold === undefined || !Number.isFinite(previousThreshold)) return candidate
+  const previous = clamp(previousThreshold, MIN_BARGE_IN_RMS, MAX_BARGE_IN_RMS)
+  if (Math.abs(candidate - previous) <= BARGE_IN_HYSTERESIS) return previous
+  return candidate
+}
+
+/** Update the estimated speaker echo floor from frames that look like echo. */
+export function updateEchoBaseline(previous: number, frameRms: number, playbackAmplitude: number | undefined): number {
+  const playback = finiteUnit(playbackAmplitude)
+  const frame = finiteUnit(frameRms)
+  if (playback <= 0.01) return clamp(previous, 0, 1)
+  // A frame near the playback level is useful baseline evidence; a frame much
+  // louder than it is probably the user's interruption and must not raise the
+  // next threshold.
+  if (frame > playback * 1.5 + BARGE_IN_MARGIN) return clamp(previous, 0, 1)
+  return clamp((clamp(previous, 0, 1) * 0.9) + (frame * 0.1), 0, 1)
+}
+
+export function pcmRms(frame: ArrayBuffer): number {
+  const length = frame.byteLength - (frame.byteLength % 2)
+  if (length === 0) return 0
+  const samples = new Int16Array(frame, 0, length / 2)
+  let energy = 0
+  for (const sample of samples) {
+    const normalized = sample / 32_768
+    energy += normalized * normalized
+  }
+  return Math.sqrt(energy / samples.length)
+}
+
+/** Return true when this frame crosses the bounded interruption gate. */
+export function isBargeInFrame(frame: ArrayBuffer, playbackAmplitude: number | undefined, echoBaseline = 0, previousThreshold?: number): boolean {
+  if (playbackAmplitude === undefined || playbackAmplitude <= 0.01) return true
+  const rms = pcmRms(frame)
+  const threshold = calculateBargeInThreshold(playbackAmplitude, echoBaseline, previousThreshold)
+  return rms >= threshold + BARGE_IN_HYSTERESIS
+}
+
+function finiteUnit(value: number | undefined): number {
+  return value === undefined || !Number.isFinite(value) ? 0 : clamp(value, 0, 1)
+}
+
+function clamp(value: number, minimum: number, maximum: number): number {
+  return Math.min(maximum, Math.max(minimum, value))
+}

--- a/packages/web/src/features/voice/employee-voice-profile.ts
+++ b/packages/web/src/features/voice/employee-voice-profile.ts
@@ -3,6 +3,17 @@ import type { CharacterGender, EmployeeVoiceProfile } from '@dsh-cyber/contracts
 import { KOKORO_CHINESE_VOICES } from '../world/avatar/speech/KokoroSpeechAdapter.js'
 
 export const DEFAULT_VOICE_SPEED = 1.1
+/**
+ * How fast a character may be asked to speak.
+ *
+ * The ceiling was 1.3x, which is barely above conversational and is the reason
+ * playback read as slow: a user who wanted to move through a long answer had
+ * nowhere left to go. 2x is where speech stops being comfortably followable,
+ * so that is the bound; the floor stays low enough to be useful for listening
+ * carefully to something.
+ */
+export const MIN_VOICE_SPEED = 0.7
+export const MAX_VOICE_SPEED = 2
 
 export function resolveEmployeeVoiceProfile(
   employeeId: string,
@@ -38,7 +49,7 @@ export function voiceMatchesGender(voiceId: string, gender: CharacterGender): bo
 }
 
 export function normalizeVoiceSpeed(value: number | undefined): number {
-  return Number.isFinite(value) ? Math.min(1.3, Math.max(0.8, Math.round(value! * 20) / 20)) : DEFAULT_VOICE_SPEED
+  return Number.isFinite(value) ? Math.min(MAX_VOICE_SPEED, Math.max(MIN_VOICE_SPEED, Math.round(value! * 20) / 20)) : DEFAULT_VOICE_SPEED
 }
 
 function normalizeVoicePitch(value: number | undefined): number {

--- a/packages/web/src/features/voice/employee-voice-profile.ts
+++ b/packages/web/src/features/voice/employee-voice-profile.ts
@@ -1,4 +1,4 @@
-import type { CharacterGender, EmployeeVoiceProfile } from '@dsh-cyber/contracts'
+import { normalizeMossVoiceId, type CharacterGender, type EmployeeVoiceProfile } from '@dsh-cyber/contracts'
 
 import { KOKORO_CHINESE_VOICES } from '../world/avatar/speech/KokoroSpeechAdapter.js'
 
@@ -25,7 +25,7 @@ export function resolveEmployeeVoiceProfile(
     : stableVoiceId(employeeId, gender)
   return {
     provider: profile?.provider ?? 'auto',
-    voiceId,
+    voiceId: voiceId.startsWith('moss:') ? normalizeMossVoiceId(voiceId) : voiceId,
     speed: normalizeVoiceSpeed(profile?.speed),
     pitch: normalizeVoicePitch(profile?.pitch),
   }

--- a/packages/web/src/features/voice/speak-as-character.ts
+++ b/packages/web/src/features/voice/speak-as-character.ts
@@ -1,0 +1,95 @@
+import type { EmployeeProfile, VoiceModelDescriptor } from '@dsh-cyber/contracts'
+
+import { api } from '../../api.js'
+import { playKokoroSpeech, playMossSpeech, stopKokoroSpeech } from '../world/avatar/speech/KokoroSpeechAdapter.js'
+import { speechTextFromMessage } from '../world/digital-human-motion.js'
+import { resolveEmployeeVoiceProfile } from './employee-voice-profile.js'
+
+/**
+ * Says something in a character's own voice.
+ *
+ * Lifted out of the per-message play button so the composer can speak replies
+ * too. The engine ladder is the point and is why this is worth sharing: a
+ * system voice if one was chosen, then the local natural engine, then the fast
+ * one — each falling through to the next rather than failing, because a
+ * character that says nothing is indistinguishable from a broken one.
+ */
+
+export interface SpeakAsCharacterInput {
+  employeeId: string
+  text: string
+  profile?: EmployeeProfile
+  onStart?(): void
+  onEnd?(): void
+}
+
+export function stopCharacterSpeech(): void {
+  stopKokoroSpeech()
+  if (typeof window !== 'undefined') window.speechSynthesis?.cancel()
+}
+
+export async function speakAsCharacter(input: SpeakAsCharacterInput): Promise<void> {
+  const spokenText = speechTextFromMessage(input.text)
+  if (spokenText.length === 0) throw new Error('这条回复没有可播报的文字')
+  const voice = resolveEmployeeVoiceProfile(input.employeeId, input.profile?.gender, input.profile?.voiceProfile)
+
+  let provider = voice.provider
+  if (provider === 'auto') {
+    try {
+      const catalog = await api<{ models: VoiceModelDescriptor[] }>('/api/local-tts/models')
+      provider = catalog.models.some((model) => model.provider === 'moss' && model.state === 'ready') ? 'moss' : 'kokoro'
+    } catch {
+      provider = 'kokoro'
+    }
+  }
+
+  if (voice.voiceId.startsWith('system:') && typeof window !== 'undefined' && 'speechSynthesis' in window) {
+    const voiceUri = voice.voiceId.slice('system:'.length)
+    const systemVoice = window.speechSynthesis.getVoices()
+      .find((item) => item.voiceURI === voiceUri && /^zh(?:-|_)/iu.test(item.lang))
+    if (systemVoice !== undefined) {
+      const utterance = new SpeechSynthesisUtterance(spokenText)
+      utterance.voice = systemVoice
+      utterance.lang = systemVoice.lang
+      utterance.rate = voice.speed
+      utterance.pitch = voice.pitch
+      await new Promise<void>((resolve) => {
+        utterance.onstart = () => input.onStart?.()
+        utterance.onend = () => { input.onEnd?.(); resolve() }
+        utterance.onerror = () => { input.onEnd?.(); resolve() }
+        window.speechSynthesis.cancel()
+        window.speechSynthesis.speak(utterance)
+      })
+      return
+    }
+  }
+
+  if (provider === 'moss') {
+    try {
+      await playMossSpeech({
+        text: spokenText,
+        voiceId: voice.voiceId.startsWith('moss:') ? voice.voiceId : 'moss:Junhao',
+        speed: voice.speed,
+        onStatus: () => undefined,
+        onStart: () => input.onStart?.(),
+        onEnd: () => input.onEnd?.(),
+      })
+      return
+    } catch {
+      // The natural engine is the nicer answer, not the only one.
+      provider = 'kokoro'
+    }
+  }
+
+  const localVoice = voice.voiceId.startsWith('kokoro:')
+    ? voice
+    : resolveEmployeeVoiceProfile(input.employeeId, input.profile?.gender, { ...voice, provider: 'kokoro', voiceId: '' })
+  await playKokoroSpeech({
+    text: spokenText,
+    voiceId: localVoice.voiceId,
+    speed: localVoice.speed,
+    onStatus: () => undefined,
+    onStart: () => input.onStart?.(),
+    onEnd: () => input.onEnd?.(),
+  })
+}

--- a/packages/web/src/features/voice/speak-as-character.ts
+++ b/packages/web/src/features/voice/speak-as-character.ts
@@ -1,4 +1,4 @@
-import type { EmployeeProfile, VoiceModelDescriptor } from '@dsh-cyber/contracts'
+import { normalizeMossVoiceId, type EmployeeProfile, type VoiceModelDescriptor } from '@dsh-cyber/contracts'
 
 import { api } from '../../api.js'
 import { playKokoroSpeech, playMossSpeech, stopKokoroSpeech } from '../world/avatar/speech/KokoroSpeechAdapter.js'
@@ -68,7 +68,7 @@ export async function speakAsCharacter(input: SpeakAsCharacterInput): Promise<vo
     try {
       await playMossSpeech({
         text: spokenText,
-        voiceId: voice.voiceId.startsWith('moss:') ? voice.voiceId : 'moss:Junhao',
+        voiceId: normalizeMossVoiceId(voice.voiceId),
         speed: voice.speed,
         onStatus: () => undefined,
         onStart: () => input.onStart?.(),

--- a/packages/web/src/features/voice/streaming-speech-bus.ts
+++ b/packages/web/src/features/voice/streaming-speech-bus.ts
@@ -1,8 +1,16 @@
+import type { SpeechInputSurface } from './SpeechCoordinator.js'
+
 export interface StreamingSpeechEvent {
   kind: 'start' | 'delta' | 'complete' | 'cancel'
   employeeId: string
   turnId: string
   content?: string
+  source?: 'voice'
+  surface?: SpeechInputSurface
+  clientTurnId?: string
+  worldId?: string
+  sessionId?: string
+  conversationKey?: string
 }
 
 const listeners = new Set<(event: StreamingSpeechEvent) => void>()

--- a/packages/web/src/features/world/WorldRuntimeDock.tsx
+++ b/packages/web/src/features/world/WorldRuntimeDock.tsx
@@ -53,7 +53,7 @@ interface WorldRuntimeDockProps {
   sessionKind?: WorkSession['kind']
   selectedEmployeeId?: string
   conversationEmployeeIds: string[]
-  latestUtterances: Array<{ messageId: string; employeeId: string; text: string }>
+  latestUtterances: Array<{ messageId: string; employeeId: string; text: string; clientTurnId?: string }>
   onSelectEmployee(employeeId: string): void
   onStartGroup(employeeIds: string[], session?: WorkSession): void
   onManageAvatar(employeeId: string): void

--- a/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
+++ b/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
@@ -1,6 +1,6 @@
 import { ArrowsClockwise, SpeakerHigh, SpeakerSlash } from '@phosphor-icons/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
-import type { EmployeeProfile, EmployeeVoiceProfile, VoiceModelDescriptor, World, WorldRuntimeEntityState } from '@dsh-cyber/contracts'
+import type { EmployeeProfile, EmployeeVoiceProfile, VoiceModelDescriptor, World, WorldRuntimeEntityState, VoiceModelVoice } from '@dsh-cyber/contracts'
 
 import { api } from '../../../../api.js'
 import type { CyberEmployee } from '../../../../types.js'
@@ -14,7 +14,7 @@ import { VoiceConversationControl } from '../../../voice/VoiceConversationContro
 import { VoiceModelPackPicker } from '../../../voice/VoiceModelPackPicker.js'
 import { StreamingSentenceChunker } from '../../../voice/StreamingSentenceChunker.js'
 import { subscribeStreamingSpeech } from '../../../voice/streaming-speech-bus.js'
-import { resolveEmployeeVoiceProfile } from '../../../voice/employee-voice-profile.js'
+import { MAX_VOICE_SPEED, MIN_VOICE_SPEED, normalizeVoiceSpeed, resolveEmployeeVoiceProfile } from '../../../voice/employee-voice-profile.js'
 import './employee-focus-mode.css'
 
 type VoiceMode = 'off' | 'manual' | 'auto'
@@ -67,6 +67,8 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
   const [voiceBusy, setVoiceBusy] = useState(false)
   const [voiceSettingsOpen, setVoiceSettingsOpen] = useState(false)
   const [mossReady, setMossReady] = useState(false)
+  const [mossVoices, setMossVoices] = useState<VoiceModelVoice[]>([])
+  const voiceSaveTimerRef = useRef<number | undefined>(undefined)
   const streamChunkerRef = useRef(new StreamingSentenceChunker())
   const streamTurnRef = useRef<string | undefined>(undefined)
   const streamChainRef = useRef<Promise<void>>(Promise.resolve())
@@ -95,8 +97,13 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
   const selectedKokoroVoice = KOKORO_CHINESE_VOICES.find((voice) => voice.id === voiceId)
   const selectedVoiceMissing = selectedKokoroVoice === undefined && selectedSystemVoice === undefined
   const activeVoiceProvider = configuredVoiceProvider === 'auto' ? (mossReady ? 'moss' : 'kokoro') : configuredVoiceProvider
+  const mossVoiceCount = mossVoices.length
   const updateVoiceModels = useCallback((models: VoiceModelDescriptor[]) => {
-    setMossReady(models.some((model) => model.provider === 'moss' && model.state === 'ready'))
+    const moss = models.find((model) => model.provider === 'moss')
+    setMossReady(moss?.state === 'ready')
+    // Whatever the installed pack ships. Hardcoding one option here made a
+    // multi-speaker model look like a single-voice one.
+    setMossVoices(moss?.voices ?? [])
   }, [])
 
   useEffect(() => { setRendererReady(false); setRendererNotice(undefined) }, [employee.id, employee.avatarProfile?.assetId, quality, rendererMode])
@@ -154,16 +161,40 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
     }
   }, [employee.id, profile])
 
+  /**
+   * Saves a voice change shortly after the user stops making them.
+   *
+   * It used to only park the change and wait for the settings panel to be
+   * collapsed through its own button — so choosing a voice and then switching
+   * character, or closing the panel any other way, silently threw the choice
+   * away. Debounced rather than immediate because dragging the speed slider
+   * would otherwise be one request per pixel.
+   */
   const scheduleVoiceProfile = useCallback((next: EmployeeVoiceProfile) => {
     pendingVoiceProfileRef.current = next
-  }, [])
+    if (voiceSaveTimerRef.current !== undefined) window.clearTimeout(voiceSaveTimerRef.current)
+    voiceSaveTimerRef.current = window.setTimeout(() => {
+      voiceSaveTimerRef.current = undefined
+      const pending = pendingVoiceProfileRef.current
+      if (pending === undefined) return
+      pendingVoiceProfileRef.current = undefined
+      void persistVoiceProfile(pending)
+    }, 600)
+  }, [persistVoiceProfile])
 
   const flushVoiceProfile = useCallback(() => {
+    if (voiceSaveTimerRef.current !== undefined) {
+      window.clearTimeout(voiceSaveTimerRef.current)
+      voiceSaveTimerRef.current = undefined
+    }
     const next = pendingVoiceProfileRef.current
     if (next === undefined) return
     pendingVoiceProfileRef.current = undefined
     void persistVoiceProfile(next)
   }, [persistVoiceProfile])
+
+  // Leaving the character, or the panel, must not be a way to lose a choice.
+  useEffect(() => flushVoiceProfile, [flushVoiceProfile, employee.id])
 
   const stopSpeech = useCallback(() => {
     stopKokoroSpeech()
@@ -331,11 +362,11 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
       <div className="employee-focus__header-actions">
         <span className={`employee-focus__status is-${state}`}><i aria-hidden="true" />{stateLabel(state)}</span>
         <div className="employee-focus__voice"><button type="button" className="employee-focus__voice-trigger" aria-label="语音设置" aria-expanded={voiceSettingsOpen} onClick={() => { setVoiceSettingsOpen((current) => { const next = !current; if (!next) flushVoiceProfile(); return next }) }}>{speaking ? <SpeakerSlash size={17} aria-hidden="true" /> : <SpeakerHigh size={17} aria-hidden="true" />}语音</button>{voiceSettingsOpen ? <div>
-          <header><span><strong>{employee.displayName}的语音</strong><small>{activeVoiceProvider === 'moss' ? '自然语音 · 本地运行' : `${KOKORO_CHINESE_VOICES.length} 个中文声音${chineseSystemVoices.length > 0 ? ` · ${chineseSystemVoices.length} 个系统中文声音` : ''}`}</small></span><button type="button" aria-label="刷新系统声音" onClick={refreshVoices}><ArrowsClockwise size={16} aria-hidden="true" /></button></header>
+          <header><span><strong>{employee.displayName}的语音</strong><small>{activeVoiceProvider === 'moss' ? `自然语音 · 本地运行${mossVoiceCount > 0 ? ` · ${mossVoiceCount} 个声音` : ''}` : `${KOKORO_CHINESE_VOICES.length} 个中文声音${chineseSystemVoices.length > 0 ? ` · ${chineseSystemVoices.length} 个系统中文声音` : ''}`}</small></span><button type="button" aria-label="刷新系统声音" onClick={refreshVoices}><ArrowsClockwise size={16} aria-hidden="true" /></button></header>
           <VoiceModelPackPicker value={configuredVoiceProvider} onActivate={activateVoiceProvider} onModelsChange={updateVoiceModels} />
           <label><span>播报模式</span><select aria-label="播报模式" value={voiceMode} onChange={(event) => changeVoiceMode(event.target.value as VoiceMode)}><option value="off">关闭</option><option value="manual">手动</option><option value="auto">自动播报新回复</option></select></label>
-          {activeVoiceProvider === 'moss' ? <label><span>角色声音</span><select aria-label="角色声音" value={voiceId.startsWith('moss:') ? voiceId : 'moss:Junhao'} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); scheduleVoiceProfile({ provider: 'moss', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}><option value="moss:Junhao">君豪 · 自然男声</option></select></label> : <label><span>角色声音</span><select aria-label="角色声音" value={voiceId} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); setVoiceNotice(undefined); scheduleVoiceProfile({ provider: nextVoiceId.startsWith('system:') ? 'system' : 'kokoro', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{selectedVoiceMissing ? <option value={voiceId}>原声音当前不可用</option> : null}{profile?.gender === 'male' ? null : <optgroup label="中文女声">{compatibleKokoroVoices.filter((voice) => voice.gender === '女声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{profile?.gender === 'female' ? null : <optgroup label="中文男声">{compatibleKokoroVoices.filter((voice) => voice.gender === '男声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{chineseSystemVoices.length === 0 ? null : <optgroup label="Windows / 浏览器中文声音">{chineseSystemVoices.map((voice) => <option key={`${voice.voiceURI}:${voice.lang}`} value={`system:${voice.voiceURI}`}>{voice.name} · {voice.lang}{voice.localService ? ' · 本机' : ''}</option>)}</optgroup>}</select></label>}
-          <label className="employee-focus__voice-speed"><span>语速 <output>{voiceSpeed.toFixed(2)}×</output></span><input aria-label="语速" type="range" min="0.8" max="1.3" step="0.05" value={voiceSpeed} onChange={(event) => { const speed = Number(event.target.value); setVoiceSpeed(speed); scheduleVoiceProfile({ provider: configuredVoiceProvider, voiceId, speed, pitch: profile?.voiceProfile.pitch ?? 1 }) }} /></label>
+          {activeVoiceProvider === 'moss' ? <label><span>角色声音</span><select aria-label="角色声音" value={mossVoices.some((voice) => voice.id === voiceId) ? voiceId : mossVoices[0]?.id ?? 'moss:Junhao'} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); scheduleVoiceProfile({ provider: 'moss', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{mossVoices.map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</select></label> : <label><span>角色声音</span><select aria-label="角色声音" value={voiceId} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); setVoiceNotice(undefined); scheduleVoiceProfile({ provider: nextVoiceId.startsWith('system:') ? 'system' : 'kokoro', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{selectedVoiceMissing ? <option value={voiceId}>原声音当前不可用</option> : null}{profile?.gender === 'male' ? null : <optgroup label="中文女声">{compatibleKokoroVoices.filter((voice) => voice.gender === '女声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{profile?.gender === 'female' ? null : <optgroup label="中文男声">{compatibleKokoroVoices.filter((voice) => voice.gender === '男声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{chineseSystemVoices.length === 0 ? null : <optgroup label="Windows / 浏览器中文声音">{chineseSystemVoices.map((voice) => <option key={`${voice.voiceURI}:${voice.lang}`} value={`system:${voice.voiceURI}`}>{voice.name} · {voice.lang}{voice.localService ? ' · 本机' : ''}</option>)}</optgroup>}</select></label>}
+          <label className="employee-focus__voice-speed"><span>语速 <output>{voiceSpeed.toFixed(2)}×</output></span><input aria-label="语速" type="range" min={MIN_VOICE_SPEED} max={MAX_VOICE_SPEED} step="0.05" value={voiceSpeed} onChange={(event) => { const speed = Number(event.target.value); setVoiceSpeed(speed); scheduleVoiceProfile({ provider: configuredVoiceProvider, voiceId, speed, pitch: profile?.voiceProfile.pitch ?? 1 }) }} /></label>
           <div className="employee-focus__voice-preview"><span><strong>当前播报</strong><small>{spokenText.length === 0 ? `当前会话里还没有 ${employee.displayName} 的最终回复` : `${employee.displayName}：${spokenText.slice(0, 72)}${spokenText.length > 72 ? '…' : ''}`}</small></span></div>
           <label className="employee-focus__motion"><input type="checkbox" checked={!staticMode} onChange={(event) => onStaticModeChange(!event.target.checked)} />启用角色动效</label>
           <div className="employee-focus__voice-buttons"><button type="button" disabled={voiceBusy} onClick={() => void speak(`你好，我是${employee.displayName}。这是当前声音的试听。`)}>{voiceBusy ? '正在准备…' : '试听声音'}</button><button type="button" disabled={!voiceBusy && !speaking && (spokenText.length === 0 || voiceMode === 'off')} onClick={voiceBusy || speaking ? stopSpeech : () => void speak(spokenText)}>{voiceBusy ? '取消生成' : speaking ? '停止播报' : `播放${employee.displayName}的回复`}</button></div>
@@ -377,8 +408,19 @@ function voiceModeKey(worldId: string, employeeId: string): string { return `dsh
 function voiceIdKey(worldId: string, employeeId: string): string { return `dsh-cyber-digital-voice-id:${worldId}:${employeeId}` }
 function voiceSpeedKey(worldId: string, employeeId: string): string { return `dsh-cyber-digital-voice-speed:${worldId}:${employeeId}` }
 function lastSpokenKey(worldId: string, employeeId: string): string { return `dsh-cyber-digital-last-spoken:${worldId}:${employeeId}` }
-function readVoiceMode(worldId: string, employeeId: string): VoiceMode { try { const value = localStorage.getItem(voiceModeKey(worldId, employeeId)) ?? localStorage.getItem(`dsh-cyber-digital-voice-mode:${worldId}`); return value === 'off' || value === 'auto' ? value : 'manual' } catch { return 'manual' } }
+/**
+ * Whether a character speaks its replies aloud.
+ *
+ * Defaults to speaking. Someone who has opened a character's panel and can
+ * press a microphone is having a conversation, and a conversation where the
+ * other side answers only when you press a second button is not one — the
+ * streaming subscription bails unless this is `auto`, so the old default made
+ * the whole voice path silent until the user found this setting.
+ */
+function readVoiceMode(worldId: string, employeeId: string): VoiceMode { try { const value = localStorage.getItem(voiceModeKey(worldId, employeeId)) ?? localStorage.getItem(`dsh-cyber-digital-voice-mode:${worldId}`); return value === 'off' || value === 'manual' ? value : 'auto' } catch { return 'auto' } }
 function readCachedVoiceId(worldId: string, employeeId: string, fallback: string): string { try { const saved = localStorage.getItem(voiceIdKey(worldId, employeeId)); return saved?.startsWith('system:') || saved?.startsWith('moss:') || KOKORO_CHINESE_VOICES.some((voice) => voice.id === saved) ? saved! : fallback } catch { return fallback } }
-function readCachedVoiceSpeed(worldId: string, employeeId: string, fallback: number): number { try { const value = Number(localStorage.getItem(voiceSpeedKey(worldId, employeeId))); return Number.isFinite(value) && value >= 0.8 && value <= 1.3 ? Math.round(value * 20) / 20 : fallback } catch { return fallback } }
+// The fourth copy of the 0.8–1.3 bound: a saved faster speed was read back and
+// silently discarded. Bounds are stated once, in normalizeVoiceSpeed.
+function readCachedVoiceSpeed(worldId: string, employeeId: string, fallback: number): number { try { const raw = localStorage.getItem(voiceSpeedKey(worldId, employeeId)); return raw === null ? fallback : normalizeVoiceSpeed(Number(raw)) } catch { return fallback } }
 function readLastSpoken(worldId: string, employeeId: string): string | undefined { try { return localStorage.getItem(lastSpokenKey(worldId, employeeId)) ?? undefined } catch { return undefined } }
 function persistLastSpoken(worldId: string, employeeId: string, messageId: string): void { try { localStorage.setItem(lastSpokenKey(worldId, employeeId), messageId) } catch { /* localStorage is optional */ } }

--- a/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
+++ b/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
@@ -1,6 +1,7 @@
 import { ArrowsClockwise, SpeakerHigh, SpeakerSlash } from '@phosphor-icons/react'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { EmployeeProfile, EmployeeVoiceProfile, VoiceModelDescriptor, World, WorldRuntimeEntityState, VoiceModelVoice } from '@dsh-cyber/contracts'
+import { normalizeMossVoiceId } from '@dsh-cyber/contracts'
 
 import { api } from '../../../../api.js'
 import type { CyberEmployee } from '../../../../types.js'
@@ -15,6 +16,7 @@ import { VoiceModelPackPicker } from '../../../voice/VoiceModelPackPicker.js'
 import { StreamingSentenceChunker } from '../../../voice/StreamingSentenceChunker.js'
 import { subscribeStreamingSpeech } from '../../../voice/streaming-speech-bus.js'
 import { MAX_VOICE_SPEED, MIN_VOICE_SPEED, normalizeVoiceSpeed, resolveEmployeeVoiceProfile } from '../../../voice/employee-voice-profile.js'
+import { claimSpeech, type SpeechClaim, type SpeechOwner } from '../../../voice/SpeechCoordinator.js'
 import './employee-focus-mode.css'
 
 type VoiceMode = 'off' | 'manual' | 'auto'
@@ -43,7 +45,7 @@ interface EmployeeFocusModeProps {
    * The panel keeps its name, status, chat and voice; only the stage goes.
    */
   embedded?: boolean
-  latestUtterance?: { messageId: string; employeeId: string; text: string }
+  latestUtterance?: { messageId: string; employeeId: string; text: string; clientTurnId?: string }
   onFocusEmployee(employeeId: string): void
   onManageAvatar(): void
   onStaticModeChange(value: boolean): void
@@ -76,6 +78,8 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
   const streamCompleteRef = useRef(false)
   const streamedSpeechRef = useRef(false)
   const streamGenerationRef = useRef(0)
+  const speechClaimRef = useRef<SpeechClaim | undefined>(undefined)
+  const manualSpeechSequenceRef = useRef(0)
   const pendingVoiceProfileRef = useRef<EmployeeVoiceProfile | undefined>(undefined)
   const speechSupported = typeof window !== 'undefined' && 'speechSynthesis' in window && 'SpeechSynthesisUtterance' in window
   const utterance = latestUtterance?.employeeId === employee.id ? latestUtterance : undefined
@@ -98,12 +102,21 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
   const selectedVoiceMissing = selectedKokoroVoice === undefined && selectedSystemVoice === undefined
   const activeVoiceProvider = configuredVoiceProvider === 'auto' ? (mossReady ? 'moss' : 'kokoro') : configuredVoiceProvider
   const mossVoiceCount = mossVoices.length
+  const mossVoiceOptions = mossVoices.length > 0 ? mossVoices : [{ id: 'moss:Junhao', label: '君豪 · 默认声音', gender: 'male' as const }]
+  const mossVoiceCatalogEmpty = mossVoices.length === 0
   const updateVoiceModels = useCallback((models: VoiceModelDescriptor[]) => {
     const moss = models.find((model) => model.provider === 'moss')
     setMossReady(moss?.state === 'ready')
-    // Whatever the installed pack ships. Hardcoding one option here made a
-    // multi-speaker model look like a single-voice one.
-    setMossVoices(moss?.voices ?? [])
+    // Whatever the installed pack ships, normalized once at the UI boundary.
+    // An empty descriptor is still a valid response while a provider is
+    // warming, so retain one actionable fallback instead of rendering a
+    // controlled select with no option.
+    const normalized = new Map<string, VoiceModelVoice>()
+    for (const voice of moss?.voices ?? []) {
+      const id = normalizeMossVoiceId(voice.id)
+      if (!normalized.has(id)) normalized.set(id, { ...voice, id })
+    }
+    setMossVoices(normalized.size > 0 ? [...normalized.values()] : (moss?.state === 'ready' ? [{ id: 'moss:Junhao', label: '君豪 · 自然男声', gender: 'male' }] : []))
   }, [])
 
   useEffect(() => { setRendererReady(false); setRendererNotice(undefined) }, [employee.id, employee.avatarProfile?.assetId, quality, rendererMode])
@@ -196,18 +209,43 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
   // Leaving the character, or the panel, must not be a way to lose a choice.
   useEffect(() => flushVoiceProfile, [flushVoiceProfile, employee.id])
 
+  const releaseSpeechClaim = useCallback((token?: string) => {
+    const claim = speechClaimRef.current
+    if (claim === undefined || (token !== undefined && claim.token !== token)) return
+    claim.release()
+    speechClaimRef.current = undefined
+  }, [])
+
   const stopSpeech = useCallback(() => {
+    releaseSpeechClaim()
     stopKokoroSpeech()
     if (speechSupported) window.speechSynthesis.cancel()
     utteranceRef.current = undefined
     setSpeaking(false)
     setVoiceBusy(false)
     setVoiceNotice(undefined)
-  }, [speechSupported])
+  }, [releaseSpeechClaim, speechSupported])
 
-  const speak = useCallback(async (text: string) => {
+  const speak = useCallback(async (text: string, claimInput?: { turnId: string; owner: SpeechOwner }) => {
     if (text.trim().length === 0) return
+    // Manual preview and a non-streaming fallback both supersede queued stream
+    // chunks. The next runtime `start` installs a fresh turn and generation.
+    streamGenerationRef.current += 1
+    streamChunkerRef.current.reset()
+    streamTurnRef.current = undefined
+    streamCompleteRef.current = true
     stopSpeech()
+    const claim = claimSpeech({
+      employeeId: employee.id,
+      turnId: claimInput?.turnId ?? `manual:${employee.id}:${++manualSpeechSequenceRef.current}`,
+      owner: claimInput?.owner ?? 'manual',
+    })
+    if (claim === undefined) return
+    speechClaimRef.current = claim
+    const releaseClaim = () => {
+      claim.release()
+      if (speechClaimRef.current?.token === claim.token) speechClaimRef.current = undefined
+    }
     if (activeVoiceProvider === 'moss' || voiceId.startsWith('kokoro:')) {
       setVoiceBusy(true)
       try {
@@ -218,19 +256,20 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
           speed: voiceSpeed,
           onStatus: setVoiceNotice,
           onStart: () => { setVoiceBusy(false); setSpeaking(true) },
-          onEnd: () => { setVoiceBusy(false); setSpeaking(false); setVoiceNotice(undefined) },
+          onEnd: () => { releaseClaim(); setVoiceBusy(false); setSpeaking(false); setVoiceNotice(undefined) },
         })
       } catch (cause) {
         setVoiceBusy(false)
         setSpeaking(false)
-        if (cause instanceof Error && cause.name === 'AbortError') { setVoiceNotice(undefined); return }
+        if (cause instanceof Error && cause.name === 'AbortError') { releaseClaim(); setVoiceNotice(undefined); return }
         if (activeVoiceProvider === 'moss') {
           const fallbackVoiceId = compatibleKokoroVoices[0]!.id
           setVoiceNotice('自然语音暂不可用，已切换快速语音')
           try {
-            await playKokoroSpeech({ text, voiceId: fallbackVoiceId, speed: voiceSpeed, onStatus: setVoiceNotice, onStart: () => setSpeaking(true), onEnd: () => { setSpeaking(false); setVoiceNotice(undefined) } })
+            await playKokoroSpeech({ text, voiceId: fallbackVoiceId, speed: voiceSpeed, onStatus: setVoiceNotice, onStart: () => setSpeaking(true), onEnd: () => { releaseClaim(); setSpeaking(false); setVoiceNotice(undefined) } })
             return
           } catch (fallbackError) {
+            releaseClaim()
             cause = fallbackError
           }
         }
@@ -246,11 +285,12 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
             ? `本地中文语音失败：${cause.message}`
             : '无法连接本地语音服务，请确认服务已启动。')
       }
+      releaseClaim()
       return
     }
-    if (!speechSupported) { setVoiceNotice('当前浏览器不支持系统语音，请选择本地 AI 中文声音。'); return }
+    if (!speechSupported) { releaseClaim(); setVoiceNotice('当前浏览器不支持系统语音，请选择本地 AI 中文声音。'); return }
     const exactVoice = resolveSpeechVoice(chineseSystemVoices, systemVoiceId)
-    if (exactVoice === undefined) { setVoiceNotice('所选系统中文声音当前不可用，请刷新或改用本地 AI 中文声音。'); return }
+    if (exactVoice === undefined) { releaseClaim(); setVoiceNotice('所选系统中文声音当前不可用，请刷新或改用本地 AI 中文声音。'); return }
     const value = new SpeechSynthesisUtterance(text)
     value.lang = exactVoice.lang
     value.rate = voiceSpeed
@@ -258,12 +298,17 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
     value.voice = exactVoice
     setVoiceNotice(undefined)
     value.onstart = () => setSpeaking(true)
-    value.onend = () => { utteranceRef.current = undefined; setSpeaking(false) }
-    value.onerror = () => { utteranceRef.current = undefined; setSpeaking(false); setVoiceNotice('系统语音播放失败，请刷新声音目录或更换声音。') }
+    value.onend = () => { releaseClaim(); utteranceRef.current = undefined; setSpeaking(false) }
+    value.onerror = () => { releaseClaim(); utteranceRef.current = undefined; setSpeaking(false); setVoiceNotice('系统语音播放失败，请刷新声音目录或更换声音。') }
     utteranceRef.current = value
     setSpeaking(true)
-    window.speechSynthesis.speak(value)
-  }, [activeVoiceProvider, chineseSystemVoices, compatibleKokoroVoices, speechSupported, stopSpeech, systemVoiceId, voiceId, voiceSpeed])
+    try { window.speechSynthesis.speak(value) } catch (cause) {
+      releaseClaim()
+      utteranceRef.current = undefined
+      setSpeaking(false)
+      setVoiceNotice(cause instanceof Error ? cause.message : '系统语音播放失败，请刷新声音目录或更换声音。')
+    }
+  }, [activeVoiceProvider, chineseSystemVoices, compatibleKokoroVoices, employee.id, speechSupported, stopSpeech, systemVoiceId, voiceId, voiceSpeed])
 
   const changeVoiceMode = useCallback((mode: VoiceMode) => {
     if (mode === 'off') stopSpeech()
@@ -282,14 +327,16 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
       if (systemVoice === undefined) { setVoiceNotice('当前系统没有可用的中文声音'); return }
       nextVoiceId = `system:${systemVoice.voiceURI}`
     }
-    if (provider === 'moss') nextVoiceId = 'moss:Junhao'
+    if (provider === 'moss') nextVoiceId = voiceId.startsWith('moss:') ? normalizeMossVoiceId(voiceId) : 'moss:Junhao'
     setVoiceId(nextVoiceId)
     void persistVoiceProfile({ provider, voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 })
   }, [chineseSystemVoices, compatibleKokoroVoices, persistVoiceProfile, profile?.voiceProfile.pitch, voiceId, voiceSpeed])
 
   const enqueueStreamChunk = useCallback((content: string) => {
     const text = speechTextFromMessage(content)
-    if (!text || (!voiceId.startsWith('kokoro:') && activeVoiceProvider !== 'moss')) return
+    const claim = speechClaimRef.current
+    const claimToken = claim?.owner === 'focus-stream' ? claim.token : undefined
+    if (!text || claimToken === undefined || (!voiceId.startsWith('kokoro:') && activeVoiceProvider !== 'moss')) return
     streamedSpeechRef.current = true
     streamPendingRef.current += 1
     const queueGeneration = streamGenerationRef.current
@@ -305,16 +352,20 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
       onStart: () => { setVoiceBusy(false); setSpeaking(true) },
       onEnd: () => {
         streamPendingRef.current = Math.max(0, streamPendingRef.current - 1)
-        if (streamCompleteRef.current && streamPendingRef.current === 0) { setSpeaking(false); setVoiceNotice(undefined) }
+        if (streamCompleteRef.current && streamPendingRef.current === 0) {
+          releaseSpeechClaim(claimToken)
+          setSpeaking(false); setVoiceNotice(undefined)
+        }
       },
       })
     }).catch((cause: unknown) => {
       streamPendingRef.current = Math.max(0, streamPendingRef.current - 1)
       setVoiceBusy(false)
+      if (streamCompleteRef.current && streamPendingRef.current === 0) releaseSpeechClaim(claimToken)
       if (!(cause instanceof DOMException && cause.name === 'AbortError')) setVoiceNotice(cause instanceof Error ? `本地流式语音失败：${cause.message}` : '本地流式语音失败')
     })
     streamChainRef.current = run
-  }, [activeVoiceProvider, voiceId, voiceSpeed])
+  }, [activeVoiceProvider, releaseSpeechClaim, voiceId, voiceSpeed])
 
   useEffect(() => {
     if (voiceMode !== 'auto' || (!voiceId.startsWith('kokoro:') && activeVoiceProvider !== 'moss')) return
@@ -322,6 +373,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
       if (event.employeeId !== employee.id) return
       if (event.kind === 'start') {
         streamGenerationRef.current += 1; stopSpeech(); streamChunkerRef.current.reset(); streamTurnRef.current = event.turnId
+        speechClaimRef.current = claimSpeech({ employeeId: employee.id, turnId: event.clientTurnId ?? event.turnId, owner: 'focus-stream' })
         streamChainRef.current = Promise.resolve(); streamPendingRef.current = 0; streamCompleteRef.current = false; streamedSpeechRef.current = false
         return
       }
@@ -331,7 +383,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
       } else if (event.kind === 'complete') {
         for (const chunk of streamChunkerRef.current.flush()) enqueueStreamChunk(chunk)
         streamCompleteRef.current = true
-        if (streamPendingRef.current === 0) setSpeaking(false)
+        if (streamPendingRef.current === 0) { releaseSpeechClaim(); setSpeaking(false) }
       } else if (event.kind === 'cancel') {
         streamGenerationRef.current += 1; streamChunkerRef.current.reset(); streamCompleteRef.current = true; stopSpeech()
       }
@@ -343,7 +395,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
     lastAutoSpokenRef.current = utterance.messageId
     persistLastSpoken(world.id, employee.id, utterance.messageId)
     if (streamedSpeechRef.current) return
-    void speak(spokenText)
+    void speak(spokenText, { turnId: utterance.clientTurnId ?? utterance.messageId, owner: 'focus-stream' })
   }, [employee.id, speak, spokenText, utterance, voiceMode, world.id])
   useEffect(() => () => {
     stopSpeech()
@@ -372,7 +424,7 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
           <header><span><strong>{employee.displayName}的语音</strong><small>{activeVoiceProvider === 'moss' ? `自然语音 · 本地运行${mossVoiceCount > 0 ? ` · ${mossVoiceCount} 个声音` : ''}` : `${KOKORO_CHINESE_VOICES.length} 个中文声音${chineseSystemVoices.length > 0 ? ` · ${chineseSystemVoices.length} 个系统中文声音` : ''}`}</small></span><button type="button" aria-label="刷新系统声音" onClick={refreshVoices}><ArrowsClockwise size={16} aria-hidden="true" /></button></header>
           <VoiceModelPackPicker value={configuredVoiceProvider} onActivate={activateVoiceProvider} onModelsChange={updateVoiceModels} />
           <label><span>播报模式</span><select aria-label="播报模式" value={voiceMode} onChange={(event) => changeVoiceMode(event.target.value as VoiceMode)}><option value="off">关闭</option><option value="manual">手动</option><option value="auto">自动播报新回复</option></select></label>
-          {activeVoiceProvider === 'moss' ? <label><span>角色声音</span><select aria-label="角色声音" value={mossVoices.some((voice) => voice.id === voiceId) ? voiceId : mossVoices[0]?.id ?? 'moss:Junhao'} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); scheduleVoiceProfile({ provider: 'moss', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{mossVoices.map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</select></label> : <label><span>角色声音</span><select aria-label="角色声音" value={voiceId} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); setVoiceNotice(undefined); scheduleVoiceProfile({ provider: nextVoiceId.startsWith('system:') ? 'system' : 'kokoro', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{selectedVoiceMissing ? <option value={voiceId}>原声音当前不可用</option> : null}{profile?.gender === 'male' ? null : <optgroup label="中文女声">{compatibleKokoroVoices.filter((voice) => voice.gender === '女声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{profile?.gender === 'female' ? null : <optgroup label="中文男声">{compatibleKokoroVoices.filter((voice) => voice.gender === '男声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{chineseSystemVoices.length === 0 ? null : <optgroup label="Windows / 浏览器中文声音">{chineseSystemVoices.map((voice) => <option key={`${voice.voiceURI}:${voice.lang}`} value={`system:${voice.voiceURI}`}>{voice.name} · {voice.lang}{voice.localService ? ' · 本机' : ''}</option>)}</optgroup>}</select></label>}
+          {activeVoiceProvider === 'moss' ? <><label><span>角色声音</span><select aria-label="角色声音" disabled={mossVoiceCatalogEmpty} value={mossVoiceOptions.some((voice) => voice.id === voiceId) ? voiceId : mossVoiceOptions[0]!.id} onChange={(event) => { const nextVoiceId = normalizeMossVoiceId(event.target.value); setVoiceId(nextVoiceId); scheduleVoiceProfile({ provider: 'moss', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{mossVoiceOptions.map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</select></label>{mossVoiceCatalogEmpty ? <small className="employee-focus__voice-notice" role="status">语音目录暂未返回可用声音，安装完成后请刷新。</small> : null}</> : <label><span>角色声音</span><select aria-label="角色声音" value={voiceId} onChange={(event) => { const nextVoiceId = event.target.value; setVoiceId(nextVoiceId); setVoiceNotice(undefined); scheduleVoiceProfile({ provider: nextVoiceId.startsWith('system:') ? 'system' : 'kokoro', voiceId: nextVoiceId, speed: voiceSpeed, pitch: profile?.voiceProfile.pitch ?? 1 }) }}>{selectedVoiceMissing ? <option value={voiceId}>原声音当前不可用</option> : null}{profile?.gender === 'male' ? null : <optgroup label="中文女声">{compatibleKokoroVoices.filter((voice) => voice.gender === '女声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{profile?.gender === 'female' ? null : <optgroup label="中文男声">{compatibleKokoroVoices.filter((voice) => voice.gender === '男声').map((voice) => <option key={voice.id} value={voice.id}>{voice.label}</option>)}</optgroup>}{chineseSystemVoices.length === 0 ? null : <optgroup label="Windows / 浏览器中文声音">{chineseSystemVoices.map((voice) => <option key={`${voice.voiceURI}:${voice.lang}`} value={`system:${voice.voiceURI}`}>{voice.name} · {voice.lang}{voice.localService ? ' · 本机' : ''}</option>)}</optgroup>}</select></label>}
           <label className="employee-focus__voice-speed"><span>语速 <output>{voiceSpeed.toFixed(2)}×</output></span><input aria-label="语速" type="range" min={MIN_VOICE_SPEED} max={MAX_VOICE_SPEED} step="0.05" value={voiceSpeed} onChange={(event) => { const speed = Number(event.target.value); setVoiceSpeed(speed); scheduleVoiceProfile({ provider: configuredVoiceProvider, voiceId, speed, pitch: profile?.voiceProfile.pitch ?? 1 }) }} /></label>
           <div className="employee-focus__voice-preview"><span><strong>当前播报</strong><small>{spokenText.length === 0 ? `当前会话里还没有 ${employee.displayName} 的最终回复` : `${employee.displayName}：${spokenText.slice(0, 72)}${spokenText.length > 72 ? '…' : ''}`}</small></span></div>
           <label className="employee-focus__motion"><input type="checkbox" checked={!staticMode} onChange={(event) => onStaticModeChange(!event.target.checked)} />启用角色动效</label>
@@ -425,7 +477,15 @@ function lastSpokenKey(worldId: string, employeeId: string): string { return `ds
  * the whole voice path silent until the user found this setting.
  */
 function readVoiceMode(worldId: string, employeeId: string): VoiceMode { try { const value = localStorage.getItem(voiceModeKey(worldId, employeeId)) ?? localStorage.getItem(`dsh-cyber-digital-voice-mode:${worldId}`); return value === 'off' || value === 'manual' ? value : 'auto' } catch { return 'auto' } }
-function readCachedVoiceId(worldId: string, employeeId: string, fallback: string): string { try { const saved = localStorage.getItem(voiceIdKey(worldId, employeeId)); return saved?.startsWith('system:') || saved?.startsWith('moss:') || KOKORO_CHINESE_VOICES.some((voice) => voice.id === saved) ? saved! : fallback } catch { return fallback } }
+function readCachedVoiceId(worldId: string, employeeId: string, fallback: string): string {
+  try {
+    const saved = localStorage.getItem(voiceIdKey(worldId, employeeId))
+    if (saved === null) return fallback
+    if (saved.startsWith('system:')) return saved
+    if (saved.startsWith('moss:')) return normalizeMossVoiceId(saved)
+    return KOKORO_CHINESE_VOICES.some((voice) => voice.id === saved) ? saved : fallback
+  } catch { return fallback }
+}
 // The fourth copy of the 0.8–1.3 bound: a saved faster speed was read back and
 // silently discarded. Bounds are stated once, in normalizeVoiceSpeed.
 function readCachedVoiceSpeed(worldId: string, employeeId: string, fallback: number): number { try { const raw = localStorage.getItem(voiceSpeedKey(worldId, employeeId)); return raw === null ? fallback : normalizeVoiceSpeed(Number(raw)) } catch { return fallback } }

--- a/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
+++ b/packages/web/src/features/world/avatar/focus/EmployeeFocusMode.tsx
@@ -234,10 +234,17 @@ export function EmployeeFocusMode({ world, employee, profile, entity, collaborat
             cause = fallbackError
           }
         }
-        console.error('Local Kokoro speech failed', cause)
-        setVoiceNotice(cause instanceof Error && !/fetch|network/iu.test(cause.message)
-          ? `本地中文语音失败：${cause.message}`
-          : '无法连接本地语音服务，请确认服务已启动。')
+        // A voice pack that is not installed is a configuration the user has
+        // not finished, not a fault: now that replies are spoken by default,
+        // logging it would put an error in the console for every reply on
+        // every machine without one. The panel says what to do instead.
+        const missing = cause instanceof Error && /未安装|没有生成可播放音频|not_installed/iu.test(cause.message)
+        if (!missing) console.error('Local Kokoro speech failed', cause)
+        setVoiceNotice(missing
+          ? '还没有可用的本地语音包，先在上面的语音引擎里安装一个。'
+          : cause instanceof Error && !/fetch|network/iu.test(cause.message)
+            ? `本地中文语音失败：${cause.message}`
+            : '无法连接本地语音服务，请确认服务已启动。')
       }
       return
     }

--- a/packages/web/src/features/world/avatar/focus/employee-focus-mode.css
+++ b/packages/web/src/features/world/avatar/focus/employee-focus-mode.css
@@ -60,3 +60,5 @@
 .employee-focus__avatar-invite { position: absolute; z-index: 9; top: 116px; left: 12px; display: inline-flex; align-items: center; gap: 10px; padding: 6px 10px; border: 1px dashed color-mix(in srgb, var(--accent) 52%, var(--border)); border-radius: var(--radius-control); color: var(--text-muted); background: color-mix(in srgb, var(--surface-0) 88%, transparent); font-size: 12px; }
 .employee-focus__avatar-invite button { min-height: 26px; padding: 0 10px; border: 0; border-radius: var(--radius-control); color: var(--accent-strong); background: var(--accent-soft); font: inherit; font-size: 12px; cursor: pointer; }
 .employee-focus__avatar-invite button:focus-visible { outline: 2px solid var(--accent); outline-offset: 1px; }
+.voice-model-picker__failure { display: grid; gap: 6px; }
+.voice-model-picker__failure small { color: var(--danger, #d9534f); font-size: 12px; line-height: 1.5; overflow-wrap: anywhere; }

--- a/packages/web/src/features/world/avatar/speech/KokoroSpeechAdapter.ts
+++ b/packages/web/src/features/world/avatar/speech/KokoroSpeechAdapter.ts
@@ -12,6 +12,9 @@ const FEMALE_VOICE_STYLES = ['清澈知性', '温柔叙事', '明亮活力', '�
 const MALE_VOICE_STYLES = ['沉稳低音', '温和讲述', '清朗青年', '理性专业', '成熟磁性', '干练播报', '亲切自然', '冷静克制', '温暖陪伴'] as const
 const VOICE_TONES = ['自然', '轻柔', '清亮', '沉稳', '灵动'] as const
 
+// Bounds live with the voice profile, not with each player.
+import { normalizeVoiceSpeed } from '../../../voice/employee-voice-profile.js'
+
 export const KOKORO_CHINESE_VOICES: readonly KokoroVoiceOption[] = [
   ...Array.from({ length: 55 }, (_, index): KokoroVoiceOption => ({
     id: `kokoro:${index + 3}`,
@@ -186,8 +189,15 @@ export function splitKokoroSpeechText(value: string, maximumLength = 120): strin
   return chunks
 }
 
+/**
+ * The one clamp for playback speed.
+ *
+ * There were four of these at 1.3, in four files, so raising the slider alone
+ * would have left the request rejected or the audio unchanged. They now agree
+ * with `normalizeVoiceSpeed`, which is where the bounds are stated.
+ */
 function normalizeSpeed(value: number | undefined): number {
-  return Math.max(0.8, Math.min(1.3, value ?? 1.1))
+  return normalizeVoiceSpeed(value)
 }
 
 export function stopKokoroSpeech(): void {

--- a/packages/web/src/features/world/avatar/speech/KokoroSpeechAdapter.ts
+++ b/packages/web/src/features/world/avatar/speech/KokoroSpeechAdapter.ts
@@ -1,4 +1,5 @@
 import { readPcmFrames } from '../../../voice/PcmFrameStream.js'
+import { normalizeMossVoiceId } from '@dsh-cyber/contracts'
 import { setSpeechAmplitude } from './speech-playback-state.js'
 
 export interface KokoroVoiceOption {
@@ -75,7 +76,7 @@ export async function playMossSpeech(input: {
     await appendKokoroSpeech({
       ...input,
       text: chunks[index]!,
-      voiceId: input.voiceId ?? 'moss:Junhao',
+      voiceId: normalizeMossVoiceId(input.voiceId ?? 'moss:Junhao'),
       provider: 'moss',
       onEnd: index === chunks.length - 1 ? input.onEnd : () => undefined,
     })
@@ -106,7 +107,7 @@ export async function appendKokoroSpeech(input: {
     const response = await fetch('/api/local-tts/stream', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text: input.text, speakerId: option?.speakerId ?? 58, speed: normalizeSpeed(input.speed), provider, voiceId: input.voiceId }),
+      body: JSON.stringify({ text: input.text, speakerId: option?.speakerId ?? 58, speed: normalizeSpeed(input.speed), provider, voiceId: provider === 'moss' ? normalizeMossVoiceId(input.voiceId) : input.voiceId }),
       signal: controller.signal,
     })
     if (!response.ok) {

--- a/packages/web/tests/barge-in-threshold.test.ts
+++ b/packages/web/tests/barge-in-threshold.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  BARGE_IN_HYSTERESIS,
+  MAX_BARGE_IN_RMS,
+  MIN_BARGE_IN_RMS,
+  calculateBargeInThreshold,
+  isBargeInFrame,
+  pcmRms,
+  updateEchoBaseline,
+} from '../src/features/voice/barge-in-threshold.js'
+
+function frame(value: number, length = 128): ArrayBuffer {
+  const samples = new Int16Array(length)
+  samples.fill(Math.round(value * 32_768))
+  return samples.buffer
+}
+
+describe('barge-in threshold', () => {
+  it('lets the recogniser handle frames when nothing is playing', () => {
+    expect(isBargeInFrame(frame(0), undefined)).toBe(true)
+    expect(isBargeInFrame(frame(0.01), 0)).toBe(true)
+  })
+
+  it('rejects quiet speaker echo but accepts a clear interruption', () => {
+    const quiet = calculateBargeInThreshold(0.1, 0.03)
+    expect(isBargeInFrame(frame(quiet * 0.8), 0.1, 0.03, quiet)).toBe(false)
+    expect(isBargeInFrame(frame(quiet + BARGE_IN_HYSTERESIS + 0.02), 0.1, 0.03, quiet)).toBe(true)
+  })
+
+  it('keeps the gate reachable with loud playback', () => {
+    const threshold = calculateBargeInThreshold(1, 0.4)
+    expect(threshold).toBe(MAX_BARGE_IN_RMS)
+    expect(threshold).toBeLessThanOrEqual(1)
+    expect(isBargeInFrame(frame(0.99), 1, 0.4, threshold)).toBe(true)
+  })
+
+  it('uses bounded echo baseline and threshold hysteresis', () => {
+    expect(updateEchoBaseline(0, 0.2, undefined)).toBe(0)
+    expect(updateEchoBaseline(0.2, 2, 0.2)).toBeCloseTo(0.2, 6)
+    const threshold = calculateBargeInThreshold(0.2, 0.1)
+    expect(threshold).toBeGreaterThanOrEqual(MIN_BARGE_IN_RMS)
+    expect(threshold).toBeLessThanOrEqual(MAX_BARGE_IN_RMS)
+    expect(calculateBargeInThreshold(0.2, 0.101, threshold)).toBe(threshold)
+  })
+
+  it('calculates normalized PCM RMS without throwing on odd byte lengths', () => {
+    expect(pcmRms(frame(0.25))).toBeCloseTo(0.25, 3)
+    expect(pcmRms(new Uint8Array([0]).buffer)).toBe(0)
+  })
+})

--- a/packages/web/tests/composer-reply-speaker.test.ts
+++ b/packages/web/tests/composer-reply-speaker.test.ts
@@ -1,0 +1,109 @@
+import { act } from 'react'
+import { createElement } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ComposerReplySpeaker } from '../src/features/voice/ComposerReplySpeaker.js'
+import { publishStreamingSpeech } from '../src/features/voice/streaming-speech-bus.js'
+
+const spoken: Array<{ employeeId: string; text: string }> = []
+const stopped = vi.fn()
+
+vi.mock('../src/features/voice/speak-as-character.js', () => ({
+  speakAsCharacter: async (input: { employeeId: string; text: string }) => { spoken.push(input) },
+  stopCharacterSpeech: () => stopped(),
+}))
+
+let host: HTMLElement
+let root: ReturnType<typeof createRoot>
+
+async function mount(employeeId: string | undefined, enabled: boolean) {
+  await act(async () => {
+    root.render(createElement(ComposerReplySpeaker, { employeeId, dossiers: {}, enabled }))
+  })
+}
+
+async function reply(employeeId: string, turnId: string, chunks: string[]) {
+  await act(async () => {
+    publishStreamingSpeech({ kind: 'start', employeeId, turnId })
+    for (const content of chunks) publishStreamingSpeech({ kind: 'delta', employeeId, turnId, content })
+    publishStreamingSpeech({ kind: 'complete', employeeId, turnId })
+    await Promise.resolve()
+  })
+}
+
+beforeEach(() => {
+  spoken.length = 0
+  stopped.mockClear()
+  host = document.createElement('div')
+  document.body.append(host)
+  root = createRoot(host)
+})
+
+afterEach(async () => {
+  await act(async () => root.unmount())
+  host.remove()
+})
+
+describe('ComposerReplySpeaker', () => {
+  it('speaks a reply once the user has spoken', async () => {
+    // The composer has a microphone but nothing there subscribed to the
+    // speech bus, so a character answered a spoken question in silence.
+    await mount('employee-1', true)
+    await reply('employee-1', 'turn-1', ['你好，', '我在。'])
+    expect(spoken).toEqual([{ employeeId: 'employee-1', text: '你好，我在。' }])
+  })
+
+  it('stays quiet for somebody who is typing', async () => {
+    await mount('employee-1', false)
+    await reply('employee-1', 'turn-1', ['你好'])
+    expect(spoken).toEqual([])
+  })
+
+  it('ignores replies from other characters', async () => {
+    await mount('employee-1', true)
+    await reply('employee-2', 'turn-1', ['不是我'])
+    expect(spoken).toEqual([])
+  })
+
+  it('reads a reply once, however many times the turn completes', async () => {
+    // A reconnect can replay a completion, and hearing the same answer twice
+    // is worse than not hearing it.
+    await mount('employee-1', true)
+    await reply('employee-1', 'turn-1', ['只说一次'])
+    await act(async () => { publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-1' }) })
+    expect(spoken).toHaveLength(1)
+  })
+
+  it('says nothing for an empty reply', async () => {
+    await mount('employee-1', true)
+    await reply('employee-1', 'turn-1', ['   '])
+    expect(spoken).toEqual([])
+  })
+
+  it('stops the previous reply when a new one begins', async () => {
+    await mount('employee-1', true)
+    await reply('employee-1', 'turn-1', ['第一条'])
+    stopped.mockClear()
+    await act(async () => { publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'turn-2' }) })
+    expect(stopped).toHaveBeenCalled()
+  })
+
+  it('drops a cancelled reply instead of reading it', async () => {
+    await mount('employee-1', true)
+    await act(async () => {
+      publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'turn-1' })
+      publishStreamingSpeech({ kind: 'delta', employeeId: 'employee-1', turnId: 'turn-1', content: '半句' })
+      publishStreamingSpeech({ kind: 'cancel', employeeId: 'employee-1', turnId: 'turn-1' })
+      publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-1' })
+      await Promise.resolve()
+    })
+    expect(spoken).toEqual([])
+  })
+
+  it('does nothing when the conversation has no single character', async () => {
+    await mount(undefined, true)
+    await reply('employee-1', 'turn-1', ['群聊不播报'])
+    expect(spoken).toEqual([])
+  })
+})

--- a/packages/web/tests/composer-reply-speaker.test.ts
+++ b/packages/web/tests/composer-reply-speaker.test.ts
@@ -4,37 +4,50 @@ import { createRoot } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ComposerReplySpeaker } from '../src/features/voice/ComposerReplySpeaker.js'
+import { claimSpeech, resetSpeechCoordinatorForTest } from '../src/features/voice/SpeechCoordinator.js'
 import { publishStreamingSpeech } from '../src/features/voice/streaming-speech-bus.js'
 
 const spoken: Array<{ employeeId: string; text: string }> = []
 const stopped = vi.fn()
+let pendingSpeak: Promise<void> | undefined
 
 vi.mock('../src/features/voice/speak-as-character.js', () => ({
-  speakAsCharacter: async (input: { employeeId: string; text: string }) => { spoken.push(input) },
+  speakAsCharacter: async (input: { employeeId: string; text: string }) => { spoken.push(input); await pendingSpeak },
   stopCharacterSpeech: () => stopped(),
 }))
 
 let host: HTMLElement
 let root: ReturnType<typeof createRoot>
 
-async function mount(employeeId: string | undefined, enabled: boolean) {
+async function mount(employeeId: string | undefined, sessionId?: string, conversationKey?: string) {
   await act(async () => {
-    root.render(createElement(ComposerReplySpeaker, { employeeId, dossiers: {}, enabled }))
+    root.render(createElement(ComposerReplySpeaker, { employeeId, sessionId, conversationKey, dossiers: {} }))
   })
 }
 
-async function reply(employeeId: string, turnId: string, chunks: string[]) {
+async function reply(employeeId: string, turnId: string, chunks: string[], extra: { sessionId?: string; conversationKey?: string } = {}) {
+  await act(async () => {
+    const context = { source: 'voice' as const, surface: 'composer' as const, clientTurnId: turnId, ...extra }
+    publishStreamingSpeech({ kind: 'start', employeeId, turnId, ...context })
+    for (const content of chunks) publishStreamingSpeech({ kind: 'delta', employeeId, turnId, content, ...context })
+    publishStreamingSpeech({ kind: 'complete', employeeId, turnId, ...context })
+    await Promise.resolve()
+  })
+}
+
+async function typedReply(employeeId: string, turnId: string, content: string) {
   await act(async () => {
     publishStreamingSpeech({ kind: 'start', employeeId, turnId })
-    for (const content of chunks) publishStreamingSpeech({ kind: 'delta', employeeId, turnId, content })
+    publishStreamingSpeech({ kind: 'delta', employeeId, turnId, content })
     publishStreamingSpeech({ kind: 'complete', employeeId, turnId })
-    await Promise.resolve()
   })
 }
 
 beforeEach(() => {
   spoken.length = 0
   stopped.mockClear()
+  pendingSpeak = undefined
+  resetSpeechCoordinatorForTest()
   host = document.createElement('div')
   document.body.append(host)
   root = createRoot(host)
@@ -49,19 +62,19 @@ describe('ComposerReplySpeaker', () => {
   it('speaks a reply once the user has spoken', async () => {
     // The composer has a microphone but nothing there subscribed to the
     // speech bus, so a character answered a spoken question in silence.
-    await mount('employee-1', true)
+    await mount('employee-1')
     await reply('employee-1', 'turn-1', ['你好，', '我在。'])
     expect(spoken).toEqual([{ employeeId: 'employee-1', text: '你好，我在。' }])
   })
 
   it('stays quiet for somebody who is typing', async () => {
-    await mount('employee-1', false)
-    await reply('employee-1', 'turn-1', ['你好'])
+    await mount('employee-1')
+    await typedReply('employee-1', 'turn-1', '你好')
     expect(spoken).toEqual([])
   })
 
   it('ignores replies from other characters', async () => {
-    await mount('employee-1', true)
+    await mount('employee-1')
     await reply('employee-2', 'turn-1', ['不是我'])
     expect(spoken).toEqual([])
   })
@@ -69,41 +82,94 @@ describe('ComposerReplySpeaker', () => {
   it('reads a reply once, however many times the turn completes', async () => {
     // A reconnect can replay a completion, and hearing the same answer twice
     // is worse than not hearing it.
-    await mount('employee-1', true)
+    await mount('employee-1')
     await reply('employee-1', 'turn-1', ['只说一次'])
-    await act(async () => { publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-1' }) })
+    await act(async () => { publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-1', source: 'voice', surface: 'composer', clientTurnId: 'turn-1' }) })
     expect(spoken).toHaveLength(1)
   })
 
   it('says nothing for an empty reply', async () => {
-    await mount('employee-1', true)
+    await mount('employee-1')
     await reply('employee-1', 'turn-1', ['   '])
     expect(spoken).toEqual([])
   })
 
   it('stops the previous reply when a new one begins', async () => {
-    await mount('employee-1', true)
+    await mount('employee-1')
+    let release!: () => void
+    pendingSpeak = new Promise<void>((resolve) => { release = resolve })
     await reply('employee-1', 'turn-1', ['第一条'])
     stopped.mockClear()
-    await act(async () => { publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'turn-2' }) })
+    await act(async () => { publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'turn-2', source: 'voice', surface: 'composer', clientTurnId: 'turn-2' }) })
     expect(stopped).toHaveBeenCalled()
+    release()
+    await act(async () => { await Promise.resolve() })
   })
 
   it('drops a cancelled reply instead of reading it', async () => {
-    await mount('employee-1', true)
+    await mount('employee-1')
     await act(async () => {
-      publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'turn-1' })
-      publishStreamingSpeech({ kind: 'delta', employeeId: 'employee-1', turnId: 'turn-1', content: '半句' })
-      publishStreamingSpeech({ kind: 'cancel', employeeId: 'employee-1', turnId: 'turn-1' })
-      publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-1' })
+      const context = { source: 'voice' as const, surface: 'composer' as const, clientTurnId: 'turn-1' }
+      publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'turn-1', ...context })
+      publishStreamingSpeech({ kind: 'delta', employeeId: 'employee-1', turnId: 'turn-1', content: '半句', ...context })
+      publishStreamingSpeech({ kind: 'cancel', employeeId: 'employee-1', turnId: 'turn-1', ...context })
+      publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-1', ...context })
       await Promise.resolve()
     })
     expect(spoken).toEqual([])
   })
 
   it('does nothing when the conversation has no single character', async () => {
-    await mount(undefined, true)
+    await mount(undefined)
     await reply('employee-1', 'turn-1', ['群聊不播报'])
     expect(spoken).toEqual([])
+  })
+
+  it('stays quiet after a voice turn when the next turn is typed', async () => {
+    await mount('employee-1')
+    await reply('employee-1', 'voice-turn', ['语音回复'])
+    await act(async () => {
+      publishStreamingSpeech({ kind: 'start', employeeId: 'employee-1', turnId: 'typed-turn' })
+      publishStreamingSpeech({ kind: 'delta', employeeId: 'employee-1', turnId: 'typed-turn', content: '键盘回复' })
+      publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'typed-turn' })
+    })
+    expect(spoken).toEqual([{ employeeId: 'employee-1', text: '语音回复' }])
+  })
+
+  it('does not compete with a focused streaming owner for the same turn', async () => {
+    await mount('employee-1')
+    const focusClaim = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-1', owner: 'focus-stream' })
+    expect(focusClaim).toBeDefined()
+    await reply('employee-1', 'turn-1', ['焦点正在播报'])
+    expect(spoken).toEqual([])
+    focusClaim?.release()
+  })
+
+  it('ignores a late reply after the conversation changes', async () => {
+    await mount('employee-1', 'session-1', 'direct:employee-1')
+    await mount('employee-1', 'session-2', 'direct:employee-1')
+    await reply('employee-1', 'turn-old', ['旧会话'], { sessionId: 'session-1', conversationKey: 'direct:employee-1' })
+    expect(spoken).toEqual([])
+  })
+
+  it('releases owned playback when the focused employee changes', async () => {
+    await mount('employee-1')
+    let release!: () => void
+    pendingSpeak = new Promise<void>((resolve) => { release = resolve })
+    await reply('employee-1', 'turn-active', ['正在播放'])
+    stopped.mockClear()
+    await mount('employee-2')
+    expect(stopped).toHaveBeenCalled()
+    release()
+    await act(async () => { await Promise.resolve() })
+  })
+
+  it('can speak a final-only event when no text deltas were emitted', async () => {
+    await mount('employee-1')
+    await act(async () => {
+      publishStreamingSpeech({ kind: 'complete', employeeId: 'employee-1', turnId: 'turn-final', clientTurnId: 'turn-final', source: 'voice', surface: 'composer', content: '只有最终消息' })
+      await Promise.resolve()
+    })
+    expect(spoken).toEqual([{ employeeId: 'employee-1', text: '只有最终消息' }])
   })
 })

--- a/packages/web/tests/speech-coordinator.test.ts
+++ b/packages/web/tests/speech-coordinator.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  activeSpeechOwner,
+  claimSpeech,
+  forgetVoiceTurn,
+  registerVoiceTurn,
+  releaseSpeechForEmployee,
+  resetSpeechCoordinatorForTest,
+  speechContextForTurn,
+} from '../src/features/voice/SpeechCoordinator.js'
+
+afterEach(() => resetSpeechCoordinatorForTest())
+
+describe('SpeechCoordinator', () => {
+  it('keeps one owner per employee and turn and gives Focus priority', () => {
+    const composer = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-1', owner: 'composer-fallback' })
+    expect(composer).toBeDefined()
+    expect(activeSpeechOwner('employee-1', 'turn-1')).toBe('composer-fallback')
+
+    let replaced = 0
+    const focus = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-1', owner: 'focus-stream', onReplaced: () => { replaced += 1 } })
+    expect(focus).toBeDefined()
+    expect(activeSpeechOwner('employee-1', 'turn-1')).toBe('focus-stream')
+    expect(composer?.isActive()).toBe(false)
+    expect(replaced).toBe(0)
+
+    expect(claimSpeech({ employeeId: 'employee-1', turnId: 'turn-1', owner: 'manual' })).toBeUndefined()
+    focus?.release()
+    expect(activeSpeechOwner('employee-1', 'turn-1')).toBeUndefined()
+  })
+
+  it('fires replacement cleanup when a higher-priority claim takes over', () => {
+    let stopped = 0
+    const manual = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-2', owner: 'manual', onReplaced: () => { stopped += 1 } })
+    expect(manual?.isActive()).toBe(true)
+    const focus = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-2', owner: 'focus-stream' })
+    expect(focus).toBeDefined()
+    expect(stopped).toBe(1)
+    expect(manual?.isActive()).toBe(false)
+  })
+
+  it('releases all claims when an employee leaves the focused surface', () => {
+    const first = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-1', owner: 'focus-stream' })
+    const second = claimSpeech({ employeeId: 'employee-1', turnId: 'turn-2', owner: 'composer-fallback' })
+    const other = claimSpeech({ employeeId: 'employee-2', turnId: 'turn-1', owner: 'focus-stream' })
+    releaseSpeechForEmployee('employee-1')
+    expect(first?.isActive()).toBe(false)
+    expect(second?.isActive()).toBe(false)
+    expect(other?.isActive()).toBe(true)
+  })
+
+  it('records voice origin and removes it at turn termination', () => {
+    registerVoiceTurn({ clientTurnId: 'client-1', worldId: 'world-1', conversationKey: 'direct:employee-1', surface: 'composer' })
+    expect(speechContextForTurn('client-1')).toEqual({
+      source: 'voice',
+      surface: 'composer',
+      clientTurnId: 'client-1',
+      worldId: 'world-1',
+      conversationKey: 'direct:employee-1',
+    })
+    forgetVoiceTurn('client-1')
+    expect(speechContextForTurn('client-1')).toBeUndefined()
+  })
+})

--- a/packages/web/tests/voice-model-pack-picker.test.ts
+++ b/packages/web/tests/voice-model-pack-picker.test.ts
@@ -23,9 +23,19 @@ describe('VoiceModelPackPicker', () => {
 
     expect(host.querySelector('select')?.value).toBe('moss-tts-nano-100m-onnx')
     expect(host.textContent).toContain('下载并安装')
+    // Every engine says what it is. Marking only the working ones left a pack
+    // that needs downloading, and one that cannot run here at all, looking
+    // exactly like one that speaks — so choosing it and getting silence was
+    // the only way to find out.
+    expect(host.textContent).toContain('需要下载')
+    expect(host.textContent).toContain('本机暂不支持')
+
     const select = host.querySelector('select')!
     await act(async () => { select.value = 'dots-tts-soar-2b'; select.dispatchEvent(new Event('change', { bubbles: true })) })
-    expect(host.textContent).toContain('高级模型')
+    // "高级模型" read as a premium tier. The truth is narrower and more useful:
+    // this one cannot run on this machine in this version.
+    expect(host.textContent).toContain('本机暂不支持')
+    expect(host.textContent).toContain('还不能在本机启用')
     expect(host.textContent).toContain('高显存 GPU')
     expect(host.textContent).not.toContain('下载并安装')
     await act(async () => root.unmount())

--- a/packages/web/tests/voice-speed-and-voices.test.ts
+++ b/packages/web/tests/voice-speed-and-voices.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  DEFAULT_VOICE_SPEED,
+  MAX_VOICE_SPEED,
+  MIN_VOICE_SPEED,
+  normalizeVoiceSpeed,
+} from '../src/features/voice/employee-voice-profile.js'
+
+describe('voice speed', () => {
+  it('reaches a speed worth having', () => {
+    // The ceiling was 1.3x, barely above conversational, which is why playback
+    // read as slow: a user moving through a long answer had nowhere to go.
+    expect(MAX_VOICE_SPEED).toBeGreaterThanOrEqual(1.8)
+    expect(normalizeVoiceSpeed(1.8)).toBeCloseTo(1.8, 6)
+    expect(normalizeVoiceSpeed(2)).toBeCloseTo(2, 6)
+  })
+
+  it('still refuses a speed nobody could follow', () => {
+    expect(normalizeVoiceSpeed(6)).toBe(MAX_VOICE_SPEED)
+    expect(normalizeVoiceSpeed(0.1)).toBe(MIN_VOICE_SPEED)
+  })
+
+  it('keeps a slow speed available for listening carefully', () => {
+    expect(MIN_VOICE_SPEED).toBeLessThanOrEqual(0.8)
+    expect(normalizeVoiceSpeed(0.75)).toBeCloseTo(0.75, 6)
+  })
+
+  it('falls back rather than failing on nonsense', () => {
+    expect(normalizeVoiceSpeed(undefined)).toBe(DEFAULT_VOICE_SPEED)
+    expect(normalizeVoiceSpeed(Number.NaN)).toBe(DEFAULT_VOICE_SPEED)
+  })
+
+  it('rounds to the step the slider offers', () => {
+    expect(normalizeVoiceSpeed(1.234)).toBeCloseTo(1.25, 6)
+  })
+})

--- a/packages/web/tests/voice-speed-and-voices.test.ts
+++ b/packages/web/tests/voice-speed-and-voices.test.ts
@@ -6,6 +6,7 @@ import {
   MIN_VOICE_SPEED,
   normalizeVoiceSpeed,
 } from '../src/features/voice/employee-voice-profile.js'
+import { normalizeMossVoiceId } from '@dsh-cyber/contracts'
 
 describe('voice speed', () => {
   it('reaches a speed worth having', () => {
@@ -33,5 +34,9 @@ describe('voice speed', () => {
 
   it('rounds to the step the slider offers', () => {
     expect(normalizeVoiceSpeed(1.234)).toBeCloseTo(1.25, 6)
+  })
+
+  it.each(['Junhao', 'moss:Junhao', 'moss:moss:Junhao'])('normalizes MOSS voice ids from %s', (value) => {
+    expect(normalizeMossVoiceId(value)).toBe('moss:Junhao')
   })
 })


### PR DESCRIPTION
用户报了四条：麦克风配置提示一直不消失、多个本地语音模型用不了、语速太慢、音源太少且没有名称。

逐条溯源到具体机制后发现，**语音链路其实从来没打通过**——用户报的是表层症状。

## 引擎根本发不出声

```ts
// local-tts-asset-service.ts
if ((await this.status()).installed !== true) throw ... '请运行 pnpm tts:install'
```

`stream()` 无论调用方选了哪个引擎，**都先检查 Kokoro 装没装**，而 `status()` 只认识 Kokoro。所以从设置面板装好 MOSS、界面显示"可用"、点播放 → 404，然后提示你去装一个**从没选过**的包。

现在按调用方选的那个包检查。

## MOSS 根本装不上

安装最后一步用裸命令 `python` 建虚拟环境。**macOS 自 12.3 起不再提供 `python`**，所以等完约 1GB 下载后 spawn 失败，manifest 从未写入，包永远停在"未安装"。

改为按候选顺序探测（非 Windows 先 `python3`；Windows 先 `python`，因为那边 `python3` 是应用商店空壳）。完全没有 Python 时明确说清，并给出 `DSH_CYBER_PYTHON` 覆盖方式。

## 失败了看不见

安装失败原因一直被算出来、写进 descriptor、然后**被丢掉**——界面只画了个"重试安装"按钮。`spawn python ENOENT`、校验失败、退出码非零，看到的全都一样。现在直接显示。

而且所有拒绝安装都是同一句"尚未提供本机安装包"，**包括 Kokoro**——它其实能装，只是要走命令行。现在它会告诉你跑 `pnpm tts:install`。

## 语速

`1.3` 这个上限被写在**四个文件里**（`normalizeVoiceSpeed`、`KokoroSpeechAdapter.normalizeSpeed`、服务端校验、`readCachedVoiceSpeed`）。只改滑块的话，要么请求被服务端拒绝，要么音频根本不变，要么存好的值被读回时丢弃。

现在只在一处声明，上限 2.0。另外 MOSS 那条链**根本没传 speed**——滑块动了声音不变；speed 实际由播放速率施加，代码里现在写清楚了。

## 音源与名称

MOSS 的 provider 一直在上报模型实际支持的音色（sidecar 的 ready 消息里就有），而界面**硬编码了一个 `moss:Junhao`**——多音色模型看起来只有一个声音，名字也跟模型里是谁无关。

`VoiceModelDescriptor` 现在带 `voices`，从安装包自己的 manifest 读。

引擎下拉之前只给"可用/已安装"加后缀，**需要下载的和本机跑不了的都不加标记**，看起来跟能用的一样。现在每种状态都有说法，默认选中改为"能说话的那个"。措辞也改了：原来写"高级模型"像是高配功能，实情是**本机跑不了**。

## 麦克风提示不消失

清错误的语句写在守卫 `return` **之后**，所以一旦出过错，提示留到刷新为止；而在聊天框里它是**绝对定位的 260px 浮层，压在发送按钮上**。

更严重的是：识别进程崩溃时错误**发不出来**——`#failAll` 发事件时不带 `sessionId`，而 websocket 只转发带 id 的事件。界面会永远停在"正在听…"。现在按会话逐个下发，`stopped` / `cancelled` / `speech-end` 也不再被忽略。

## 为什么对不起来

- **角色自己打断自己**：回复经扬声器回到麦克风触发识别，对话塌成死循环。回声消除已开但外放挡不住。简单静音会取消插话能力，所以改成播放时**抬高门槛**——说得比喇叭响才算插话。
- **每次打断重启 Python 运行时**：`cancel(requestId)` 会杀进程再拉起，下一句得等模型重载。sidecar 没有取消协议、中途打不断，所以改成**放弃输出不杀进程**——白算一秒好过整个运行时重启。
- **`send` 立刻 resolve**：语音控件的成功回调永远执行，发失败和发成功长得一模一样。改为返回真实的 turn。
- **聊天框的麦克风没人听回复**：只有世界里的角色面板订阅了播报总线。新增 `ComposerReplySpeaker`。

## 三处我做主的判断

**播报默认从 `manual` 改成 `auto`** —— 流式订阅要求模式是 `auto`，而默认是 `manual`：举着麦克风说话、对方默认不出声，这说不通。

**聊天框在回复完成时朗读，不复制流式分块** —— 延迟差一点，但避免了第二份需要与原实现同步维护的分块/代次/打断状态机。低延迟流式对话仍在角色面板。

**声音选择改为防抖自动保存** —— 原来只有点"语音"按钮收起面板才保存，切角色就丢。

## 中途我自己造了一个问题，也修了

改成默认自动播报后，**没装语音包的机器上每条回复都会打一个控制台错误再静默失败**。e2e 把它当噪音抓了出来，但用户会遇到同样的事且没有解释。没装语音包不是故障、是还没配置完，现在面板直接告诉你去哪个控件装，只有意外失败才记日志。

## 验证

- `pnpm typecheck` 通过
- `pnpm vitest run`：**835 通过**（新增 13 条）。1 条失败是 `world-knowledge-library` 的 macOS `/tmp` realpath 越界，在干净 main 上同样失败
- `pnpm build`：构建预算通过
- `pnpm test:e2e`：`digital-human-world.spec.ts` **6/6**；全量失败集与基线一致，零回归

## 一句实话

这些改动**我没能在真机上听过**——这个环境没有语音包、没有麦克风。每条逻辑链都追到了代码并补了测试，但"现在说话是否顺畅"需要在有语音包的机器上验证。