### PR TITLE
feat: use embedded authored motion from official VRM

### DIFF
--- a/packages/web/scripts/verify-official-avatar-base-pack-runtime.mjs
+++ b/packages/web/scripts/verify-official-avatar-base-pack-runtime.mjs
@@ -14,6 +14,7 @@ const REQUIRED_BONES = [
   'leftUpperLeg', 'rightUpperLeg',
 ]
 const REQUIRED_VARIANT_NODES = ['Hair_Long', 'Hair_SidePart', 'Hair_TechCrop']
+const REQUIRED_EMBEDDED_MOTIONS = ['Idle_Loop', 'Walk_Loop', 'Idle_Talking_Loop', 'Interact']
 
 async function main() {
   const body = await readFile(VRM_PATH)
@@ -42,11 +43,18 @@ async function main() {
     throw new Error('Generated official avatar is missing the managed casual Base mesh')
   }
 
-  const animations = gltf.animations.map((clip) => clip.name).filter(Boolean)
+  const animationByName = new Map(gltf.animations.filter((clip) => clip.name).map((clip) => [clip.name, clip]))
+  for (const name of REQUIRED_EMBEDDED_MOTIONS) {
+    const clip = animationByName.get(name)
+    if (clip === undefined || clip.tracks.length === 0) {
+      throw new Error(`Generated official avatar is missing required embedded motion: ${name}`)
+    }
+  }
+  const animations = [...animationByName.keys()]
   console.log(`Production Web VRM loader accepted ${VRM_PATH}`)
   console.log(`Scene objects: ${names.size}`)
   console.log(`Embedded animation clips: ${animations.length}`)
-  if (animations.length > 0) console.log(`Animation names: ${animations.slice(0, 24).join(', ')}`)
+  if (animations.length > 0) console.log(`Animation names: ${animations.join(', ')}`)
 }
 
 main().catch((error) => {

--- a/packages/web/src/features/world/avatar/motion/embedded-motion-clips.ts
+++ b/packages/web/src/features/world/avatar/motion/embedded-motion-clips.ts
@@ -1,0 +1,48 @@
+import type { AnimationClip } from 'three'
+
+import type { DigitalHumanGesture } from '../../digital-human-motion.js'
+
+/**
+ * High-confidence semantic mappings for animations already embedded in a VRM.
+ *
+ * The official CC0 Base contains many game-oriented clips too. We intentionally
+ * do not map a kneeling repair, weapon pose or dance to office work merely
+ * because it moves more. A wrong authored motion is more distracting than the
+ * existing procedural fallback, so only names whose meaning matches the world
+ * gesture are eligible here.
+ */
+export const EMBEDDED_GESTURE_CLIP_CANDIDATES: Readonly<Record<DigitalHumanGesture, readonly string[]>> = {
+  breathe: ['Idle_Loop'],
+  walk: ['Walk_Loop', 'Walk_Formal_Loop'],
+  listen: ['Idle_Loop'],
+  explain: ['Idle_Talking_Loop'],
+  present: ['Interact'],
+  hold: ['Idle_Loop'],
+  // Failure is primarily communicated by expression/state. Keeping a real
+  // neutral idle here avoids snapping into T-pose or a game-like death clip.
+  freeze: ['Idle_Loop'],
+}
+
+export interface EmbeddedMotionClip {
+  gesture: DigitalHumanGesture
+  clip: AnimationClip
+}
+
+/** Selects at most one embedded authored clip for every world gesture. */
+export function selectEmbeddedMotionClips(animations: readonly AnimationClip[]): EmbeddedMotionClip[] {
+  const byName = new Map<string, AnimationClip>()
+  for (const clip of animations) {
+    const name = clip.name.trim()
+    if (name !== '' && !byName.has(name)) byName.set(name, clip)
+  }
+
+  const selected: EmbeddedMotionClip[] = []
+  for (const [gesture, candidates] of Object.entries(EMBEDDED_GESTURE_CLIP_CANDIDATES) as Array<[
+    DigitalHumanGesture,
+    readonly string[],
+  ]>) {
+    const clip = candidates.map((name) => byName.get(name)).find((item): item is AnimationClip => item !== undefined)
+    if (clip !== undefined) selected.push({ gesture, clip })
+  }
+  return selected
+}

--- a/packages/web/src/features/world/avatar/vrm/VrmActor.ts
+++ b/packages/web/src/features/world/avatar/vrm/VrmActor.ts
@@ -1,8 +1,9 @@
 import type { VRM } from '@pixiv/three-vrm'
-import type { Object3D } from 'three'
+import type { AnimationClip, Object3D } from 'three'
 
 import type { DigitalHumanMotionCue, DigitalHumanVisualState } from '../../digital-human-motion.js'
 import type { AvatarAssemblyPlan, AvatarBasePackManifest } from '../avatar-base-pack.js'
+import { selectEmbeddedMotionClips } from '../motion/embedded-motion-clips.js'
 import { declaredMotionSources, loadMotionClips } from '../motion/load-motion-clips.js'
 import { applyAvatarAssembly } from './apply-avatar-assembly.js'
 import { VrmAnimationController } from './VrmAnimationController.js'
@@ -74,7 +75,11 @@ export class VrmActor {
   #springFrame = 0
   #disposed = false
 
-  private constructor(vrm: VRM, onDispose?: () => void) {
+  private constructor(
+    vrm: VRM,
+    onDispose?: () => void,
+    embeddedAnimations: readonly AnimationClip[] = [],
+  ) {
     this.vrm = vrm
     this.root = vrm.scene
     this.#motion = new VrmMotionController(vrm)
@@ -83,6 +88,9 @@ export class VrmActor {
     this.#blink = new VrmBlinkController(vrm)
     this.#speech = new VrmSpeechController(vrm)
     this.#animation = new VrmAnimationController(vrm.scene)
+    for (const { gesture, clip } of selectEmbeddedMotionClips(embeddedAnimations)) {
+      this.#animation.register(gesture, clip)
+    }
     this.#onDispose = onDispose
   }
 
@@ -137,7 +145,7 @@ export class VrmActor {
     return new VrmActor(vrm, () => {
       disposeVrmScene(vrm.scene)
       releaseBytes()
-    })
+    }, gltf.animations)
   }
 
   /**
@@ -145,11 +153,17 @@ export class VrmActor {
    * three-vrm-animation; the bundled offline pack uses semantic Humanoid bone
    * tracks and is retargeted by our loader. Procedural bones remain only the
    * fallback for a gesture a pack genuinely does not provide.
+   *
+   * Embedded clips belong to the avatar itself, so they win over the generic
+   * default motion pack. An explicitly supplied world/theme motion library is
+   * still authoritative and may intentionally replace them.
    */
   async loadDeclaredMotion(
     library?: Parameters<typeof declaredMotionSources>[0],
   ): Promise<{ registered: number; failures: number }> {
-    const sources = declaredMotionSources(library)
+    const explicitLibrary = library !== undefined
+    const sources = declaredMotionSources(library).filter((source) =>
+      explicitLibrary || !this.#animation.hasGesture(source.gesture))
     if (sources.length === 0) return { registered: 0, failures: 0 }
     const result = await loadMotionClips(this.vrm, sources)
     if (this.#disposed) {
@@ -165,8 +179,12 @@ export class VrmActor {
   }
 
   /** Wraps an already-loaded VRM, useful for tests and specialized caches. */
-  static fromLoaded(vrm: VRM, onDispose?: () => void): VrmActor {
-    return new VrmActor(vrm, onDispose)
+  static fromLoaded(
+    vrm: VRM,
+    onDispose?: () => void,
+    embeddedAnimations: readonly AnimationClip[] = [],
+  ): VrmActor {
+    return new VrmActor(vrm, onDispose, embeddedAnimations)
   }
 
   /**

--- a/packages/web/src/features/world/avatar/vrm/VrmAnimationController.ts
+++ b/packages/web/src/features/world/avatar/vrm/VrmAnimationController.ts
@@ -10,7 +10,9 @@ export class VrmAnimationController {
 
   constructor(root: Object3D) { this.#mixer = new AnimationMixer(root) }
 
-  register(gesture: DigitalHumanGesture, clip: AnimationClip): void { this.#actions.set(gesture, this.#mixer.clipAction(clip)) }
+  register(gesture: DigitalHumanGesture, clip: AnimationClip): void {
+    this.#actions.set(gesture, this.#mixer.clipAction(clip))
+  }
 
   hasGesture(gesture: DigitalHumanGesture): boolean {
     return this.#actions.has(gesture)
@@ -18,10 +20,19 @@ export class VrmAnimationController {
 
   setGesture(gesture: DigitalHumanGesture): void {
     const next = this.#actions.get(gesture)
-    if (next === undefined || next === this.#current) return
+    if (next === this.#current) return
     const duration = DEFAULT_MOTION_LIBRARY[gesture].transitionMs / 1_000
+    if (next === undefined) {
+      // A missing authored gesture means the procedural controller owns the
+      // primary pose. Do not leave the previous authored walk/talk looping
+      // underneath it forever.
+      this.#current?.fadeOut(duration)
+      this.#current = undefined
+      return
+    }
     next.reset().play()
     if (this.#current !== undefined) this.#current.crossFadeTo(next, duration, true)
+    else next.fadeIn(duration)
     this.#current = next
   }
 

--- a/packages/web/tests/embedded-motion-clips.test.ts
+++ b/packages/web/tests/embedded-motion-clips.test.ts
@@ -1,0 +1,54 @@
+import { AnimationClip } from 'three'
+import { describe, expect, it } from 'vitest'
+
+import {
+  EMBEDDED_GESTURE_CLIP_CANDIDATES,
+  selectEmbeddedMotionClips,
+} from '../src/features/world/avatar/motion/embedded-motion-clips.js'
+
+describe('embedded VRM motion selection', () => {
+  it('maps only semantically trustworthy office gestures from the official clip set', () => {
+    const animations = [
+      'Idle_Loop',
+      'Walk_Loop',
+      'Idle_Talking_Loop',
+      'Interact',
+      'Fixing_Kneeling',
+      'Dance_Loop',
+      'Pistol_Shoot',
+      'Death01',
+    ].map((name) => new AnimationClip(name, 1, []))
+
+    const selected = selectEmbeddedMotionClips(animations)
+    expect(Object.fromEntries(selected.map(({ gesture, clip }) => [gesture, clip.name]))).toEqual({
+      breathe: 'Idle_Loop',
+      walk: 'Walk_Loop',
+      listen: 'Idle_Loop',
+      explain: 'Idle_Talking_Loop',
+      present: 'Interact',
+      hold: 'Idle_Loop',
+      freeze: 'Idle_Loop',
+    })
+    expect(selected.some(({ clip }) => /Fixing|Dance|Pistol|Death/u.test(clip.name))).toBe(false)
+  })
+
+  it('uses the formal walk only as an honest fallback when the normal walk is absent', () => {
+    const selected = selectEmbeddedMotionClips([
+      new AnimationClip('Idle_Loop', 1, []),
+      new AnimationClip('Walk_Formal_Loop', 1, []),
+    ])
+    expect(selected.find(({ gesture }) => gesture === 'walk')?.clip.name).toBe('Walk_Formal_Loop')
+  })
+
+  it('keeps the candidate table complete for every runtime gesture', () => {
+    expect(Object.keys(EMBEDDED_GESTURE_CLIP_CANDIDATES).sort()).toEqual([
+      'breathe',
+      'explain',
+      'freeze',
+      'hold',
+      'listen',
+      'present',
+      'walk',
+    ])
+  })
+})

--- a/packages/web/tests/vrm-embedded-motion-priority.test.ts
+++ b/packages/web/tests/vrm-embedded-motion-priority.test.ts
@@ -1,0 +1,49 @@
+import { AnimationClip, Group, Object3D } from 'three'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { VrmActor } from '../src/features/world/avatar/vrm/VrmActor.js'
+
+afterEach(() => vi.unstubAllGlobals())
+
+describe('VrmActor embedded authored motion', () => {
+  it('uses a complete embedded gesture set without downloading the generic motion pack', async () => {
+    const fetchSpy = vi.fn()
+    vi.stubGlobal('fetch', fetchSpy)
+    const actor = VrmActor.fromLoaded(fakeVrm() as never, () => {}, [
+      new AnimationClip('Idle_Loop', 1, []),
+      new AnimationClip('Walk_Loop', 1, []),
+      new AnimationClip('Idle_Talking_Loop', 1, []),
+      new AnimationClip('Interact', 1, []),
+    ])
+
+    await expect(actor.loadDeclaredMotion()).resolves.toEqual({ registered: 0, failures: 0 })
+    expect(fetchSpy).not.toHaveBeenCalled()
+    actor.dispose()
+  })
+})
+
+function fakeVrm() {
+  const scene = new Group()
+  const bones = new Map<string, Object3D>()
+  for (const name of ['spine', 'leftUpperArm', 'rightUpperArm', 'head']) {
+    const bone = new Object3D()
+    bone.name = `bone-${name}`
+    scene.add(bone)
+    bones.set(name, bone)
+  }
+  return {
+    scene,
+    humanoid: {
+      getNormalizedBoneNode: (name: string) => bones.get(name),
+      getRawBoneNode: () => undefined,
+    },
+    expressionManager: {
+      setValue: () => {},
+      getValue: () => 0,
+      expressions: [],
+      getExpression: () => undefined,
+    },
+    lookAt: { target: undefined, update: () => {} },
+    update: () => {},
+  }
+}


### PR DESCRIPTION
## Goal
Make the official 6.09 MiB VRM use its own authored AnimationClips as the primary body motion instead of immediately falling back to the generic procedural/self-authored motion pack.

## Scope
- map only semantically trustworthy embedded clips: `Idle_Loop`, `Walk_Loop`, `Idle_Talking_Loop`, `Interact`
- use embedded clips for breathe/walk/listen/explain/present/hold/failure-neutral-idle
- do **not** mislabel game-oriented clips such as kneeling repair, weapon, dance or death as office typing/thinking
- embedded avatar motion beats the generic default motion pack, while an explicitly supplied theme/world motion library may still override it
- if an authored gesture disappears, fade the previous authored action out so procedural fallback does not run underneath a stale looping walk/talk
- require the official production VRM to keep the embedded office motion clips in its production-loader verification gate
- add regressions proving a complete embedded gesture set causes no extra generic motion-pack fetch

## Merge gate
Keep this PR draft until the latest HEAD passes Typecheck, full Unit/Integration, Migration/Schema, 19/19 Required Smoke, official CC0 pack rebuild + production VRM parse, and protected `CI / required`. Do not start outfit/identity work before this PR is merged.