### PR TITLE
feat: resolve production avatar packs without losing character identity

### DIFF
--- a/packages/web/src/features/world/WorldCanvas.tsx
+++ b/packages/web/src/features/world/WorldCanvas.tsx
@@ -13,6 +13,8 @@ import { createWorldRendererRegistry } from './renderer/renderer-registry.js'
 import { WorldLocomotion, WorldLocomotionClock } from './runtime/world-locomotion.js'
 import { browserSpatialCapabilityProvider, type SpatialCapabilityProvider } from './avatar/renderer/RenderingQuality.js'
 import type { WorldCameraMode } from './runtime/world-view-mode.js'
+import type { ResolvedAvatarRepresentation } from './avatar/avatar-representation.js'
+import { loadRendererAvatar, rendererAvatarUrl } from './avatar/avatar-representation-loader.js'
 
 interface WorldCanvasProps {
   manifest: WorldThemeManifestV1
@@ -35,8 +37,13 @@ interface WorldCanvasProps {
    */
   cameraMode?: WorldCameraMode
   cameraSubjectId?: string
-  /** This character's published avatar, so the world can adopt it in place. */
+  /** Legacy employee-specific published avatar resolver. */
   resolveAvatarUrl?: (entityId: string) => string | undefined
+  /**
+   * Full representation resolver. A published avatar still wins, but when one
+   * does not exist this may return an identity-safe shared Base Pack assembly.
+   */
+  resolveAvatarRepresentation?: (entityId: string) => ResolvedAvatarRepresentation | undefined
   /** Injectable renderer registry for real renderer integration tests. */
   rendererRegistry?: RendererRegistry<HTMLElement>
   /** Injectable capability policy; production defaults to browser detection. */
@@ -72,6 +79,7 @@ export function WorldCanvas({
   cameraMode,
   cameraSubjectId,
   resolveAvatarUrl,
+  resolveAvatarRepresentation,
   rendererIdentity,
   snapshot,
   cues,
@@ -99,12 +107,13 @@ export function WorldCanvas({
   latestCameraState.current = { mode: cameraMode, subjectId: cameraSubjectId }
   const latestSelection = useRef<{ entityId: string | undefined; objectId: string | undefined; focusEntityId: string | undefined }>({ entityId: selectedEntityId, objectId: selectedObjectId, focusEntityId })
   latestSelection.current = { entityId: selectedEntityId, objectId: selectedObjectId, focusEntityId }
-  // Held in a ref, not closed over at mount: the renderer is built once and
-  // asks again on every snapshot, so a resolver captured at mount would keep
-  // answering with the character list from the moment the world opened — and
-  // an avatar published while the world is open would never be adopted.
+  // Held in refs, not closed over at mount: the renderer is built once and
+  // asks again on every snapshot, so a published avatar or installed pack can
+  // hot-swap while the world stays mounted.
   const resolveAvatarUrlRef = useRef(resolveAvatarUrl)
   resolveAvatarUrlRef.current = resolveAvatarUrl
+  const resolveAvatarRepresentationRef = useRef(resolveAvatarRepresentation)
+  resolveAvatarRepresentationRef.current = resolveAvatarRepresentation
   // Zoom is renderer-local state. A Pixi stage scale of 1.8 and a Three camera
   // zoom of 1.8 are not the same semantic value: replaying one into the other
   // is what made a 3D follow camera jump almost inside a character after a 2D
@@ -159,12 +168,23 @@ export function WorldCanvas({
     // Reduced motion still reaches the renderer — as the lowest tier, which
     // strips shadows and secondary motion — rather than as a refusal to draw.
     const quality = capability.quality
+    const representationResolver = (entityId: string) => resolveAvatarRepresentationRef.current?.(entityId)
     const registry = rendererRegistry ?? createWorldRendererRegistry({
       locomotion: sharedLocomotion,
       lodCeiling: quality === 'high' ? 'full' : quality === 'balanced' ? 'reduced' : 'billboard',
       shadows: quality === 'high',
       pixelRatio: quality === 'high' ? 2 : quality === 'balanced' ? 1.5 : 1,
-      resolveAvatarUrl: (entityId: string) => resolveAvatarUrlRef.current?.(entityId),
+      resolveAvatarUrl: (entityId: string) => {
+        const representation = representationResolver(entityId)
+        return representation === undefined
+          ? resolveAvatarUrlRef.current?.(entityId)
+          : rendererAvatarUrl(entityId, representation)
+      },
+      ...(resolveAvatarRepresentation === undefined
+        ? {}
+        : {
+            loadAvatar: (rendererUrl, signal) => loadRendererAvatar(rendererUrl, representationResolver, signal),
+          }),
     })
     const toViewport = (position: { x: number; y: number }) => { const rect = host.getBoundingClientRect(); return { x: rect.left + position.x, y: rect.top + position.y } }
     const renderer = registry.create(activeKind, { onEntitySelect, onObjectSelect, onReady, ...(onEntityContext === undefined ? {} : { onEntityContext: (id, position) => onEntityContext(id, toViewport(position)) }), ...(onObjectContext === undefined ? {} : { onObjectContext: (id, position) => onObjectContext(id, toViewport(position)) }) })

--- a/packages/web/src/features/world/WorldCanvas.tsx
+++ b/packages/web/src/features/world/WorldCanvas.tsx
@@ -13,7 +13,7 @@ import { createWorldRendererRegistry } from './renderer/renderer-registry.js'
 import { WorldLocomotion, WorldLocomotionClock } from './runtime/world-locomotion.js'
 import { browserSpatialCapabilityProvider, type SpatialCapabilityProvider } from './avatar/renderer/RenderingQuality.js'
 import type { WorldCameraMode } from './runtime/world-view-mode.js'
-import type { ResolvedAvatarRepresentation } from './avatar/avatar-representation.js'
+import { resolveCharacterAvatarRepresentation, type ResolvedAvatarRepresentation } from './avatar/avatar-representation.js'
 import { loadRendererAvatar, rendererAvatarUrl } from './avatar/avatar-representation-loader.js'
 
 interface WorldCanvasProps {
@@ -107,6 +107,8 @@ export function WorldCanvas({
   latestCameraState.current = { mode: cameraMode, subjectId: cameraSubjectId }
   const latestSelection = useRef<{ entityId: string | undefined; objectId: string | undefined; focusEntityId: string | undefined }>({ entityId: selectedEntityId, objectId: selectedObjectId, focusEntityId })
   latestSelection.current = { entityId: selectedEntityId, objectId: selectedObjectId, focusEntityId }
+  const latestSnapshot = useRef(snapshot)
+  latestSnapshot.current = snapshot
   // Held in refs, not closed over at mount: the renderer is built once and
   // asks again on every snapshot, so a published avatar or installed pack can
   // hot-swap while the world stays mounted.
@@ -168,7 +170,22 @@ export function WorldCanvas({
     // Reduced motion still reaches the renderer — as the lowest tier, which
     // strips shadows and secondary motion — rather than as a refusal to draw.
     const quality = capability.quality
-    const representationResolver = (entityId: string) => resolveAvatarRepresentationRef.current?.(entityId)
+    const representationResolver = (entityId: string): ResolvedAvatarRepresentation | undefined => {
+      const supplied = resolveAvatarRepresentationRef.current?.(entityId)
+      if (supplied !== undefined) return supplied
+      const entity = latestSnapshot.current.entities.find((candidate) => candidate.id === entityId)
+      const rosterIndex = entity?.visualState['rosterIndex']
+      const publishedAvatarUrl = resolveAvatarUrlRef.current?.(entityId)
+      // This baseline is intentionally conservative: the snapshot knows the
+      // same built-in portrait index as Pixi, which is enough to protect hair,
+      // outfit and palette identity. A richer Profile resolver may override it.
+      if (entity === undefined && publishedAvatarUrl === undefined) return undefined
+      return resolveCharacterAvatarRepresentation({
+        employeeId: entityId,
+        ...(typeof rosterIndex === 'number' && Number.isFinite(rosterIndex) ? { fallbackAvatarIndex: Math.max(0, Math.floor(rosterIndex)) } : {}),
+        ...(publishedAvatarUrl === undefined ? {} : { publishedAvatarUrl }),
+      })
+    }
     const registry = rendererRegistry ?? createWorldRendererRegistry({
       locomotion: sharedLocomotion,
       lodCeiling: quality === 'high' ? 'full' : quality === 'balanced' ? 'reduced' : 'billboard',
@@ -180,11 +197,10 @@ export function WorldCanvas({
           ? resolveAvatarUrlRef.current?.(entityId)
           : rendererAvatarUrl(entityId, representation)
       },
-      ...(resolveAvatarRepresentation === undefined
-        ? {}
-        : {
-            loadAvatar: (rendererUrl, signal) => loadRendererAvatar(rendererUrl, representationResolver, signal),
-          }),
+      // The loader stays lazy. Published URLs follow the old path, while an
+      // internal pack key resolves to Base VRM bytes + an assembly plan only
+      // after ThreeWorldRenderer actually asks for that actor.
+      loadAvatar: (rendererUrl, signal) => loadRendererAvatar(rendererUrl, representationResolver, signal),
     })
     const toViewport = (position: { x: number; y: number }) => { const rect = host.getBoundingClientRect(); return { x: rect.left + position.x, y: rect.top + position.y } }
     const renderer = registry.create(activeKind, { onEntitySelect, onObjectSelect, onReady, ...(onEntityContext === undefined ? {} : { onEntityContext: (id, position) => onEntityContext(id, toViewport(position)) }), ...(onObjectContext === undefined ? {} : { onObjectContext: (id, position) => onObjectContext(id, toViewport(position)) }) })

--- a/packages/web/src/features/world/avatar/avatar-representation-loader.ts
+++ b/packages/web/src/features/world/avatar/avatar-representation-loader.ts
@@ -28,7 +28,10 @@ export async function loadRendererAvatar(
   const packed = parsePackRendererUrl(rendererUrl)
   if (packed === undefined) {
     const { VrmActor } = await import('./vrm/VrmActor.js')
-    return VrmActor.load({ assetUrl: rendererUrl, signal })
+    return VrmActor.load({
+      assetUrl: rendererUrl,
+      ...(signal === undefined ? {} : { signal }),
+    })
   }
   const current = resolve(packed.employeeId)
   if (current === undefined || current.source !== 'base-pack' || current.key !== packed.key || current.assembly === undefined) {
@@ -39,7 +42,7 @@ export async function loadRendererAvatar(
     assetUrl: current.assetUrl,
     ...(current.cacheKey === undefined ? {} : { cacheKey: current.cacheKey }),
     assembly: current.assembly,
-    signal,
+    ...(signal === undefined ? {} : { signal }),
   })
 }
 

--- a/packages/web/src/features/world/avatar/avatar-representation-loader.ts
+++ b/packages/web/src/features/world/avatar/avatar-representation-loader.ts
@@ -1,0 +1,59 @@
+import type { VrmActor } from './vrm/VrmActor.js'
+import type { ResolvedAvatarRepresentation } from './avatar-representation.js'
+
+const PACK_URL_PREFIX = 'dsh-avatar-pack:'
+
+/**
+ * ThreeWorldRenderer currently uses one string as both "what representation is
+ * this?" and "what should I load?". Published VRMs are already real URLs. A
+ * shared assembled pack is not: its identity includes the recipe/pack version,
+ * while its bytes come from one shared Base VRM. This opaque internal key keeps
+ * hot-swap/failure de-duplication correct without exposing the pack source URL
+ * as if it were an employee-specific avatar.
+ */
+export function rendererAvatarUrl(
+  employeeId: string,
+  representation: ResolvedAvatarRepresentation | undefined,
+): string | undefined {
+  if (representation === undefined) return undefined
+  if (representation.source === 'published') return representation.assetUrl
+  return `${PACK_URL_PREFIX}${encodeURIComponent(employeeId)}:${encodeURIComponent(representation.key)}`
+}
+
+export async function loadRendererAvatar(
+  rendererUrl: string,
+  resolve: (employeeId: string) => ResolvedAvatarRepresentation | undefined,
+  signal?: AbortSignal,
+): Promise<VrmActor> {
+  const packed = parsePackRendererUrl(rendererUrl)
+  if (packed === undefined) {
+    const { VrmActor } = await import('./vrm/VrmActor.js')
+    return VrmActor.load({ assetUrl: rendererUrl, signal })
+  }
+  const current = resolve(packed.employeeId)
+  if (current === undefined || current.source !== 'base-pack' || current.key !== packed.key || current.assembly === undefined) {
+    throw new DOMException('角色 3D 表示已更新', 'AbortError')
+  }
+  const { VrmActor } = await import('./vrm/VrmActor.js')
+  return VrmActor.load({
+    assetUrl: current.assetUrl,
+    ...(current.cacheKey === undefined ? {} : { cacheKey: current.cacheKey }),
+    assembly: current.assembly,
+    signal,
+  })
+}
+
+export function parsePackRendererUrl(value: string): { employeeId: string; key: string } | undefined {
+  if (!value.startsWith(PACK_URL_PREFIX)) return undefined
+  const rest = value.slice(PACK_URL_PREFIX.length)
+  const split = rest.indexOf(':')
+  if (split <= 0 || split === rest.length - 1) return undefined
+  try {
+    return {
+      employeeId: decodeURIComponent(rest.slice(0, split)),
+      key: decodeURIComponent(rest.slice(split + 1)),
+    }
+  } catch {
+    return undefined
+  }
+}

--- a/packages/web/src/features/world/avatar/avatar-representation.ts
+++ b/packages/web/src/features/world/avatar/avatar-representation.ts
@@ -1,0 +1,208 @@
+import type { CharacterGender, JsonObject } from '@dsh-cyber/contracts'
+
+import {
+  avatarBasePacks,
+  assemblyPlanFor,
+  materialNamesFor,
+  type AvatarAssemblyPlan,
+  type AvatarBasePackManifest,
+  type AvatarMaterialSlotId,
+  type AvatarPartKind,
+} from './avatar-base-pack.js'
+import {
+  avatarRecipeForCharacter,
+  parseAvatarRecipe,
+  type AvatarBaseModel,
+  type AvatarRecipe,
+} from './avatar-recipe.js'
+
+/**
+ * A detailed 3D model is only an upgrade if the user can still recognise the
+ * same character. Hair and outfit are therefore hard identity gates rather
+ * than cosmetic bonus points.
+ */
+export const MIN_PRODUCTION_AVATAR_IDENTITY_SCORE = 0.78
+
+export interface AvatarPackIdentityMatch {
+  pack: AvatarBasePackManifest
+  plan: AvatarAssemblyPlan
+  score: number
+  criticalMissing: string[]
+  optionalMissing: string[]
+  eligible: boolean
+}
+
+export interface ResolvedAvatarRepresentation {
+  source: 'published' | 'base-pack'
+  /** Changes whenever the visual representation should be reloaded. */
+  key: string
+  assetUrl: string
+  cacheKey?: string
+  assembly?: { pack: AvatarBasePackManifest; plan: AvatarAssemblyPlan }
+  identityScore?: number
+}
+
+export interface CharacterRepresentationInput {
+  employeeId: string
+  role?: string | undefined
+  gender?: CharacterGender | undefined
+  fallbackAvatarIndex?: number | undefined
+  appearance?: JsonObject | undefined
+  /** A published employee-specific VRM always wins over a shared pack. */
+  publishedAvatarUrl?: string | undefined
+  /** Optional explicit installed pack preference stored by a future pack picker. */
+  preferredPackId?: string | undefined
+}
+
+export function resolveCharacterAvatarRepresentation(
+  input: CharacterRepresentationInput,
+  packs: readonly AvatarBasePackManifest[] = avatarBasePacks.list(),
+): ResolvedAvatarRepresentation | undefined {
+  if (input.publishedAvatarUrl !== undefined) {
+    return {
+      source: 'published',
+      key: `published:${input.publishedAvatarUrl}`,
+      assetUrl: input.publishedAvatarUrl,
+      cacheKey: `employee-avatar:${input.employeeId}:${input.publishedAvatarUrl}`,
+    }
+  }
+
+  const recipe = avatarRecipeForCharacter({
+    employeeId: input.employeeId,
+    role: input.role,
+    gender: input.gender,
+    fallbackAvatarIndex: input.fallbackAvatarIndex,
+    appearance: input.appearance,
+  })
+  const match = bestAvatarPackMatch(recipe, packs, input.preferredPackId)
+  if (match === undefined || !match.eligible) return undefined
+  return {
+    source: 'base-pack',
+    key: `base-pack:${match.pack.id}@${match.pack.version}:${recipeFingerprint(recipe)}`,
+    assetUrl: match.plan.assetUrl,
+    cacheKey: match.plan.cacheKey,
+    assembly: { pack: match.pack, plan: match.plan },
+    identityScore: match.score,
+  }
+}
+
+export function bestAvatarPackMatch(
+  recipeValue: AvatarRecipe,
+  packs: readonly AvatarBasePackManifest[],
+  preferredPackId?: string,
+): AvatarPackIdentityMatch | undefined {
+  const recipe = parseAvatarRecipe(recipeValue)
+  return packs
+    .filter((pack) => pack.quality === 'production')
+    .filter((pack) => preferredPackId === undefined || pack.id === preferredPackId)
+    .filter((pack) => pack.bases.some((base) => base.baseModel === recipe.baseModel))
+    .map((pack) => avatarPackIdentityMatch(pack, recipe))
+    .sort(compareMatches)[0]
+}
+
+export function avatarPackIdentityMatch(
+  pack: AvatarBasePackManifest,
+  recipeValue: AvatarRecipe,
+): AvatarPackIdentityMatch {
+  const recipe = parseAvatarRecipe(recipeValue)
+  const basePlan = assemblyPlanFor(pack, recipe)
+  // Rebuild visible names by kind. The v1 assembly helper accepts a flat id
+  // set, so a hair and outfit that happen to share an id could otherwise both
+  // turn on. Installed content is not allowed to exploit that ambiguity.
+  const plan: AvatarAssemblyPlan = {
+    ...basePlan,
+    visibleMeshNames: identityVisibleMeshes(pack, recipe),
+  }
+  const criticalMissing: string[] = []
+  const optionalMissing: string[] = []
+  let score = 0.30 // exact baseModel, already gated above
+
+  if (recipe.hair === undefined) score += 0.24
+  else if (hasPart(pack, recipe.baseModel, 'hair', recipe.hair)) score += 0.24
+  else criticalMissing.push(`hair:${recipe.hair}`)
+
+  if (recipe.outfit === undefined) score += 0.20
+  else if (hasPart(pack, recipe.baseModel, 'outfit', recipe.outfit)) score += 0.20
+  else criticalMissing.push(`outfit:${recipe.outfit}`)
+
+  const requestedColours: Array<[AvatarMaterialSlotId, string | undefined]> = [
+    ['skin', recipe.skinTone],
+    ['hair', recipe.hairColor],
+    ['outfit', recipe.outfitColor],
+    ['accent', recipe.accentColor],
+  ]
+  const colourRequests = requestedColours.filter(([, value]) => value !== undefined)
+  if (colourRequests.length === 0) score += 0.16
+  else {
+    const matched = colourRequests.filter(([slot]) => materialNamesFor(pack, slot).length > 0).length
+    score += 0.16 * matched / colourRequests.length
+    for (const [slot, value] of colourRequests) {
+      if (materialNamesFor(pack, slot).length === 0) optionalMissing.push(`${slot}:${value}`)
+    }
+  }
+
+  const accessories = recipe.accessoryIds ?? []
+  if (accessories.length === 0) score += 0.10
+  else {
+    const matched = accessories.filter((id) => hasPart(pack, recipe.baseModel, 'accessory', id)).length
+    score += 0.10 * matched / accessories.length
+    for (const id of accessories) {
+      if (!hasPart(pack, recipe.baseModel, 'accessory', id)) optionalMissing.push(`accessory:${id}`)
+    }
+  }
+
+  const normalized = Math.min(1, Math.max(0, Number(score.toFixed(4))))
+  return {
+    pack,
+    plan,
+    score: normalized,
+    criticalMissing,
+    optionalMissing,
+    eligible: criticalMissing.length === 0 && normalized >= MIN_PRODUCTION_AVATAR_IDENTITY_SCORE,
+  }
+}
+
+function identityVisibleMeshes(pack: AvatarBasePackManifest, recipe: AvatarRecipe): string[] {
+  const requests: Record<AvatarPartKind, Set<string>> = {
+    hair: new Set(recipe.hair === undefined ? [] : [recipe.hair]),
+    outfit: new Set(recipe.outfit === undefined ? [] : [recipe.outfit]),
+    accessory: new Set(recipe.accessoryIds ?? []),
+  }
+  const visible = pack.parts
+    .filter((part) => part.compatibleBaseModels === undefined || part.compatibleBaseModels.includes(recipe.baseModel))
+    .filter((part) => requests[part.kind].has(part.id))
+    .flatMap((part) => part.meshNames)
+  return [...new Set(visible)]
+}
+
+function hasPart(
+  pack: AvatarBasePackManifest,
+  baseModel: AvatarBaseModel,
+  kind: AvatarPartKind,
+  id: string,
+): boolean {
+  return pack.parts.some((part) => part.kind === kind
+    && part.id === id
+    && (part.compatibleBaseModels === undefined || part.compatibleBaseModels.includes(baseModel)))
+}
+
+function compareMatches(left: AvatarPackIdentityMatch, right: AvatarPackIdentityMatch): number {
+  if (left.eligible !== right.eligible) return left.eligible ? -1 : 1
+  if (left.score !== right.score) return right.score - left.score
+  if (left.pack.id !== right.pack.id) return left.pack.id.localeCompare(right.pack.id)
+  return right.pack.version.localeCompare(left.pack.version, undefined, { numeric: true, sensitivity: 'base' })
+}
+
+function recipeFingerprint(recipe: AvatarRecipe): string {
+  return [
+    recipe.baseModel,
+    recipe.build ?? '',
+    recipe.hair ?? '',
+    recipe.hairColor ?? '',
+    recipe.skinTone ?? '',
+    recipe.outfit ?? '',
+    recipe.outfitColor ?? '',
+    recipe.accentColor ?? '',
+    ...(recipe.accessoryIds ?? []),
+  ].join('|')
+}

--- a/packages/web/tests/avatar-representation-loader.test.ts
+++ b/packages/web/tests/avatar-representation-loader.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest'
+
+import { parsePackRendererUrl, rendererAvatarUrl } from '../src/features/world/avatar/avatar-representation-loader.js'
+
+describe('avatar representation renderer keys', () => {
+  it('leaves employee-published VRM URLs untouched', () => {
+    expect(rendererAvatarUrl('employee-1', {
+      source: 'published',
+      key: 'published:/api/avatar.vrm',
+      assetUrl: '/api/avatar.vrm',
+    })).toBe('/api/avatar.vrm')
+  })
+
+  it('turns a Base Pack assembly into an opaque renderer key rather than leaking its shared URL as identity', () => {
+    const url = rendererAvatarUrl('员工:A', {
+      source: 'base-pack',
+      key: 'base-pack:studio@1.0.0:female|bob|professional',
+      assetUrl: '/assets/shared-female.vrm',
+      cacheKey: 'avatar-pack:studio@1.0.0:female-a',
+      identityScore: 0.96,
+    })
+    expect(url).toMatch(/^dsh-avatar-pack:/u)
+    expect(url).not.toContain('/assets/shared-female.vrm')
+    expect(parsePackRendererUrl(url!)).toEqual({
+      employeeId: '员工:A',
+      key: 'base-pack:studio@1.0.0:female|bob|professional',
+    })
+  })
+
+  it('does not treat ordinary or malformed strings as pack renderer keys', () => {
+    expect(parsePackRendererUrl('/api/avatar.vrm')).toBeUndefined()
+    expect(parsePackRendererUrl('dsh-avatar-pack:missing-separator')).toBeUndefined()
+    expect(parsePackRendererUrl('dsh-avatar-pack:%E0%A4%A:key')).toBeUndefined()
+  })
+})

--- a/packages/web/tests/avatar-representation.test.ts
+++ b/packages/web/tests/avatar-representation.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it } from 'vitest'
+
+import type { AvatarBasePackManifest } from '../src/features/world/avatar/avatar-base-pack.js'
+import {
+  MIN_PRODUCTION_AVATAR_IDENTITY_SCORE,
+  avatarPackIdentityMatch,
+  bestAvatarPackMatch,
+  resolveCharacterAvatarRepresentation,
+} from '../src/features/world/avatar/avatar-representation.js'
+import { parseAvatarRecipe } from '../src/features/world/avatar/avatar-recipe.js'
+
+const matchingPack: AvatarBasePackManifest = {
+  schemaVersion: 1,
+  id: 'studio-v1',
+  version: '1.0.0',
+  displayName: 'Studio Avatar Pack',
+  license: 'CC0-1.0',
+  publisher: 'test',
+  quality: 'production',
+  bases: [
+    { baseModel: 'female-a', assetUrl: '/assets/avatars/female.vrm' },
+    { baseModel: 'neutral-a', assetUrl: '/assets/avatars/neutral.vrm' },
+  ],
+  parts: [
+    { id: 'long-layered', kind: 'hair', meshNames: ['Hair_Long'] },
+    { id: 'professional', kind: 'outfit', meshNames: ['Outfit_Professional'] },
+    // Intentional cross-kind id collision. Selecting hair must not enable this.
+    { id: 'long-layered', kind: 'outfit', meshNames: ['Outfit_Collision'] },
+    { id: 'glasses', kind: 'accessory', meshNames: ['Accessory_Glasses'] },
+  ],
+  materialSlots: [
+    { id: 'skin', materialNames: ['Skin'] },
+    { id: 'hair', materialNames: ['Hair'] },
+    { id: 'outfit', materialNames: ['Outfit'] },
+    { id: 'accent', materialNames: ['Accent'] },
+  ],
+}
+
+const violetProfessional = parseAvatarRecipe({
+  baseModel: 'female-a',
+  build: 'balanced',
+  hair: 'long-layered',
+  hairColor: '#7c3aed',
+  skinTone: '#d9a67f',
+  outfit: 'professional',
+  outfitColor: '#4338ca',
+  accentColor: '#c4b5fd',
+})
+
+describe('avatar production representation', () => {
+  it('accepts a production pack only when critical identity traits match', () => {
+    const match = avatarPackIdentityMatch(matchingPack, violetProfessional)
+    expect(match.eligible).toBe(true)
+    expect(match.score).toBeGreaterThanOrEqual(MIN_PRODUCTION_AVATAR_IDENTITY_SCORE)
+    expect(match.criticalMissing).toEqual([])
+    expect(match.plan.visibleMeshNames).toContain('Hair_Long')
+    expect(match.plan.visibleMeshNames).toContain('Outfit_Professional')
+    expect(match.plan.visibleMeshNames).not.toContain('Outfit_Collision')
+  })
+
+  it('rejects a detailed pack that cannot reproduce the character hair', () => {
+    const recipe = parseAvatarRecipe({ ...violetProfessional, hair: 'bob' })
+    const match = avatarPackIdentityMatch(matchingPack, recipe)
+    expect(match.eligible).toBe(false)
+    expect(match.criticalMissing).toEqual(['hair:bob'])
+  })
+
+  it('rejects a detailed pack that cannot reproduce the character outfit', () => {
+    const recipe = parseAvatarRecipe({ ...violetProfessional, outfit: 'analyst' })
+    const match = avatarPackIdentityMatch(matchingPack, recipe)
+    expect(match.eligible).toBe(false)
+    expect(match.criticalMissing).toEqual(['outfit:analyst'])
+  })
+
+  it('treats unavailable accessories as optional rather than silently inventing them', () => {
+    const recipe = parseAvatarRecipe({ ...violetProfessional, accessoryIds: ['badge'] })
+    const match = avatarPackIdentityMatch(matchingPack, recipe)
+    expect(match.criticalMissing).toEqual([])
+    expect(match.optionalMissing).toContain('accessory:badge')
+    expect(match.score).toBeLessThan(1)
+  })
+
+  it('never selects a preview pack for the live world', () => {
+    const preview: AvatarBasePackManifest = { ...matchingPack, id: 'preview', quality: 'preview' }
+    expect(bestAvatarPackMatch(violetProfessional, [preview])).toBeUndefined()
+  })
+
+  it('chooses the best identity match rather than the first registered pack', () => {
+    const incomplete: AvatarBasePackManifest = {
+      ...matchingPack,
+      id: 'aaa-incomplete',
+      parts: matchingPack.parts.filter((part) => part.kind !== 'hair'),
+    }
+    const match = bestAvatarPackMatch(violetProfessional, [incomplete, matchingPack])
+    expect(match?.pack.id).toBe('studio-v1')
+    expect(match?.eligible).toBe(true)
+  })
+
+  it('keeps an employee-specific published VRM above every shared Base Pack', () => {
+    const representation = resolveCharacterAvatarRepresentation({
+      employeeId: 'employee-1',
+      gender: 'female',
+      fallbackAvatarIndex: 0,
+      publishedAvatarUrl: '/api/assets/employee-1.vrm',
+    }, [matchingPack])
+    expect(representation).toMatchObject({
+      source: 'published',
+      assetUrl: '/api/assets/employee-1.vrm',
+    })
+  })
+
+  it('uses a matching pack when no employee-specific VRM exists', () => {
+    const representation = resolveCharacterAvatarRepresentation({
+      employeeId: 'employee-1',
+      gender: 'female',
+      fallbackAvatarIndex: 0,
+    }, [matchingPack])
+    expect(representation?.source).toBe('base-pack')
+    expect(representation?.assetUrl).toBe('/assets/avatars/female.vrm')
+    expect(representation?.assembly?.plan.visibleMeshNames).toContain('Hair_Long')
+    expect(representation?.identityScore).toBeGreaterThanOrEqual(MIN_PRODUCTION_AVATAR_IDENTITY_SCORE)
+  })
+
+  it('returns no 3D replacement instead of showing a high-quality stranger', () => {
+    const incompatible: AvatarBasePackManifest = {
+      ...matchingPack,
+      id: 'wrong-hair',
+      parts: matchingPack.parts.filter((part) => part.kind !== 'hair'),
+    }
+    const representation = resolveCharacterAvatarRepresentation({
+      employeeId: 'employee-1',
+      gender: 'female',
+      fallbackAvatarIndex: 0,
+    }, [incompatible])
+    expect(representation).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Why
The previous phase introduced the Avatar Base Pack assembly contract, but it was not yet part of the live 3D world and it had no product rule preventing a visually detailed but identity-incompatible model from replacing the exact 2D character.

## What changed
- add an identity-safe avatar representation layer with a hard production match threshold
- treat base model, hair family and outfit family as identity constraints rather than optional cosmetics
- score palette/material slots and accessories and expose missing-trait diagnostics
- rebuild visible variant meshes by part kind, preventing hair/outfit/accessory id collisions from enabling the wrong geometry
- keep employee-specific published VRM as the highest-priority representation
- generate opaque `dsh-avatar-pack:` renderer keys for assembled shared avatars so hot-swap/failure de-duplication follows the full recipe rather than only the shared Base VRM URL
- lazily resolve those keys into `VrmActor.load({ cacheKey, assembly })`; no second WebGL context and no Three import on the first screen
- let WorldCanvas derive a conservative Base Pack recipe from the same live `rosterIndex` used by the 2D world, while allowing a richer profile resolver to override it later
- keep the exact 2D identity when no production pack clears the identity threshold
- add regression coverage for match scoring, critical hair/outfit rejection, cross-kind id collisions, published-avatar precedence and opaque renderer keys

## Product rule
A high-quality stranger is not an upgrade. If a pack cannot reproduce the character's critical identity, the 3D world must keep the recognisable 2.5D portrait.

## Asset scope
This PR connects the production pack runtime to the live world but still does not bundle an unverified third-party VRM. A follow-up can install/license real Base Pack assets through the existing local package system without changing the renderer contract again.

## Validation
Require the full protected CI gate before merge: typecheck, build budget, unit/integration, migration/schema, Required smoke E2E and protected branch status.