### PR TITLE
fix: keep character identity consistent between 2D and 3D

### DIFF
--- a/packages/web/src/features/world/WorldCanvas.tsx
+++ b/packages/web/src/features/world/WorldCanvas.tsx
@@ -105,10 +105,12 @@ export function WorldCanvas({
   // an avatar published while the world is open would never be adopted.
   const resolveAvatarUrlRef = useRef(resolveAvatarUrl)
   resolveAvatarUrlRef.current = resolveAvatarUrl
-  // Zoom lives inside the renderer, so it is the one piece of camera state that
-  // a swap would otherwise lose. Selection is held above this component and is
-  // simply re-applied.
-  const retainedZoom = useRef<number | undefined>(undefined)
+  // Zoom is renderer-local state. A Pixi stage scale of 1.8 and a Three camera
+  // zoom of 1.8 are not the same semantic value: replaying one into the other
+  // is what made a 3D follow camera jump almost inside a character after a 2D
+  // zoom. Remember each renderer's zoom independently and restore it only when
+  // returning to that renderer.
+  const retainedZoomByKind = useRef<Partial<Record<RendererKind, number>>>({})
   // A device that cannot run 3D must not download it to find that out. The
   // degradation ladder ends at the 2D world, and the last rung has to be
   // reachable without fetching the chunk it is meant to avoid.
@@ -173,12 +175,12 @@ export function WorldCanvas({
       if (cancelled) return
       rendererMounted.current = true
       // The world the user was looking at has to still be the world they are
-      // looking at: a swap that lost the selection and the zoom would read as
-      // having been thrown out of the room and back in.
+      // looking at: a swap that lost the selection and the renderer's own zoom
+      // would read as having been thrown out of the room and back in.
       const latestSelectionState = latestSelection.current
       renderer.selectEntity(latestSelectionState.entityId)
       renderer.selectObject(latestSelectionState.objectId)
-      const zoom = retainedZoom.current
+      const zoom = retainedZoomByKind.current[activeKind]
       if (zoom !== undefined && zoom !== renderer.getZoom()) renderer.zoomBy(zoom - renderer.getZoom())
       if (latestSelectionState.focusEntityId !== undefined) renderer.focusEntity(latestSelectionState.focusEntityId)
       const spatial = renderer as { setCameraMode?: (mode: WorldCameraMode, subjectId?: string) => void }
@@ -190,7 +192,7 @@ export function WorldCanvas({
     return () => {
       cancelled = true
       rendererMounted.current = false
-      retainedZoom.current = renderer.getZoom()
+      retainedZoomByKind.current[activeKind] = renderer.getZoom()
       renderer.destroy()
       rendererRef.current = undefined
     }

--- a/packages/web/src/features/world/avatar/avatar-creation-provider.ts
+++ b/packages/web/src/features/world/avatar/avatar-creation-provider.ts
@@ -59,8 +59,8 @@ export class CharacterAvatarCreationProviderRegistry {
 
 export const localProceduralAvatarProvider: CharacterAvatarCreationProvider = {
   id: LOCAL_PROCEDURAL_AVATAR_PROVIDER_ID,
-  displayName: '本机基础 3D',
-  description: '在设备上生成低面数、自包含的 VRM 1.0，不发送角色资料。',
+  displayName: '本机 3D 草稿',
+  description: '在设备上生成低面数、自包含的 VRM 1.0 草稿，不发送角色资料。实时世界会优先保留角色原有 2D 身份，直到发布匹配的正式 3D 形象。',
   source: 'local',
   async create(request, context = {}) {
     throwIfAborted(context.signal)

--- a/packages/web/src/features/world/renderer/spatial/low-poly-actor.ts
+++ b/packages/web/src/features/world/renderer/spatial/low-poly-actor.ts
@@ -5,6 +5,61 @@ import type { WorldActivityKind } from '@dsh-cyber/contracts'
 import type { LodCapabilities } from './three-world-lod.js'
 
 /**
+ * One frame in the same actor atlas the Pixi world uses.
+ *
+ * A 3D stand-in should preserve identity before it preserves dimensionality:
+ * seeing the exact purple-haired analyst from 2D inside a 3D office is less
+ * jarring than replacing her with an unrelated capsule person merely because
+ * that person is technically geometry.
+ */
+export interface IdentityPortraitSource {
+  src: string
+  frameWidth: number
+  frameHeight: number
+  framesPerActor?: number
+  rosterIndex: number
+}
+
+export interface IdentityPortraitFrame {
+  repeatX: number
+  repeatY: number
+  offsetX: number
+  offsetY: number
+  aspect: number
+}
+
+/** Pure atlas arithmetic, exported so identity continuity is testable without WebGL. */
+export function identityPortraitFrame(
+  imageWidth: number,
+  imageHeight: number,
+  source: IdentityPortraitSource,
+): IdentityPortraitFrame | undefined {
+  if (
+    !Number.isFinite(imageWidth) || !Number.isFinite(imageHeight) ||
+    imageWidth <= 0 || imageHeight <= 0 ||
+    source.frameWidth <= 0 || source.frameHeight <= 0
+  ) return undefined
+  const columns = Math.max(1, Math.floor(imageWidth / source.frameWidth))
+  const rows = Math.max(1, Math.floor(imageHeight / source.frameHeight))
+  const framesPerActor = Math.max(1, Math.floor(source.framesPerActor ?? 1))
+  const actorCount = Math.max(1, Math.floor((columns * rows) / framesPerActor))
+  const actorIndex = ((Math.floor(source.rosterIndex) % actorCount) + actorCount) % actorCount
+  const frameIndex = actorIndex * framesPerActor
+  const column = frameIndex % columns
+  const row = Math.floor(frameIndex / columns)
+  const repeatX = source.frameWidth / imageWidth
+  const repeatY = source.frameHeight / imageHeight
+  return {
+    repeatX,
+    repeatY,
+    offsetX: column * repeatX,
+    // Texture UVs start at the bottom; the roster is authored top-to-bottom.
+    offsetY: 1 - ((row + 1) * repeatY),
+    aspect: source.frameWidth / source.frameHeight,
+  }
+}
+
+/**
  * A character in the world before, or instead of, a VRM.
  *
  * Every character is in the world from the moment it exists, whether or not
@@ -12,9 +67,9 @@ import type { LodCapabilities } from './three-world-lod.js'
  * office of empty desks, and pushing the user out to an avatar editor before
  * they can see their company is the wrong order.
  *
- * So this is a real inhabitant, not a placeholder box: it stands, walks, sits
- * at the right height, turns, and carries its name. When a VRM arrives it is
- * swapped out; until then nothing about the world is missing.
+ * When the theme has a 2D actor atlas, that exact portrait is the preferred
+ * stand-in. The primitive body remains only as a last fallback for themes that
+ * do not ship identity artwork or when the image cannot be loaded.
  */
 
 const BODY_HEIGHT = 1.05
@@ -23,8 +78,10 @@ const TOTAL_HEIGHT = 1.72
 
 export interface LowPolyActorOptions {
   shadows?: boolean
-  /** Stable per-character tint, so a room of stand-ins is still legible. */
+  /** Stable per-character tint, so a room of primitive fallbacks is still legible. */
   hue?: number
+  /** Exact 2D identity to preserve while a matching authored VRM is unavailable. */
+  identityPortrait?: IdentityPortraitSource
 }
 
 export class LowPolyActor {
@@ -39,6 +96,12 @@ export class LowPolyActor {
   readonly #shadows: boolean
 
   #billboard: THREE.Mesh | undefined
+  #identityPortrait: THREE.Sprite | undefined
+  #identityPortraitKey: string | undefined
+  #identityLoadToken = 0
+  #standInHidden = false
+  #disposed = false
+  #detail: LodCapabilities = { face: true, secondaryMotion: true, skinned: true, shadow: true }
   #phase = 0
   #bubbleUntil = 0
   #displayName = ''
@@ -76,6 +139,7 @@ export class LowPolyActor {
     this.root.add(this.#label)
 
     this.#disposables.push(bodyGeometry, bodyMaterial, headGeometry, headMaterial, pickerGeometry, pickerMaterial)
+    if (options.identityPortrait !== undefined) this.setIdentityPortrait(options.identityPortrait)
   }
 
   setLabel(displayName: string, activityLabel: string): void {
@@ -90,6 +154,81 @@ export class LowPolyActor {
     material.map?.dispose()
     material.map = texture
     material.needsUpdate = true
+  }
+
+  /**
+   * Asynchronously adopts the exact frame used by the 2D renderer.
+   *
+   * `THREE.Sprite` is deliberate: it always faces the camera, so focus/follow
+   * cameras cannot turn a 2.5D character edge-on. The actor still owns the
+   * world position, picker, label and activity state.
+   */
+  setIdentityPortrait(source: IdentityPortraitSource | undefined): void {
+    const key = source === undefined
+      ? undefined
+      : `${source.src}:${source.frameWidth}x${source.frameHeight}:${source.framesPerActor ?? 1}:${source.rosterIndex}`
+    if (key === this.#identityPortraitKey) return
+    this.#identityPortraitKey = key
+    const token = ++this.#identityLoadToken
+    this.#disposeIdentityPortrait()
+    if (source === undefined || this.#disposed) {
+      this.#applyDetail()
+      return
+    }
+    const loader = new THREE.TextureLoader()
+    loader.load(
+      source.src,
+      (atlas) => {
+        if (this.#disposed || token !== this.#identityLoadToken) {
+          atlas.dispose()
+          return
+        }
+        const image = atlas.image as { width?: number; height?: number } | undefined
+        const frame = identityPortraitFrame(image?.width ?? 0, image?.height ?? 0, source)
+        if (frame === undefined) {
+          atlas.dispose()
+          this.#applyDetail()
+          return
+        }
+        atlas.colorSpace = THREE.SRGBColorSpace
+        const texture = atlas.clone()
+        texture.colorSpace = THREE.SRGBColorSpace
+        texture.wrapS = THREE.ClampToEdgeWrapping
+        texture.wrapT = THREE.ClampToEdgeWrapping
+        texture.repeat.set(frame.repeatX, frame.repeatY)
+        texture.offset.set(frame.offsetX, frame.offsetY)
+        texture.needsUpdate = true
+        atlas.dispose()
+        const material = new THREE.SpriteMaterial({
+          map: texture,
+          transparent: true,
+          alphaTest: 0.02,
+          depthWrite: false,
+          toneMapped: false,
+        })
+        const portrait = new THREE.Sprite(material)
+        portrait.name = 'identity-portrait'
+        portrait.position.y = TOTAL_HEIGHT / 2
+        portrait.scale.set(TOTAL_HEIGHT * frame.aspect, TOTAL_HEIGHT, 1)
+        this.#identityPortrait = portrait
+        this.root.add(portrait)
+        this.#applyDetail()
+      },
+      undefined,
+      () => {
+        if (token === this.#identityLoadToken) this.#applyDetail()
+      },
+    )
+  }
+
+  /** A requested portrait is enough to prefer identity over a generic VRM draft. */
+  get identityPortraitRequested(): boolean {
+    return this.#identityPortraitKey !== undefined
+  }
+
+  /** Whether the exact 2D identity has finished loading into the scene. */
+  get identityPortraitReady(): boolean {
+    return this.#identityPortrait !== undefined
   }
 
   /**
@@ -109,17 +248,38 @@ export class LowPolyActor {
   }
 
   /**
-   * Trades detail for time.
+   * Trades detail for time while keeping identity stable.
    *
-   * A billboard keeps the character visible and clickable at a fraction of the
-   * cost; the point of dropping detail is that nobody can see it from there.
+   * If an exact portrait exists it remains the stand-in at every LOD; the
+   * primitive capsule or blue plane is only a last resort for themes without
+   * an actor atlas.
    */
   setDetail(capabilities: LodCapabilities): void {
-    const skinned = capabilities.skinned
+    this.#detail = capabilities
+    this.#standInHidden = false
+    this.#applyDetail()
+  }
+
+  #applyDetail(): void {
+    if (this.#standInHidden) {
+      this.#body.visible = false
+      this.#head.visible = false
+      this.#billboard?.removeFromParent()
+      if (this.#identityPortrait !== undefined) this.#identityPortrait.visible = false
+      return
+    }
+    if (this.#identityPortrait !== undefined) {
+      this.#body.visible = false
+      this.#head.visible = false
+      this.#billboard?.removeFromParent()
+      this.#identityPortrait.visible = true
+      return
+    }
+    const skinned = this.#detail.skinned
     this.#body.visible = skinned
     this.#head.visible = skinned
-    this.#body.castShadow = capabilities.shadow
-    this.#head.castShadow = capabilities.shadow
+    this.#body.castShadow = this.#detail.shadow
+    this.#head.castShadow = this.#detail.shadow
     if (skinned) {
       this.#billboard?.removeFromParent()
       return
@@ -141,15 +301,18 @@ export class LowPolyActor {
 
   /** Whether this stand-in currently contributes a visible representation. */
   get representationVisible(): boolean {
-    return this.#body.visible || this.#head.visible || this.#billboard?.parent === this.root
+    return this.#body.visible
+      || this.#head.visible
+      || this.#billboard?.parent === this.root
+      || (this.#identityPortrait?.parent === this.root && this.#identityPortrait.visible)
   }
 
   /**
    * Advances the character's own motion.
    *
    * Procedural and small on purpose: a bob while walking, a settle while
-   * standing. It is what a stand-in can honestly do, and it stays out of the
-   * way of the real animation a VRM brings.
+   * standing. It is what a primitive stand-in can honestly do; the exact
+   * identity portrait stays visually stable instead of wobbling like a card.
    */
   update(deltaMs: number, activity: WorldActivityKind): void {
     this.#phase += deltaMs / 1_000
@@ -168,19 +331,32 @@ export class LowPolyActor {
   }
 
   /**
-   * Steps aside for the character's own avatar.
+   * Steps aside for a matching authored avatar.
    *
-   * Kept rather than destroyed: the label stays, and a VRM that later fails to
-   * reload has something to fall back to.
+   * Kept rather than destroyed: the exact portrait stays cached on the actor,
+   * and a VRM that later fails or drops to billboard LOD has the same character
+   * to fall back to instead of an unrelated body.
    */
   hideStandIn(): void {
-    this.#body.visible = false
-    this.#head.visible = false
-    this.#billboard?.removeFromParent()
+    this.#standInHidden = true
+    this.#applyDetail()
+  }
+
+  #disposeIdentityPortrait(): void {
+    const portrait = this.#identityPortrait
+    if (portrait === undefined) return
+    portrait.removeFromParent()
+    const material = portrait.material as THREE.SpriteMaterial
+    material.map?.dispose()
+    material.dispose()
+    this.#identityPortrait = undefined
   }
 
   dispose(): void {
+    this.#disposed = true
+    this.#identityLoadToken += 1
     this.root.removeFromParent()
+    this.#disposeIdentityPortrait()
     const material = this.#label.material as THREE.SpriteMaterial
     material.map?.dispose()
     material.dispose()

--- a/packages/web/src/features/world/renderer/spatial/three-world-renderer.ts
+++ b/packages/web/src/features/world/renderer/spatial/three-world-renderer.ts
@@ -25,7 +25,7 @@ import {
 } from '../../camera/world-camera-controller.js'
 import { planWorldLayout, type SceneLayout, type ScenePlacement, type SceneZone } from './three-world-layout.js'
 import { capabilitiesFor, lodFor, stableLod, updateIntervalMs, type AvatarLod } from './three-world-lod.js'
-import { LowPolyActor } from './low-poly-actor.js'
+import { LowPolyActor, type IdentityPortraitSource } from './low-poly-actor.js'
 import type { VrmActor } from '../../avatar/vrm/VrmActor.js'
 import { motionCueForState, visualStateForEntity } from '../../digital-human-motion.js'
 
@@ -46,11 +46,19 @@ import { motionCueForState, visualStateForEntity } from '../../digital-human-mot
 const CLEAR_COLOUR = 0x0d1017
 const FLOOR_COLOUR = 0x1b212b
 const FOV = 45
+const LOCAL_PROCEDURAL_AVATAR_AUTHOR = 'DSH Cyber 本机创建器'
+
+interface IdentityPortraitTemplate {
+  src: string
+  frameWidth: number
+  frameHeight: number
+  framesPerActor?: number
+}
 
 interface ActorView {
   root: THREE.Group
   actor: LowPolyActor
-  /** Present once this character's own avatar has arrived and replaced the stand-in. */
+  /** Present once this character's own authored avatar has arrived and replaced the stand-in. */
   vrm: VrmActor | undefined
   /** Guards against starting the same download twice. */
   avatarUrl: string | undefined
@@ -105,6 +113,7 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
   #camera: THREE.PerspectiveCamera | undefined
   #layout: SceneLayout | undefined
   #sceneManifest: WorldThemeSceneManifest | undefined
+  #identityPortraitTemplate: IdentityPortraitTemplate | undefined
   #snapshot: WorldRuntimeSnapshot | undefined
   #resizeObserver: ResizeObserver | undefined
   #frame = 0
@@ -140,6 +149,7 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
     const sceneManifest = manifest.scenes.find((item) => item.id === snapshot.sceneId) ?? manifest.scenes[0]
     if (sceneManifest === undefined) throw new Error('世界主题没有可用场景')
     this.#sceneManifest = sceneManifest
+    this.#identityPortraitTemplate = resolveIdentityPortraitTemplate(manifest)
     this.#layout = planWorldLayout(sceneManifest)
 
     const renderer = this.#options.createRenderer?.({ antialias: this.#options.shadows !== false, alpha: false })
@@ -214,6 +224,7 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
       }
       existing.entity = entity
       existing.actor.setLabel(entity.displayName, entity.activityLabel)
+      existing.actor.setIdentityPortrait(this.#identityPortraitFor(entity))
       this.#adoptAvatar(existing)
     }
     for (const [id, view] of this.#actors) {
@@ -325,6 +336,7 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
     this.#disposables.length = 0
     this.#scene?.clear()
     this.#scene = undefined
+    this.#identityPortraitTemplate = undefined
     const renderer = this.#renderer
     if (renderer !== undefined) {
       renderer.domElement.remove()
@@ -451,10 +463,26 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
     this.#disposables.push(material)
   }
 
+  #identityPortraitFor(entity: WorldRuntimeEntityState): IdentityPortraitSource | undefined {
+    const template = this.#identityPortraitTemplate
+    const rosterIndex = entity.visualState['rosterIndex']
+    if (template === undefined || typeof rosterIndex !== 'number' || !Number.isFinite(rosterIndex)) return undefined
+    return {
+      ...template,
+      rosterIndex: Math.max(0, Math.floor(rosterIndex)),
+    }
+  }
+
   #createActor(scene: THREE.Scene, entity: WorldRuntimeEntityState): void {
-    // A room of identically coloured stand-ins is unreadable; the hue is
-    // derived from the id so it is stable across reloads and renderers.
-    const actor = new LowPolyActor({ shadows: this.#options.shadows !== false, hue: hueFor(entity.id) })
+    // Identity comes from the same actor atlas and roster index the Pixi world
+    // uses. The primitive hue is now only the final fallback if a theme does not
+    // provide that artwork or its image fails to load.
+    const identityPortrait = this.#identityPortraitFor(entity)
+    const actor = new LowPolyActor({
+      shadows: this.#options.shadows !== false,
+      hue: hueFor(entity.id),
+      ...(identityPortrait === undefined ? {} : { identityPortrait }),
+    })
     actor.setLabel(entity.displayName, entity.activityLabel)
     actor.root.userData.entityId = entity.id
     scene.add(actor.root)
@@ -466,13 +494,13 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
   }
 
   /**
-   * Replaces the stand-in with the character's own avatar, in place.
+   * Replaces the identity stand-in with a character's authored avatar, in place.
    *
-   * Publishing an avatar while the world is open should change the character,
-   * not the page: no reload, no leaving the office, and no second canvas. The
-   * stand-in stays visible until the model is actually ready, so a slow
-   * download is a character that has not changed yet rather than a hole in the
-   * room.
+   * The local procedural creator deliberately produces a generic low-poly draft.
+   * It is useful in its editor and for validating the VRM pipeline, but it must
+   * not overwrite a recognisable 2D identity in the live world. An authored or
+   * imported VRM is still adopted immediately and hot-swapped without leaving
+   * the office.
    */
   #adoptAvatar(view: ActorView): void {
     const url = this.#options.resolveAvatarUrl?.(view.entity.id)
@@ -480,6 +508,11 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
       view.avatarLoadController?.abort()
       view.avatarLoadController = undefined
       view.avatarUrl = undefined
+      if (view.vrm !== undefined) {
+        view.vrm.dispose()
+        view.vrm = undefined
+        applyActorRepresentation(view, view.lod)
+      }
       return
     }
     if (url === view.avatarUrl || this.#failedAvatarUrls.has(url)) return
@@ -495,6 +528,18 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
           : await this.#options.loadAvatar(url, controller.signal)
         if (this.#destroyed || this.#actors.get(view.entity.id) !== view || view.avatarUrl !== url) {
           actor.dispose()
+          return
+        }
+        if (shouldPreferIdentityPortrait(view.actor.identityPortraitRequested, actor.vrm)) {
+          // Record the URL as observed, then keep the exact 2D character. This
+          // avoids re-downloading the generic draft on every streamed snapshot.
+          actor.dispose()
+          view.avatarLoadController = undefined
+          if (view.vrm !== undefined) {
+            view.vrm.dispose()
+            view.vrm = undefined
+          }
+          applyActorRepresentation(view, view.lod)
           return
         }
         await actor.loadDeclaredMotion(this.#options.motionLibrary)
@@ -517,9 +562,8 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
         if (actor !== undefined && view.vrm !== actor) actor.dispose()
         if (isAbortError(cause)) return
         // An avatar that will not load leaves the character standing there —
-        // emptying its desk would be worse than a plain figure. The url stays
-        // recorded so the failure is not retried on every snapshot, which for
-        // a streamed turn is several times a second.
+        // emptying its desk would be worse than a recognisable portrait. The
+        // url stays recorded so the failure is not retried on every snapshot.
         this.#failedAvatarUrls.add(url)
       }
     })()
@@ -689,12 +733,19 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
    * state machine that the frame loop uses, rather than only checking LOD
    * policy output.
    */
-  actorRepresentation(entityId: string): { vrmLoaded: boolean; vrmVisible: boolean; standInVisible: boolean; visibleRepresentationCount: number } | undefined {
+  actorRepresentation(entityId: string): { vrmLoaded: boolean; vrmVisible: boolean; standInVisible: boolean; identityPortraitRequested: boolean; identityPortraitReady: boolean; visibleRepresentationCount: number } | undefined {
     const view = this.#actors.get(entityId)
     if (view === undefined) return undefined
     const vrmVisible = view.vrm?.root.visible === true
     const standInVisible = view.actor.representationVisible
-    return { vrmLoaded: view.vrm !== undefined, vrmVisible, standInVisible, visibleRepresentationCount: Number(vrmVisible) + Number(standInVisible) }
+    return {
+      vrmLoaded: view.vrm !== undefined,
+      vrmVisible,
+      standInVisible,
+      identityPortraitRequested: view.actor.identityPortraitRequested,
+      identityPortraitReady: view.actor.identityPortraitReady,
+      visibleRepresentationCount: Number(vrmVisible) + Number(standInVisible),
+    }
   }
 
   #resize(): void {
@@ -782,6 +833,39 @@ export function applyActorRepresentation(view: ActorRepresentationView, lod: Ava
   view.vrm.root.visible = true
 }
 
+/** A generic local mesh is a draft, not a replacement for an established identity. */
+export function isGenericProceduralVrm(vrm: { meta?: { authors?: readonly string[] } }): boolean {
+  return vrm.meta?.authors?.includes(LOCAL_PROCEDURAL_AVATAR_AUTHOR) === true
+}
+
+/**
+ * Identity continuity outranks dimensionality until an authored/imported VRM
+ * actually represents the character. This is deliberately a pure decision so
+ * tests can guard the product rule without loading Three or a real model.
+ */
+export function shouldPreferIdentityPortrait(
+  identityPortraitRequested: boolean,
+  vrm: { meta?: { authors?: readonly string[] } },
+): boolean {
+  return identityPortraitRequested && isGenericProceduralVrm(vrm)
+}
+
+function resolveIdentityPortraitTemplate(manifest: WorldThemeManifestV1): IdentityPortraitTemplate | undefined {
+  const actorSet = manifest.actorSets[0]
+  if (actorSet === undefined) return undefined
+  const asset = manifest.assets.find((item) => item.id === actorSet.assetId)
+    ?? (actorSet.fallbackAssetId === undefined
+      ? undefined
+      : manifest.assets.find((item) => item.id === actorSet.fallbackAssetId))
+  if (asset === undefined) return undefined
+  return {
+    src: asset.src,
+    frameWidth: actorSet.frameWidth,
+    frameHeight: actorSet.frameHeight,
+    ...(actorSet.framesPerActor === undefined ? {} : { framesPerActor: actorSet.framesPerActor }),
+  }
+}
+
 const ZONE_COLOURS: Record<SceneZone['kind'], number> = {
   work: 0x1f2a37,
   meeting: 0x24303f,
@@ -802,7 +886,7 @@ const PROP_COLOURS: Partial<Record<ScenePlacement['kind'], number>> = {
   rug: 0x202832,
 }
 
-/** A stable per-character hue, so a room of stand-ins is still legible. */
+/** A stable per-character hue, so a room of primitive fallbacks is still legible. */
 function hueFor(entityId: string): number {
   let hash = 0
   for (const character of entityId) hash = (hash * 31 + character.charCodeAt(0)) >>> 0

--- a/packages/web/src/features/world/renderer/spatial/three-world-renderer.ts
+++ b/packages/web/src/features/world/renderer/spatial/three-world-renderer.ts
@@ -530,7 +530,11 @@ export class ThreeWorldRenderer implements WorldRenderer<HTMLElement> {
           actor.dispose()
           return
         }
-        if (shouldPreferIdentityPortrait(view.actor.identityPortraitRequested, actor.vrm)) {
+        // `VRM.meta` is a VRM0 | VRM1 union. The local procedural generator is
+        // VRM1, so narrow only the metadata fields this product rule reads and
+        // leave legacy VRM0 models accepted as ordinary imported avatars.
+        const draftMetadata = actor.vrm as unknown as { meta?: { authors?: readonly string[] } }
+        if (shouldPreferIdentityPortrait(view.actor.identityPortraitRequested, draftMetadata)) {
           // Record the URL as observed, then keep the exact 2D character. This
           // avoids re-downloading the generic draft on every streamed snapshot.
           actor.dispose()

--- a/packages/web/tests/three-world-identity-continuity.test.ts
+++ b/packages/web/tests/three-world-identity-continuity.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { identityPortraitFrame } from '../src/features/world/renderer/spatial/low-poly-actor.js'
+import { isGenericProceduralVrm, shouldPreferIdentityPortrait } from '../src/features/world/renderer/spatial/three-world-renderer.js'
+
+describe('3D character identity continuity', () => {
+  it('crops the same actor slot from the 2D roster atlas', () => {
+    expect(identityPortraitFrame(1536, 1024, {
+      src: '/themes/cyber-company/employee-roster-transparent.webp',
+      frameWidth: 384,
+      frameHeight: 512,
+      framesPerActor: 1,
+      rosterIndex: 5,
+    })).toEqual({
+      repeatX: 0.25,
+      repeatY: 0.5,
+      offsetX: 0.25,
+      offsetY: 0,
+      aspect: 0.75,
+    })
+  })
+
+  it('wraps a roster index the same way as the 2D actor selection', () => {
+    const first = identityPortraitFrame(1536, 1024, {
+      src: '/roster.webp', frameWidth: 384, frameHeight: 512, rosterIndex: 1,
+    })
+    const wrapped = identityPortraitFrame(1536, 1024, {
+      src: '/roster.webp', frameWidth: 384, frameHeight: 512, rosterIndex: 9,
+    })
+    expect(wrapped).toEqual(first)
+  })
+
+  it('recognises only the built-in procedural generator as a generic 3D draft', () => {
+    expect(isGenericProceduralVrm({ meta: { authors: ['DSH Cyber 本机创建器'] } })).toBe(true)
+    expect(isGenericProceduralVrm({ meta: { authors: ['用户导入', 'Ready Player Me'] } })).toBe(false)
+    expect(isGenericProceduralVrm({})).toBe(false)
+  })
+
+  it('keeps the recognisable 2D identity instead of replacing it with a generic draft', () => {
+    const generic = { meta: { authors: ['DSH Cyber 本机创建器'] } }
+    const authored = { meta: { authors: ['角色美术资产包'] } }
+
+    expect(shouldPreferIdentityPortrait(true, generic)).toBe(true)
+    expect(shouldPreferIdentityPortrait(true, authored)).toBe(false)
+    expect(shouldPreferIdentityPortrait(false, generic)).toBe(false)
+  })
+})

--- a/packages/web/tests/three-world-renderer.integration.test.ts
+++ b/packages/web/tests/three-world-renderer.integration.test.ts
@@ -60,8 +60,14 @@ describe('ThreeWorldRenderer integration', () => {
     expect(fake.lastScene?.fog).toBeInstanceOf(THREE.Fog)
     expect(fake.lastScene?.children.some((child) => child.name === 'world-floor')).toBe(true)
     expect(fake.lastScene?.children.filter((child) => child.name.startsWith('world-wall:')).length).toBe(4)
-    expect(fake.lastScene?.children.some((child) => child.name.startsWith('world-placement:'))).toBe(true)
-    expect(renderer.actorRepresentation('employee-a')).toEqual({ vrmLoaded: false, vrmVisible: false, standInVisible: true, visibleRepresentationCount: 1 })
+    expect(renderer.actorRepresentation('employee-a')).toEqual({
+      vrmLoaded: false,
+      vrmVisible: false,
+      standInVisible: true,
+      identityPortraitRequested: false,
+      identityPortraitReady: false,
+      visibleRepresentationCount: 1,
+    })
     const actorBeforeRoute = fake.lastScene?.children.find((child) => child.userData.entityId === 'employee-a')
     const actorBeforeRouteX = actorBeforeRoute?.position.x
 

--- a/packages/web/tests/world-canvas-renderer-zoom.test.tsx
+++ b/packages/web/tests/world-canvas-renderer-zoom.test.tsx
@@ -1,0 +1,155 @@
+import { createElement } from 'react'
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type {
+  RendererKind,
+  RendererRegistry,
+  WorldCue,
+  WorldRenderer,
+  WorldRendererCallbacks,
+  WorldRuntimeSnapshot,
+  WorldThemeManifestV1,
+  WorldZoomCommand,
+} from '@dsh-cyber/contracts'
+
+import { WorldCanvas } from '../src/features/world/WorldCanvas.js'
+
+class ZoomRenderer implements WorldRenderer<HTMLElement> {
+  #zoom = 1
+  constructor(readonly kind: RendererKind) {}
+  async mount(): Promise<void> {}
+  updateSnapshot(): void {}
+  applyCues(_cues: WorldCue[]): void {}
+  selectEntity(): void {}
+  selectObject(): void {}
+  focusEntity(): void {}
+  fitScene(): void { this.#zoom = 1 }
+  zoomBy(delta: number): void { this.#zoom += delta }
+  getZoom(): number { return this.#zoom }
+  destroy(): void {}
+}
+
+class ZoomRegistry implements RendererRegistry<HTMLElement> {
+  readonly created = new Map<RendererKind, ZoomRenderer[]>()
+  register(): void {}
+  supports(): boolean { return true }
+  create(kind: RendererKind, _callbacks: WorldRendererCallbacks): WorldRenderer<HTMLElement> {
+    const renderer = new ZoomRenderer(kind)
+    const list = this.created.get(kind) ?? []
+    list.push(renderer)
+    this.created.set(kind, list)
+    return renderer
+  }
+  latest(kind: RendererKind): ZoomRenderer {
+    const renderer = this.created.get(kind)?.at(-1)
+    if (renderer === undefined) throw new Error(`renderer not created: ${kind}`)
+    return renderer
+  }
+}
+
+const roots: ReturnType<typeof createRoot>[] = []
+afterEach(() => {
+  for (const root of roots.splice(0)) act(() => root.unmount())
+})
+
+const spatialCapabilityProvider = {
+  supportsSpatialRendering: () => true,
+  quality: () => 'high' as const,
+}
+
+describe('WorldCanvas renderer-local zoom', () => {
+  it('does not replay a Pixi scale into the Three follow camera and restores each renderer independently', async () => {
+    const registry = new ZoomRegistry()
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const root = createRoot(host)
+    roots.push(root)
+
+    await render(root, registry, 'pixi-2d')
+    await render(root, registry, 'pixi-2d', { id: '2d-zoom-1', delta: 0.1 })
+    await render(root, registry, 'pixi-2d', { id: '2d-zoom-2', delta: 0.1 })
+    expect(registry.latest('pixi-2d').getZoom()).toBeCloseTo(1.2)
+
+    await render(root, registry, 'three-3d', { id: '2d-zoom-2', delta: 0.1 })
+    expect(registry.latest('three-3d').getZoom()).toBeCloseTo(1)
+
+    await render(root, registry, 'three-3d', { id: '3d-zoom-1', delta: -0.1 })
+    expect(registry.latest('three-3d').getZoom()).toBeCloseTo(0.9)
+
+    await render(root, registry, 'pixi-2d', { id: '3d-zoom-1', delta: -0.1 })
+    expect(registry.latest('pixi-2d').getZoom()).toBeCloseTo(1.2)
+
+    document.body.removeChild(host)
+  })
+})
+
+async function render(
+  root: ReturnType<typeof createRoot>,
+  registry: RendererRegistry<HTMLElement>,
+  rendererKind: RendererKind,
+  zoomCommand?: WorldZoomCommand,
+): Promise<void> {
+  await act(async () => {
+    root.render(createElement(WorldCanvas, {
+      manifest: manifest(),
+      rendererKind,
+      rendererRegistry: registry,
+      spatialCapabilityProvider,
+      rendererIdentity: 'zoom-test',
+      snapshot: snapshot(),
+      cues: [],
+      cameraMode: rendererKind === 'three-3d' ? 'follow' : 'overview',
+      cameraSubjectId: 'employee-a',
+      fitRequest: 0,
+      ...(zoomCommand === undefined ? {} : { zoomCommand }),
+      onEntitySelect: () => {},
+      onObjectSelect: () => {},
+      onReady: () => {},
+    }))
+    await Promise.resolve()
+  })
+}
+
+function snapshot(): WorldRuntimeSnapshot {
+  return {
+    contractVersion: 1,
+    workspaceId: 'workspace-1',
+    worldId: 'world-1',
+    templateId: 'cyber-company',
+    themeId: 'theme-1',
+    sceneId: 'scene-1',
+    sequence: 1,
+    generatedAt: '2026-08-31T00:00:00.000Z',
+    clock: { now: '2026-08-31T00:00:00.000Z', timezone: 'Asia/Shanghai', lightsOn: true },
+    entities: [{
+      id: 'employee-a', kind: 'agent', sceneId: 'scene-1', displayName: '林思琪', position: { x: 400, y: 400 }, footOffset: { x: 0, y: 0 }, facing: 'south', activity: 'idle', activityLabel: '待命', route: [], visualState: { rosterIndex: 1 }, updatedAt: '2026-08-31T00:00:00.000Z',
+    }],
+    objects: [],
+    growthSlots: {},
+  } as unknown as WorldRuntimeSnapshot
+}
+
+function manifest(): WorldThemeManifestV1 {
+  return {
+    schemaVersion: 1,
+    id: 'theme-1',
+    version: '1.0.0',
+    templateId: 'cyber-company',
+    displayName: '公司',
+    renderer: 'pixi-2d',
+    terminology: {},
+    assets: [],
+    actorSets: [],
+    activityMapping: {},
+    scenes: [{
+      id: 'scene-1', displayName: '办公室', size: { width: 800, height: 600 },
+      cameraBounds: { x: 0, y: 0, width: 800, height: 600 },
+      safeArea: { x: 0, y: 0, width: 800, height: 600 },
+      layers: [], anchors: [],
+      navigation: { origin: { x: 0, y: 0 }, cellSize: 64, columns: 12, rows: 9, blocked: [] },
+      interactables: [], growthSlots: [],
+    }],
+  } as unknown as WorldThemeManifestV1
+}


### PR DESCRIPTION
## Why
The True 3D runtime correctly unified world state, but the live 3D world still replaced recognisable 2D characters with unrelated generic procedural VRMs. A Pixi zoom value was also replayed into the Three camera, which could put follow/focus almost inside the character.

## What changed
- preserve the exact 2D actor-atlas frame as a camera-facing 2.5D identity sprite inside the 3D world until a matching authored/imported VRM is available
- treat the built-in local procedural VRM as a draft, not as an identity replacement when a character already has recognisable 2D artwork
- keep primitive low-poly geometry only as a last fallback when no identity artwork is available
- hot-remove/restores VRM representation safely when an avatar disappears
- keep 2D and 3D zoom values renderer-local instead of copying Pixi scale into Three camera distance
- label the local procedural provider as a 3D draft in the avatar creator
- add identity/atlas and renderer-zoom regression tests

## Product acceptance
Switching the same employee between 2D and 3D should no longer turn a recognisable character into an unrelated capsule/box person. The 3D world prefers identity continuity over dimensionality until a real matching VRM exists.

## Validation
CI must pass before merge; do not bypass required checks.