### PR TITLE
feat: put the world's stable rules into the cacheable prefix

### DIFF
--- a/docs/architecture/magic-context-v1.md
+++ b/docs/architecture/magic-context-v1.md
@@ -28,7 +28,7 @@ Magic Context 的目标不是“压缩提示词”，而是把上下文变成一
 | 层 | 内容 | 变动频率 |
 | --- | --- | --- |
 | `stableIdentity` | 人格、角色资料、世界职权、会话权限、已授权工作方法 | 只随 revision 变 |
-| `worldContext` | 世界运行时上下文（仍由 `WorldRuntimeContextComposer` 贡献） | 低 |
+| `worldContext` | 世界稳定规则：世界观、场景、用户身份、隔离规则、回复语言、本 lane 的身份说明（由 `WorldSettingsService.composeWorldContext` 渲染，`CharacterProfileRuntime` 放进前缀并计入 `stablePrefixHash`；每次请求真正变化的知识检索仍由 `WorldRuntimeContextComposer` 放在请求里） | 只随世界设置 revision 变 |
 | `taskContext` | 路由后的 `TaskCollaborationPlan`：目标、步骤、依赖、已完成步骤、相关产物 | 随计划版本 |
 | `memoryIndex` | 本回合“能想起什么”的清单：memoryId、日期、scope | 每回合 |
 | `retrievedMemories` | 命中记忆的摘要，必要时附带 `[记忆原文]` 水合块 | 每回合 |

--- a/packages/contracts/src/context-envelope.ts
+++ b/packages/contracts/src/context-envelope.ts
@@ -258,7 +258,7 @@ export function composeContextEnvelope(input: ComposeContextEnvelopeInput): Cont
     ...(input.retrievedMemories === undefined ? {} : { retrievedMemories: input.retrievedMemories }),
     ...(input.recentConversation === undefined ? {} : { recentConversation: input.recentConversation }),
     currentRequest: input.currentRequest,
-    stableContextHash: stableContextHash(input.stableIdentity),
+    stableContextHash: stableContextHash(input.stableIdentity, input.worldContext),
     ...(input.promptCache === undefined ? {} : { promptCache: input.promptCache }),
     totalTokenEstimate: 0,
   }
@@ -282,8 +282,21 @@ export function contextEnvelopeLayers(envelope: ContextEnvelope): ContextLayer[]
   })
 }
 
-export function stableContextHash(identity: ContextLayer): string {
-  return contextContentHash([identity.kind, identity.id, identity.contentHash])
+/**
+ * Cache identity of the prefix: the identity layer plus, when present, the
+ * world context. Both are properties of the character and its world, not of
+ * the turn, which is what lets them sit in front of every dynamic layer.
+ *
+ * An envelope without world context hashes exactly as it did before the layer
+ * joined the prefix, so nothing that recorded a hash earlier is invalidated.
+ */
+export function stableContextHash(identity: ContextLayer, worldContext?: ContextLayer): string {
+  return contextContentHash([
+    identity.kind,
+    identity.id,
+    identity.contentHash,
+    ...(worldContext === undefined ? [] : [worldContext.kind, worldContext.id, worldContext.contentHash]),
+  ])
 }
 
 function normalizeSkillInstructions(

--- a/packages/contracts/tests/prompt-cache.test.ts
+++ b/packages/contracts/tests/prompt-cache.test.ts
@@ -141,3 +141,65 @@ describe('prompt cache policy', () => {
     expect(promptCacheKey(policy)).toBeUndefined()
   })
 })
+
+describe('world context in the cacheable prefix', () => {
+  const WORLD_RULES = [
+    '[当前世界设定]',
+    '世界观：雨夜学院的每一条结论都要附上出处。',
+    '当前世界与其他世界的数据、文件、记忆相互隔离。',
+  ].join('\n')
+
+  function worldContext(text: string, revision: string): ContextLayer {
+    return composeContextLayer({
+      id: 'world-context:world-1',
+      kind: 'world-context',
+      revision,
+      text,
+      sourceRefs: [{ kind: 'world', id: 'world-1', revision }],
+    })
+  }
+
+  it('folds the world rules into the prefix hash, so a settings edit moves the cache identity', () => {
+    const stableIdentity = identity()
+    const before = composeContextEnvelope({
+      stableIdentity,
+      worldContext: worldContext(WORLD_RULES, '1'),
+      currentRequest: composeContextLayer({ id: 'request:1', kind: 'current-request', text: '第一轮' }),
+    })
+    const after = composeContextEnvelope({
+      stableIdentity,
+      worldContext: worldContext(`${WORLD_RULES}\n新增：讲解引用的事实保留来源。`, '2'),
+      currentRequest: composeContextLayer({ id: 'request:2', kind: 'current-request', text: '第二轮' }),
+    })
+    const none = composeContextEnvelope({
+      stableIdentity,
+      currentRequest: composeContextLayer({ id: 'request:3', kind: 'current-request', text: '第三轮' }),
+    })
+
+    expect(before.stableContextHash).toBe(stableContextHash(stableIdentity, before.worldContext))
+    expect(after.stableContextHash).not.toBe(before.stableContextHash)
+    expect(none.stableContextHash).not.toBe(before.stableContextHash)
+    // An envelope without world context hashes exactly as it did before the layer existed.
+    expect(none.stableContextHash).toBe(stableContextHash(stableIdentity))
+  })
+
+  it('keeps the prefix hash fixed across turns that only move dynamic layers', () => {
+    const stableIdentity = identity()
+    const turn = (index: number) => composeContextEnvelope({
+      stableIdentity,
+      worldContext: worldContext(WORLD_RULES, '1'),
+      recentConversation: composeContextLayer({
+        id: 'recent-conversation:session-1',
+        kind: 'recent-conversation',
+        text: `${index} · 用户：第 ${index} 轮请求`,
+      }),
+      currentRequest: composeContextLayer({ id: `request:${index}`, kind: 'current-request', text: `第 ${index} 轮` }),
+    })
+    const first = turn(1)
+    const second = turn(2)
+    expect(second.currentRequest.contentHash).not.toBe(first.currentRequest.contentHash)
+    expect(second.stableContextHash).toBe(first.stableContextHash)
+    expect(contextEnvelopeLayers(second).map((layer) => layer.kind).slice(0, 2))
+      .toEqual(['stable-identity', 'world-context'])
+  })
+})

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -86,6 +86,8 @@ interface EmployeeLane {
   permissionMode: AgentPermissionMode | undefined
   /** The directory this lane's runtime was started in. */
   workspacePath: string | undefined
+  /** The persona this lane's runtime was started with; it is the process's system prompt. */
+  persona: string | undefined
   runtime: HarnessRuntime | undefined
   agentSessionId: string | undefined
   current: LaneTask | undefined
@@ -206,9 +208,15 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
     // running after the owner revokes a file permission would keep the
     // directory it was given. Both halves of the sandbox have to invalidate
     // the lane, not just the permission mode.
+    //
+    // The persona is fixed the same way: it is bound as the process's system
+    // prompt, and it now carries the world's stable rules. A lane that kept
+    // running after the owner edited those rules (or the persona itself)
+    // would keep answering under the old ones.
     if (
       (lane.permissionMode !== undefined && lane.permissionMode !== permissionMode) ||
-      (lane.workspacePath !== undefined && lane.workspacePath !== workspacePath)
+      (lane.workspacePath !== undefined && lane.workspacePath !== workspacePath) ||
+      (lane.persona !== undefined && lane.persona !== request.revision.persona)
     ) {
       // Permission is lane-local. Changing a private chat from read-only to
       // workspace-write must not tear down the same employee's group lane.
@@ -236,6 +244,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       }
       lane.permissionMode = permissionMode
       lane.workspacePath = workspacePath
+      lane.persona = request.revision.persona
       lane.runtime = runtime
     }
     // The 0.1.2-alpha.3 SDK server creates its session through
@@ -313,6 +322,7 @@ export class HarnessCompatibilityAdapter implements AgentRuntimePort, AsyncDispo
       conversationId,
       permissionMode: undefined,
       workspacePath: undefined,
+      persona: undefined,
       runtime: undefined,
       agentSessionId: undefined,
       current: undefined,

--- a/packages/harness-adapter/tests/adapter.test.ts
+++ b/packages/harness-adapter/tests/adapter.test.ts
@@ -701,6 +701,31 @@ describe('Harness profile and adapter', () => {
     expect(closes).toBe(3)
   })
 
+  it('restarts an employee runtime when the persona it was started with changes', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-persona-'))
+    const personas: string[] = []
+    let closes = 0
+    const adapter = new HarnessCompatibilityAdapter({
+      stateRoot,
+      runtimeFactory(spec) {
+        personas.push(spec.revision.persona)
+        return { run: async () => ({ finalResponse: 'ok', notifications: [] }), close: async () => { closes += 1 } }
+      },
+    })
+    const edited = { ...revision(), persona: `${revision().persona}\n\n[当前世界设定]\n世界观：雨夜学院，结论必须附出处。` }
+    const base = { employee: employee(), conversationId: 'conversation-direct', history: [], observedThroughSequence: 0, workspacePath: stateRoot, permissionMode: 'read-only' as const }
+    await adapter.runEmployeeTurn({ ...base, revision: revision(), prompt: '第一轮' })
+    await adapter.runEmployeeTurn({ ...base, revision: revision(), prompt: '第二轮' })
+    // The persona is the system prompt of the lane's process, bound when it
+    // starts: a lane that kept running after the world rules or the persona
+    // changed would keep answering under the old ones.
+    await adapter.runEmployeeTurn({ ...base, revision: edited, prompt: '第三轮' })
+    expect(personas).toEqual([revision().persona, edited.persona])
+    expect(closes).toBe(1)
+    await adapter.close()
+    expect(closes).toBe(2)
+  })
+
   it('checks candidate Harness packages in an isolated profile without switching the active runtime', async () => {
     const directory = await mkdtemp(join(tmpdir(), 'dsh-cyber-candidate-'))
     const candidateRoot = join(directory, 'candidate')

--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -45,7 +45,7 @@ import type { WorldPackageInstanceService } from '../services/world-package-inst
 import type { OwnerRuntimeAccessService } from '../services/owner-runtime-access-service.js'
 import type { WorldRuntimePermissionResolver } from '../services/world-runtime-permission-resolver.js'
 import type { TurnAwareApprovalContinuationService } from '../services/turn-aware-approval-continuation-service.js'
-import type { WorldRuntimePromptComposer } from '../services/world-runtime-context-composer.js'
+import { WorldRuntimeContextComposer, type WorldRuntimePromptComposer } from '../services/world-runtime-context-composer.js'
 import { ServiceError } from '../services/service-error.js'
 import type { GroupTaskCollaborationService } from '../services/group-task-collaboration-service.js'
 import type { GroupTaskRoutingResult } from '../services/group-task-router.js'
@@ -92,7 +92,10 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     worldAccess,
     worldFiles,
     worldSettings,
-    runtimeContext = worldSettings,
+    // The world's stable rules no longer travel in the request: the runtime
+    // renders them into the cacheable prefix, so a caller without contributors
+    // gets the bare request composer rather than the settings service.
+    runtimeContext = new WorldRuntimeContextComposer(),
     worldTrace,
     employeeActivity,
     worldPackages,

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -296,7 +296,10 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
     ...(activeDshBinPath === undefined ? {} : { dshBinPath: activeDshBinPath }),
     resolveRoute(request) { return resolveHarnessRoute(store, request) },
   })
-  const profileRuntime = new CharacterProfileRuntime(baseRuntime, store, skillRegistry, authority, skillAvailability)
+  // World settings are the source of the envelope's `world-context` layer: the
+  // runtime renders them into the cacheable prefix, so the request composers
+  // below no longer repeat them behind the retrieved memories.
+  const profileRuntime = new CharacterProfileRuntime(baseRuntime, store, skillRegistry, authority, skillAvailability, undefined, undefined, worldSettings)
   const contextRuntime = new ContextPlanningRuntime(profileRuntime, (request) => contextModelLimits(resolveHarnessRoute(store, request)))
   const runtime = new TurnInteractionLoggingRuntime({
     inner: contextRuntime,
@@ -339,7 +342,6 @@ export async function createCyberServer(options: CyberServerOptions): Promise<Cy
   publishDecisionChanged = (worldId, payload) => worldRuntime.publishDecisionChanged(worldId, payload)
   const toolApprovals = new HarnessToolApprovalService({ store, runtime, onChanged: (worldId, payload) => publishDecisionChanged?.(worldId, payload) })
   const worldRuntimeContext = new WorldRuntimeContextComposer({
-    settings: worldSettings,
     contributors: [knowledgeGraphRuntime.contributor, new WorldKnowledgeRuntimeContextContributor(
       new WorldKnowledgeRetrievalService({ search: worldKnowledgeSearch }),
       (input, context) => {

--- a/packages/server/src/services/character-profile-runtime.ts
+++ b/packages/server/src/services/character-profile-runtime.ts
@@ -3,10 +3,13 @@ import type {
   AgentRuntimeEvent,
   AgentRuntimePort,
   AgentTurnRequest,
+  ContextLayer,
+  EmployeeInstance,
   EmployeeProfile,
   JsonObject,
   WorkMessage,
 } from '@dsh-cyber/contracts'
+import { composeContextLayer } from '@dsh-cyber/contracts'
 import type { SqliteStore } from '@dsh-cyber/persistence'
 import type { CharacterSkillAdapterRegistry } from '../skills/skill-adapter.js'
 import type { WorldCharacterAuthority } from '@dsh-cyber/contracts/world-authority'
@@ -16,7 +19,9 @@ import {
   type CharacterMemoryContextPort,
 } from './employee-conversation-memory-service.js'
 import {
+  conversationLane,
   defaultConversationContextComposer,
+  type ContextConversationLane,
   type ConversationContextComposer,
   type ConversationMemoryLayersPort,
 } from './conversation-context-composer.js'
@@ -52,6 +57,23 @@ type CharacterRuntimeStore = Pick<
 const OBSERVED_THROUGH_KEY = 'contextObservedThroughSequence'
 const OBSERVATION_VERSION_KEY = 'contextObservationVersion'
 
+/**
+ * Where the world's stable rules come from.
+ *
+ * The text must be a function of durable world facts and the lane alone -
+ * `WorldSettingsService` renders lore, scenario, user identity, isolation and
+ * response language from `settings.json` - because it is placed in the
+ * cacheable prefix and hashed there. A source that read a clock or a counter
+ * would silently defeat the cache on every turn.
+ */
+export interface WorldContextPort {
+  composeWorldContext(input: {
+    worldId: string
+    character: EmployeeInstance
+    lane: ContextConversationLane
+  }): Promise<{ text: string; revision: number }>
+}
+
 export class CharacterProfileRuntime implements AgentRuntimePort {
   readonly #inner: AgentRuntimePort
   readonly #store: CharacterRuntimeStore
@@ -61,6 +83,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
   readonly #memory: CharacterMemoryContextPort | undefined
   readonly #context: ConversationContextComposer | undefined
   readonly #snapshots: ContextSnapshotService | undefined
+  readonly #worldContext: WorldContextPort | undefined
   /**
    * What the Context Inspector reads back.
    *
@@ -80,12 +103,14 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
     skillAvailability?: WorldSkillAvailabilityPort,
     memory?: CharacterMemoryContextPort,
     inspection?: ContextInspectionService,
+    worldContext?: WorldContextPort,
   ) {
     this.#inner = inner
     this.#store = store
     this.#skills = skills
     this.#authority = authority
     this.#skillAvailability = skillAvailability
+    this.#worldContext = worldContext
     this.contextInspection = inspection ?? new ContextInspectionService()
     this.#memory = memory ?? defaultMemoryForStore(store)
     this.#context = defaultConversationContextComposer(
@@ -145,10 +170,16 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
       request.agentRunId,
       request.permissionMode ?? 'read-only',
     )
+    // The world's stable rules are a property of the world and the lane, not
+    // of the turn, so they are rendered once here and placed directly behind
+    // the identity: in the cacheable prefix, in front of every retrieved
+    // memory, instead of being re-sent behind them on every request.
+    const worldContext = await this.#composeWorldContext(agent, request.conversationId)
     const composed = await this.#context?.compose({
       employee: agent,
       persona: effectivePersona,
       personaRevision: revision.revision,
+      ...(worldContext === undefined ? {} : { worldContext }),
       conversationId: request.conversationId,
       prompt: turnPrompt,
       history: request.history ?? [],
@@ -223,7 +254,12 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
         // Keep historical unavailable grants durable, but do not expose them
         // to the model prompt or downstream Harness runtime for this turn.
         skillGrants: grantedSkillIds,
-        persona: effectivePersona,
+        // The persona is what a provider adapter treats as the prefix (the
+        // Harness binds it as the system prompt), so the world context is
+        // rendered here, after the identity and before anything per-turn.
+        persona: worldContext === undefined
+          ? effectivePersona
+          : `${effectivePersona.trim()}\n\n${worldContext.text}`,
       },
     })
 
@@ -247,6 +283,32 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
     }
 
     return result
+  }
+
+  /**
+   * The `world-context` layer for this turn, or nothing when no world context
+   * source is composed (legacy embedders and unit tests keep their prompt).
+   *
+   * The lane is read from the durable session, never from the caller: a group
+   * turn gets the group identity note because its `WorkSession` is a group
+   * session, not because an entry point said so.
+   */
+  async #composeWorldContext(agent: EmployeeInstance, conversationId: string): Promise<ContextLayer | undefined> {
+    if (this.#worldContext === undefined) return undefined
+    const lane = conversationLane(this.#store.getSession?.(conversationId))
+    const rendered = await this.#worldContext.composeWorldContext({ worldId: agent.worldId, character: agent, lane })
+    if (!rendered.text.trim()) return undefined
+    const revision = String(rendered.revision)
+    return composeContextLayer({
+      id: `world-context:${agent.worldId}`,
+      kind: 'world-context',
+      revision,
+      text: rendered.text,
+      sourceRefs: [
+        { kind: 'world', id: agent.worldId, revision },
+        { kind: 'employee', id: agent.id },
+      ],
+    })
   }
 
   close(): Promise<void> {

--- a/packages/server/src/services/conversation-context-composer.ts
+++ b/packages/server/src/services/conversation-context-composer.ts
@@ -45,8 +45,10 @@ import {
  *
  * Two responsibilities stay outside on purpose:
  *
- * - World context is still contributed by `WorldRuntimeContextComposer` before
- *   the runtime sees the prompt, so this composer leaves that layer empty.
+ * - The world's stable rules are rendered by the caller (`CharacterProfileRuntime`
+ *   reads them from the world settings) and handed in as the `worldContext`
+ *   layer. The composer places that layer directly behind the identity and
+ *   folds it into the cacheable prefix; it never invents world facts itself.
  * - The *rendering* of the recent-conversation layer stays with the runtime
  *   lane, because only the lane knows what its live Agent session has already
  *   observed. The composer decides which turns are eligible; the lane may send
@@ -96,6 +98,12 @@ export interface ComposeTurnContextInput {
   /** The persona this turn will actually run with, already fully composed. */
   persona: string
   personaRevision?: number
+  /**
+   * The world's stable rules for this character, already rendered as a layer.
+   * Stable per world and character: it joins the cacheable prefix, so nothing
+   * that moves per turn may be put in it.
+   */
+  worldContext?: ContextLayer
   conversationId: string
   prompt: string
   history: readonly ConversationHistoryEntry[]
@@ -240,10 +248,11 @@ export class ConversationContextComposer {
       ? input.prompt
       : `${sections.join('\n\n')}\n\n[当前请求]\n${input.prompt}`
 
-    // The cacheable prefix is exactly the identity layer: persona, world stable
-    // rules and stable skill instructions, already folded into one deterministic
-    // string upstream. Everything the envelope adds after it is dynamic by
-    // construction, which is what makes the prefix worth a cache key at all.
+    // The cacheable prefix is the identity layer - persona, authority, permission
+    // guidance and stable skill instructions, already folded into one
+    // deterministic string upstream - followed by the world's stable rules.
+    // Everything the envelope adds after them is dynamic by construction,
+    // which is what makes the prefix worth a cache key at all.
     const stableIdentity = composeContextLayer({
       id: `identity:${input.employee.id}`,
       kind: 'stable-identity',
@@ -259,16 +268,18 @@ export class ConversationContextComposer {
       ],
     })
 
+    const worldContext = input.worldContext
     const envelope = composeContextEnvelope({
       stableIdentity,
+      ...(worldContext === undefined ? {} : { worldContext }),
       promptCache: derivePromptCachePolicy({
-        stablePrefixHash: stableContextHash(stableIdentity),
+        stablePrefixHash: stableContextHash(stableIdentity, worldContext),
         // Partitioned down to the character. Two characters whose prefixes are
         // byte-identical still never share one, because a cache partition is a
         // boundary and boundaries are not an optimisation.
         namespace: `${input.employee.worldId}/${input.employee.id}`,
         scope: 'employee',
-        stablePrefixTokens: stableIdentity.tokenEstimate,
+        stablePrefixTokens: stableIdentity.tokenEstimate + (worldContext?.tokenEstimate ?? 0),
         // A direct lane is the same character answering again tomorrow; a group
         // or task lane is assembled per collaboration and rarely reruns.
         retentionHint: lane === 'direct' ? 'long' : 'short',

--- a/packages/server/src/services/world-runtime-context-composer.ts
+++ b/packages/server/src/services/world-runtime-context-composer.ts
@@ -23,6 +23,17 @@ export interface RuntimeContextContributor {
   contribute(input: RuntimeContextInput): Promise<RuntimeContextSection | undefined> | RuntimeContextSection | undefined
 }
 
+/**
+ * Composes the per-turn request a runtime lane receives.
+ *
+ * The world's stable rules are deliberately *not* part of this output any
+ * more. They are rendered once per character and world as the envelope's
+ * `world-context` layer by `CharacterProfileRuntime`, so they sit in the
+ * cacheable prefix in front of the retrieved memories instead of being
+ * re-sent behind them on every turn. What is left here is what genuinely
+ * changes per request: the knowledge retrieved for this prompt and the
+ * prompt itself.
+ */
 export interface WorldRuntimePromptComposer {
   composeRuntimePrompt(worldId: string, character: EmployeeInstance, prompt: string): Promise<string>
   composeGroupRuntimePrompt(worldId: string, prompt: string): Promise<string>
@@ -33,29 +44,22 @@ export interface ComposedRuntimeContext {
   sections: RuntimeContextSection[]
 }
 
-/** Provider-neutral seam for world settings, identity, knowledge and facts. */
-export class WorldRuntimeContextComposer {
+/** Provider-neutral seam for per-request knowledge and facts. */
+export class WorldRuntimeContextComposer implements WorldRuntimePromptComposer {
   readonly #contributors: readonly RuntimeContextContributor[]
-  readonly #settings: WorldRuntimePromptComposer | undefined
 
   constructor(options: readonly RuntimeContextContributor[] | {
     contributors?: readonly RuntimeContextContributor[]
-    settings?: WorldRuntimePromptComposer
   } = []) {
-    const configured = Array.isArray(options)
-      ? undefined
-      : options as {
-          contributors?: readonly RuntimeContextContributor[]
-          settings?: WorldRuntimePromptComposer
-        }
-    const contributors = configured?.contributors ?? options as readonly RuntimeContextContributor[]
+    const contributors = Array.isArray(options)
+      ? options as readonly RuntimeContextContributor[]
+      : (options as { contributors?: readonly RuntimeContextContributor[] }).contributors ?? []
     const ids = new Set<string>()
     for (const contributor of contributors) {
       if (!contributor.id.trim() || ids.has(contributor.id)) throw new Error(`Duplicate runtime context contributor: ${contributor.id}`)
       ids.add(contributor.id)
     }
     this.#contributors = [...contributors]
-    this.#settings = configured?.settings
   }
 
   async compose(input: RuntimeContextInput): Promise<ComposedRuntimeContext> {
@@ -79,18 +83,12 @@ export class WorldRuntimeContextComposer {
 
   async composeRuntimePrompt(worldId: string, character: EmployeeInstance, prompt: string): Promise<string> {
     const contributed = await this.#contributedText({ worldId, characterId: character.id, prompt, group: false })
-    const request = [contributed, prompt.trim()].filter(Boolean).join('\n\n')
-    return this.#settings === undefined
-      ? ['[用户请求]', request].join('\n')
-      : this.#settings.composeRuntimePrompt(worldId, character, request)
+    return ['[用户请求]', [contributed, prompt.trim()].filter(Boolean).join('\n\n')].join('\n')
   }
 
   async composeGroupRuntimePrompt(worldId: string, prompt: string): Promise<string> {
     const contributed = await this.#contributedText({ worldId, prompt, group: true })
-    const request = [contributed, prompt.trim()].filter(Boolean).join('\n\n')
-    return this.#settings === undefined
-      ? ['[用户请求]', request].join('\n')
-      : this.#settings.composeGroupRuntimePrompt(worldId, request)
+    return ['[用户请求]', [contributed, prompt.trim()].filter(Boolean).join('\n\n')].join('\n')
   }
 
   async #contributedText(input: RuntimeContextInput): Promise<string> {

--- a/packages/server/src/services/world-settings-service.ts
+++ b/packages/server/src/services/world-settings-service.ts
@@ -3,6 +3,7 @@ import { open, readFile, rename } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import type { AgentPermissionMode, EmployeeInstance, ReasoningEffort, WorldSettings } from '@dsh-cyber/contracts'
+import type { ContextConversationLane } from './conversation-context-composer.js'
 import type { WorldRootService } from './world-root-service.js'
 
 const reasoning = new Set<ReasoningEffort>(['auto', 'off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'])
@@ -102,16 +103,37 @@ export class WorldSettingsService {
     return { settings: next, revision }
   }
 
-  async composeRuntimePrompt(worldId: string, character: EmployeeInstance, prompt: string): Promise<string> {
-    const settings = await this.get(worldId)
-    return `${worldHeader(settings)}\n${characterIdentity(character)}\n\n[用户请求]\n${prompt}`
-  }
-
-  async composeGroupRuntimePrompt(worldId: string, prompt: string): Promise<string> {
-    const settings = await this.get(worldId)
-    return `${worldHeader(settings)}\n多人会话中的每个角色都必须保持自己的当前身份、知识边界和立场，不替其他角色发言。角色的最新 Persona / Identity 优先于创建时模板中的旧岗位。\n\n[用户请求]\n${prompt}`
+  /**
+   * The world's stable rules for one character's turn: lore, scenario, the
+   * user's identity, the isolation rule and the response language, followed by
+   * the identity note for the lane the turn runs in.
+   *
+   * This is the `world-context` layer of the envelope, not a request. It reads
+   * nothing that moves per turn - no clock, no counter, no retrieval - so two
+   * turns of the same character in the same world render byte-identical text
+   * until the settings revision changes. That is what lets it sit in the
+   * cacheable prefix instead of behind the retrieved memories.
+   */
+  async composeWorldContext(input: {
+    worldId: string
+    character: EmployeeInstance
+    lane: ContextConversationLane
+  }): Promise<WorldContextText> {
+    const snapshot = await this.getSnapshot(input.worldId)
+    const identity = input.lane === 'direct' || input.lane === 'unknown'
+      ? characterIdentity(input.character)
+      : GROUP_IDENTITY_NOTE
+    return { text: `${worldHeader(snapshot.settings)}\n${identity}`, revision: snapshot.revision }
   }
 }
+
+export interface WorldContextText {
+  text: string
+  /** The world settings revision the text was rendered from. */
+  revision: number
+}
+
+const GROUP_IDENTITY_NOTE = '多人会话中的每个角色都必须保持自己的当前身份、知识边界和立场，不替其他角色发言。角色的最新 Persona / Identity 优先于创建时模板中的旧岗位。'
 
 /**
  * One in-flight settings write per world, shared by every service instance.

--- a/packages/server/tests/conversation-context-prompt-cache.test.ts
+++ b/packages/server/tests/conversation-context-prompt-cache.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path'
 
 import { afterEach, describe, expect, it } from 'vitest'
 import type { ConversationHistoryEntry, EmployeeBlueprint, EmployeeInstance } from '@dsh-cyber/contracts'
-import { CONTEXT_LAYER_ORDER, contextEnvelopeLayers, promptCacheKey } from '@dsh-cyber/contracts'
+import { CONTEXT_LAYER_ORDER, composeContextLayer, contextEnvelopeLayers, promptCacheKey } from '@dsh-cyber/contracts'
 import { SqliteStore } from '@dsh-cyber/persistence'
 
 import { ConversationContextComposer } from '../src/services/conversation-context-composer.js'
@@ -194,5 +194,46 @@ describe('conversation context prompt cache', () => {
     expect(composed.envelope.promptCache?.retentionHint).toBe('short')
     // The partition is the character, never the conversation's participants.
     expect(composed.envelope.promptCache?.namespace).toBe(`${employee.worldId}/${employee.id}`)
+  })
+
+  it('places the world rules in the prefix and hashes them there, so only a settings edit moves the key', async () => {
+    const { employee, session, composer } = await setup()
+    const rules = (revision: string, extra = '') => composeContextLayer({
+      id: `world-context:${employee.worldId}`,
+      kind: 'world-context',
+      revision,
+      text: [
+        '[当前世界设定]',
+        '世界观：雨夜学院的每一条结论都要附上出处。',
+        '当前世界与其他世界的数据、文件、记忆相互隔离。',
+        extra,
+      ].filter(Boolean).join('\n'),
+      sourceRefs: [{ kind: 'world', id: employee.worldId, revision }],
+    })
+    const base = { employee, persona: PERSONA, personaRevision: 1, conversationId: session.id, observedThroughSequence: 0 }
+
+    const first = await composer.compose({ ...base, worldContext: rules('1'), prompt: '第一轮请求', history: turnHistory(employee, 1) })
+    const second = await composer.compose({ ...base, worldContext: rules('1'), prompt: '完全不同的第二轮请求', history: turnHistory(employee, 4) })
+    const edited = await composer.compose({ ...base, worldContext: rules('2', '新增：讲解引用的事实保留来源。'), prompt: '第一轮请求', history: turnHistory(employee, 1) })
+    const bare = await composer.compose({ ...base, prompt: '第一轮请求', history: turnHistory(employee, 1) })
+
+    // The rules are the second layer, directly behind the identity, and the
+    // dynamic prompt body the lane renders never carries them.
+    const kinds = contextEnvelopeLayers(second.envelope).map((layer) => layer.kind)
+    expect(kinds.slice(0, 2)).toEqual(['stable-identity', 'world-context'])
+    expect(kinds).toEqual(CONTEXT_LAYER_ORDER.filter((kind) => kinds.includes(kind)))
+    expect(second.prompt).not.toContain('[当前世界设定]')
+
+    // Dynamic layers moved; the prefix did not.
+    expect(second.envelope.currentRequest.contentHash).not.toBe(first.envelope.currentRequest.contentHash)
+    expect(second.envelope.promptCache?.stablePrefixHash).toBe(first.envelope.promptCache?.stablePrefixHash)
+    expect(second.envelope.promptCache?.stablePrefixHash).toBe(second.envelope.stableContextHash)
+    expect(promptCacheKey(second.envelope.promptCache!)).toBe(promptCacheKey(first.envelope.promptCache!))
+
+    // The rules are part of the hashed prefix: editing them, or dropping them,
+    // is a different cache identity.
+    expect(edited.envelope.promptCache?.stablePrefixHash).not.toBe(first.envelope.promptCache?.stablePrefixHash)
+    expect(bare.envelope.promptCache?.stablePrefixHash).not.toBe(first.envelope.promptCache?.stablePrefixHash)
+    expect(bare.envelope.worldContext).toBeUndefined()
   })
 })

--- a/packages/server/tests/current-character-identity-prompt.test.ts
+++ b/packages/server/tests/current-character-identity-prompt.test.ts
@@ -26,13 +26,35 @@ describe('world prompt character identity boundary', () => {
       updatedAt: '2026-08-23T00:00:00.000Z',
     }
 
-    const prompt = await settings.composeRuntimePrompt(character.worldId, character, '陪我聊一会。')
+    const { text, revision } = await settings.composeWorldContext({ worldId: character.worldId, character, lane: 'direct' })
 
-    expect(prompt).toContain('持久角色“团子”')
-    expect(prompt).toContain('最新角色 Persona / Identity 契约')
-    expect(prompt).toContain('初始岗位只属于来源元数据')
-    expect(prompt).toContain('最终回复、可展示的判断摘要、计划和工具使用说明统一使用简体中文')
-    expect(prompt).not.toContain('身份为“秘书”')
-    expect(prompt).not.toContain('秘书')
+    expect(revision).toBe(0)
+    expect(text).toContain('持久角色“团子”')
+    expect(text).toContain('最新角色 Persona / Identity 契约')
+    expect(text).toContain('初始岗位只属于来源元数据')
+    expect(text).toContain('最终回复、可展示的判断摘要、计划和工具使用说明统一使用简体中文')
+    expect(text).not.toContain('身份为“秘书”')
+    expect(text).not.toContain('秘书')
+  })
+
+  it('renders the same rules byte-for-byte across turns and moves only with the settings revision', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-world-identity-'))
+    const settings = new WorldSettingsService(new WorldRootService(stateRoot))
+    const character = { id: 'character-1', worldId: 'world-1', displayName: '团子' } as EmployeeInstance
+
+    const first = await settings.composeWorldContext({ worldId: 'world-1', character, lane: 'direct' })
+    const again = await settings.composeWorldContext({ worldId: 'world-1', character, lane: 'direct' })
+    expect(again).toEqual(first)
+    // Nothing per-turn leaks into the layer: no clock, no counter.
+    expect(first.text).not.toMatch(/\d{4}-\d{2}-\d{2}T/)
+
+    await settings.save('world-1', { lore: '雨夜学院' })
+    const edited = await settings.composeWorldContext({ worldId: 'world-1', character, lane: 'direct' })
+    expect(edited.revision).toBe(first.revision + 1)
+    expect(edited.text).toContain('世界观：雨夜学院')
+
+    const group = await settings.composeWorldContext({ worldId: 'world-1', character, lane: 'group' })
+    expect(group.text).toContain('多人会话中的每个角色都必须保持自己的当前身份')
+    expect(group.text).not.toContain('持久角色“团子”')
   })
 })

--- a/packages/server/tests/turn-aware-approval-continuation.test.ts
+++ b/packages/server/tests/turn-aware-approval-continuation.test.ts
@@ -13,7 +13,7 @@ import { CharacterSkillRuntime } from '../src/services/character-skill-runtime.j
 import { TurnAwareApprovalContinuationService } from '../src/services/turn-aware-approval-continuation-service.js'
 import { WorldPackageInstanceService } from '../src/services/world-package-instance-service.js'
 import { WorldRootService } from '../src/services/world-root-service.js'
-import { WorldSettingsService } from '../src/services/world-settings-service.js'
+import { WorldRuntimeContextComposer } from '../src/services/world-runtime-context-composer.js'
 import { SqliteSkillActionRepository } from '../src/skills/sqlite-skill-action-repository.js'
 import { CharacterSkillAdapterRegistry, type CharacterSkillAdapter, type CharacterSkillMatchContext } from '../src/skills/skill-adapter.js'
 
@@ -174,7 +174,7 @@ async function setup() {
   const orchestrator = new ConversationOrchestrator({ store, runtime: agent, workspacePath: root })
   const worldRoots = new WorldRootService(root)
   const continuations = new TurnAwareApprovalContinuationService({
-    store, orchestrator, skills, settings: new WorldSettingsService(worldRoots),
+    store, orchestrator, skills, settings: new WorldRuntimeContextComposer(),
     worldPackages: new WorldPackageInstanceService(store, worldRoots),
   })
   return { store, workspaceId: workspace.id, worldId: world.id, employeeId: employee.id, adapter, agent, continuations }

--- a/packages/server/tests/world-context-prefix.test.ts
+++ b/packages/server/tests/world-context-prefix.test.ts
@@ -1,0 +1,260 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+import type {
+  AgentRuntimePort,
+  AgentTurnRequest,
+  ConversationHistoryEntry,
+  EmployeeBlueprint,
+  EmployeeInstance,
+  WorkSession,
+} from '@dsh-cyber/contracts'
+import { CONTEXT_LAYER_ORDER } from '@dsh-cyber/contracts'
+import { SqliteStore } from '@dsh-cyber/persistence'
+
+import { CharacterProfileRuntime } from '../src/services/character-profile-runtime.js'
+import { WorldRootService } from '../src/services/world-root-service.js'
+import { WorldRuntimeContextComposer } from '../src/services/world-runtime-context-composer.js'
+import { WorldSettingsService } from '../src/services/world-settings-service.js'
+
+/**
+ * D2.5 follow-up: the world's stable rules sit in the cacheable prefix.
+ *
+ * Before this slice the rules were the last thing in the prompt - inside the
+ * per-turn request, behind the volatile retrieved memories - and were never
+ * part of the hashed prefix. These tests pin the reordering from the only
+ * vantage point that matters: what the inner runtime is actually handed.
+ */
+
+const stores: SqliteStore[] = []
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close()
+})
+
+class CaptureRuntime implements AgentRuntimePort {
+  readonly requests: AgentTurnRequest[] = []
+
+  async runTurn(request: AgentTurnRequest) {
+    this.requests.push(request)
+    return { agentSessionId: 'agent-session', finalResponse: '好的。', eventCount: 0 }
+  }
+
+  async close(): Promise<void> {}
+}
+
+/** Long enough that the prefix is actually cacheable. */
+const PERSONA = [
+  '你是长期驻留在本世界的内容员工，只引用自己真实参与过的经历。',
+  '回答使用简洁中文，先给结论再给依据；不确定时直接说明不确定，不编造来源。',
+  '未获授权的世界数据一律不读取，也不推断其内容或替用户猜测。',
+  '每一轮都保持同一身份，不冒充其他角色，也不恢复创建时的旧模板身份。',
+].join('\n')
+
+const LORE = '雨夜学院：每一条结论都要附上可核对的出处，没有出处的说法标为待核实。'
+const SCENARIO = '期末周，学员们在图书馆通宵备考。'
+
+/** Every rule line the world header renders for this world. */
+const WORLD_RULES = [
+  '[当前世界设定]',
+  `世界观：${LORE}`,
+  `当前场景：${SCENARIO}`,
+  '用户在这个世界中的身份：洛（院长），请称呼用户为“院长”。',
+  '当前世界与其他世界的数据、文件、记忆相互隔离。',
+  '最终回复、可展示的判断摘要、计划和工具使用说明统一使用简体中文',
+]
+
+function blueprint(): EmployeeBlueprint {
+  return {
+    schemaVersion: 1,
+    id: 'prefix.worker',
+    version: 1,
+    worldTemplateId: 'personal-world',
+    displayName: '小林',
+    role: '内容员工',
+    summary: '负责测试世界规则进入缓存前缀',
+    persona: PERSONA,
+    requestedSkills: [],
+    requestedCapabilities: [],
+    createdAt: '2026-08-28T00:00:00.000Z',
+  }
+}
+
+async function setup() {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-world-context-prefix-'))
+  const store = await SqliteStore.open(join(root, 'cyber.sqlite'))
+  stores.push(store)
+  const workspace = store.createWorkspace({ name: '本地工作区' })
+  const world = store.createWorld({ workspaceId: workspace.id, name: '雨夜学院', templateId: 'personal-world' })
+  store.saveBlueprint(blueprint())
+  const employee = store.recruitEmployee({
+    workspaceId: workspace.id,
+    worldId: world.id,
+    blueprintId: 'prefix.worker',
+    blueprintVersion: 1,
+  })
+  const settings = new WorldSettingsService(new WorldRootService(join(root, 'worlds')))
+  await settings.save(world.id, {
+    lore: LORE,
+    scenario: SCENARIO,
+    userIdentity: { displayName: '洛', worldRole: '院长', addressAs: '院长' },
+  })
+  const inner = new CaptureRuntime()
+  const runtime = new CharacterProfileRuntime(inner, store, undefined, undefined, undefined, undefined, undefined, settings)
+  // The request is composed the way every entry point composes it.
+  const requests = new WorldRuntimeContextComposer({ contributors: [] })
+  return { store, workspace, world, employee, settings, inner, runtime, requests }
+}
+
+function session(store: SqliteStore, world: { id: string; workspaceId: string }, employee: EmployeeInstance, kind: WorkSession['kind']): WorkSession {
+  return store.createSession({
+    workspaceId: world.workspaceId,
+    worldId: world.id,
+    kind,
+    title: kind === 'direct' ? '私聊' : '协作',
+    participants: [
+      { participantId: 'owner', kind: 'owner' },
+      { participantId: employee.id, kind: 'employee' },
+    ],
+  })
+}
+
+function turnHistory(employee: EmployeeInstance, turns: number): ConversationHistoryEntry[] {
+  const entries: ConversationHistoryEntry[] = []
+  for (let index = 1; index <= turns; index += 1) {
+    entries.push({
+      role: 'user',
+      sequence: index * 2 - 1,
+      speakerId: 'owner',
+      speakerName: '用户',
+      content: `第 ${index} 轮请求`,
+      createdAt: `2026-08-28T00:${String(index).padStart(2, '0')}:00.000Z`,
+    })
+    entries.push({
+      role: 'assistant',
+      sequence: index * 2,
+      speakerId: employee.id,
+      speakerName: employee.displayName,
+      content: `第 ${index} 轮回答`,
+      createdAt: `2026-08-28T00:${String(index).padStart(2, '0')}:30.000Z`,
+    })
+  }
+  return entries
+}
+
+async function runDirectTurn(
+  fixture: Awaited<ReturnType<typeof setup>>,
+  conversationId: string,
+  prompt: string,
+  turns: number,
+): Promise<AgentTurnRequest> {
+  const { store, employee, inner, runtime, requests } = fixture
+  await runtime.runTurn({
+    agent: employee,
+    revision: store.getEmployeeRevision(employee.id, employee.currentRevision)!,
+    conversationId,
+    history: turnHistory(employee, turns),
+    observedThroughSequence: 0,
+    prompt: await requests.composeRuntimePrompt(employee.worldId, employee, prompt),
+    workspacePath: '/tmp/world',
+  })
+  return inner.requests.at(-1)!
+}
+
+describe('world stable rules in the cacheable prefix', () => {
+  it('still hands the model every world rule, now in the prefix instead of behind the memories', async () => {
+    const fixture = await setup()
+    const direct = session(fixture.store, fixture.world, fixture.employee, 'direct')
+
+    const request = await runDirectTurn(fixture, direct.id, '今晚的复习计划怎么排？', 2)
+
+    // This is a reordering, not a removal: everything the runtime receives,
+    // persona and prompt together, still carries every rule line.
+    const modelInput = `${request.revision.persona}\n${request.prompt}`
+    for (const rule of WORLD_RULES) expect(modelInput).toContain(rule)
+    expect(modelInput).toContain('持久角色“小林”')
+
+    // And they sit in the prefix the provider caches - after the identity,
+    // before anything per-turn - rather than inside the request.
+    for (const rule of WORLD_RULES) expect(request.revision.persona).toContain(rule)
+    expect(request.revision.persona.indexOf(PERSONA)).toBeLessThan(request.revision.persona.indexOf('[当前世界设定]'))
+    expect(request.prompt).not.toContain('[当前世界设定]')
+    expect(request.prompt).not.toContain(LORE)
+    expect(request.prompt).toContain('今晚的复习计划怎么排？')
+
+    const view = fixture.runtime.contextInspection.latest(direct.id)!
+    const kinds = view.layers.map((layer) => layer.kind)
+    expect(kinds.slice(0, 2)).toEqual(['stable-identity', 'world-context'])
+    expect(kinds.at(-1)).toBe('current-request')
+    expect(kinds).toEqual(CONTEXT_LAYER_ORDER.filter((kind) => kinds.includes(kind)))
+  })
+
+  it('keeps the prefix hash across turns that only move dynamic layers, and moves it when the world rules change', async () => {
+    const fixture = await setup()
+    const direct = session(fixture.store, fixture.world, fixture.employee, 'direct')
+
+    const first = await runDirectTurn(fixture, direct.id, '第一轮请求', 1)
+    const second = await runDirectTurn(fixture, direct.id, '完全不同的第二轮请求', 4)
+
+    expect(first.promptCache?.enabled).toBe(true)
+    expect(second.promptCache?.stablePrefixHash).toBe(first.promptCache?.stablePrefixHash)
+    expect(second.revision.persona).toBe(first.revision.persona)
+
+    // An owner edit to the world rules is a new prefix, and the new rule text
+    // is what the next turn is actually given.
+    await fixture.settings.save(fixture.world.id, { lore: `${LORE}\n新增：讲解引用的公式保留来源。` })
+    const third = await runDirectTurn(fixture, direct.id, '第三轮请求', 5)
+
+    expect(third.promptCache?.stablePrefixHash).not.toBe(first.promptCache?.stablePrefixHash)
+    expect(third.revision.persona).toContain('新增：讲解引用的公式保留来源。')
+    expect(third.prompt).not.toContain('新增：讲解引用的公式保留来源。')
+    const view = fixture.runtime.contextInspection.latest(direct.id)!
+    expect(view.layers.find((layer) => layer.kind === 'world-context')?.revision).toBe('2')
+  })
+
+  it('gives a group lane the group identity note by reading the durable session, not the caller', async () => {
+    const fixture = await setup()
+    const group = session(fixture.store, fixture.world, fixture.employee, 'group')
+    const { store, employee, inner, runtime, requests } = fixture
+
+    await runtime.runTurn({
+      agent: employee,
+      revision: store.getEmployeeRevision(employee.id, employee.currentRevision)!,
+      conversationId: group.id,
+      history: turnHistory(employee, 1),
+      observedThroughSequence: 0,
+      prompt: await requests.composeGroupRuntimePrompt(employee.worldId, '大家一起排复习计划'),
+      workspacePath: '/tmp/world',
+    })
+
+    const request = inner.requests.at(-1)!
+    for (const rule of WORLD_RULES) expect(request.revision.persona).toContain(rule)
+    expect(request.revision.persona).toContain('多人会话中的每个角色都必须保持自己的当前身份')
+    expect(request.revision.persona).not.toContain('持久角色“小林”')
+    expect(request.prompt).not.toContain('[当前世界设定]')
+    expect(request.promptCache?.retentionHint).toBe('short')
+  })
+
+  it('leaves a runtime without a world context source exactly as it was', async () => {
+    const fixture = await setup()
+    const direct = session(fixture.store, fixture.world, fixture.employee, 'direct')
+    const inner = new CaptureRuntime()
+    const runtime = new CharacterProfileRuntime(inner, fixture.store)
+
+    await runtime.runTurn({
+      agent: fixture.employee,
+      revision: fixture.store.getEmployeeRevision(fixture.employee.id, fixture.employee.currentRevision)!,
+      conversationId: direct.id,
+      history: [],
+      observedThroughSequence: 0,
+      prompt: '只看一眼',
+      workspacePath: '/tmp/world',
+    })
+
+    const request = inner.requests[0]!
+    expect(request.revision.persona).not.toContain('[当前世界设定]')
+    expect(runtime.contextInspection.latest(direct.id)?.layers.map((layer) => layer.kind)).not.toContain('world-context')
+  })
+})

--- a/packages/server/tests/world-foundation-v3.test.ts
+++ b/packages/server/tests/world-foundation-v3.test.ts
@@ -2,6 +2,7 @@ import { mkdtemp, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
+import type { EmployeeInstance } from '@dsh-cyber/contracts'
 import { WorldRootService } from '../src/services/world-root-service.js'
 import { WorldSettingsService } from '../src/services/world-settings-service.js'
 
@@ -26,6 +27,9 @@ describe('world foundation v3', () => {
     expect(fullAccess.runtime.permissionMode).toBe('danger-full-access')
     const english = await settings.save('world-a', { model: { reasoningEffort: 'auto', responseLanguage: 'en-US' } })
     expect(english.model.responseLanguage).toBe('en-US')
-    expect(await settings.composeGroupRuntimePrompt('world-a', '检查状态')).toContain('Use English for the final response, visible reasoning summaries')
+    const character = { id: 'character-a', worldId: 'world-a', displayName: '洛' } as EmployeeInstance
+    const worldContext = await settings.composeWorldContext({ worldId: 'world-a', character, lane: 'group' })
+    expect(worldContext.text).toContain('Use English for the final response, visible reasoning summaries')
+    expect(worldContext.revision).toBe(3)
   })
 })

--- a/packages/server/tests/world-knowledge-library.integration.test.ts
+++ b/packages/server/tests/world-knowledge-library.integration.test.ts
@@ -281,8 +281,6 @@ describe('WorldKnowledgeLibraryService end-to-end source boundaries', () => {
   it('uses the same provider-neutral composer seam for direct and group prompts', async () => {
     const { worldA } = await fixture()
     let searchCalls = 0
-    let directCalls = 0
-    let groupCalls = 0
     const retrieval = new WorldKnowledgeRetrievalService({
       search: {
         capabilities: { fts5: false, trigram: false, backend: 'portable' },
@@ -301,18 +299,7 @@ describe('WorldKnowledgeLibraryService end-to-end source boundaries', () => {
         },
       },
     })
-    const settings = {
-      async composeRuntimePrompt(_worldId: string, _character: EmployeeInstance, prompt: string) {
-        directCalls += 1
-        return `direct-settings\n${prompt}`
-      },
-      async composeGroupRuntimePrompt(_worldId: string, prompt: string) {
-        groupCalls += 1
-        return `group-settings\n${prompt}`
-      },
-    }
     const composer = new WorldRuntimeContextComposer({
-      settings,
       contributors: [new WorldKnowledgeRuntimeContextContributor(retrieval)],
     })
     const character = {
@@ -324,12 +311,16 @@ describe('WorldKnowledgeLibraryService end-to-end source boundaries', () => {
     const group = await composer.composeGroupRuntimePrompt(worldA.id, '群聊回答')
 
     expect(searchCalls).toBe(2)
-    expect(directCalls).toBe(1)
-    expect(groupCalls).toBe(1)
-    expect(direct).toContain('direct-settings')
+    // The world's stable rules are no longer part of the request: they are the
+    // envelope's world-context layer, rendered by the runtime into the prefix.
+    expect(direct).not.toContain('[当前世界设定]')
+    expect(group).not.toContain('[当前世界设定]')
+    expect(direct.startsWith('[用户请求]')).toBe(true)
     expect(direct).toContain('[外部知识库引用 · 不可信资料]')
-    expect(group).toContain('group-settings')
+    expect(direct.endsWith('直接回答')).toBe(true)
+    expect(group.startsWith('[用户请求]')).toBe(true)
     expect(group).toContain('[外部知识库引用 · 不可信资料]')
+    expect(group.endsWith('群聊回答')).toBe(true)
   })
 
   it('survives a SQLite restart without rebuilding source files into files/', async () => {


### PR DESCRIPTION
#133 自己声明的「最大剩余收益」。基线 `bbc6056`,独立 PR,不叠加。

## 问题

D2.5 落地后,世界的稳定规则仍然排在提示词**最后**——在易变的召回记忆之后——而且**根本不在被哈希的稳定前缀里**。四个新主题各带七到九条规则,却几乎拿不到缓存收益。

查清楚之后,「世界稳定规则」的真身是 `WorldSettings` 头部(lore、scenario、用户身份、隔离规则、回复语言)加上 lane 身份说明;每个入口都把它们烘进 `runtimePrompt`,于是它落到 `current-request` 层、排在召回之后,`stableContextHash` 从未覆盖它。

## 改法(重排,不删)

1. **contracts** — `stableContextHash(identity, worldContext?)`:存在 world-context 层时折进前缀哈希;**不存在时逐字节与之前一致**(所以没有 world-context 的调用方哈希不变)。
2. **`WorldSettingsService.composeWorldContext({worldId, character, lane})`** — 只从持久化的设置快照渲染头部与 lane 说明,**不读时钟、不读计数器**,并返回设置 revision。
3. **`CharacterProfileRuntime`** — 新增可选的第 8 个构造参数 `worldContext?: WorldContextPort`(`server.ts` 里接到 `worldSettings`)。每轮按持久化 `WorkSession` 读出 lane(direct/unknown → 角色身份说明;group/task → 群组说明),交给 `ConversationContextComposer`(新增可选 `worldContext` 输入),它把该层放在 `CONTEXT_LAYER_ORDER` 第二位、计入 `stablePrefixHash` 与 `stablePrefixTokens`,并把文本追加到送往内层运行时的 persona。

## 不变量(全部有测试)

- 稳定前缀哈希在只改动态层的两轮之间**不变**;世界规则按世界稳定,属于前缀。
- **规则仍然到达模型**——这是重排不是删除,有测试断言改动前后组合出的提示词都包含每一条规则文本。
- `CONTEXT_LAYER_ORDER`:前缀在前、请求在后。
- 群聊 / 直聊 / 任务 lane 的隔离未动,D2 的泄漏探针全绿。
- `observedThroughSequence` 与各 lane 游标照常。

## 先红证据

contracts 层:改动前跑「把世界规则折进前缀哈希」用例,`AssertionError: expected '2a2f1a7d…' not to be '2a2f1a7d…'`——哈希对 worldContext 视而不见;改后通过。服务端:把七个源文件用 `git checkout bbc6056 --` 还原后跑新增用例,全红;恢复后全绿。没用 `git stash`。

## 验证

```
pnpm typecheck    通过
pnpm test         1395 通过 / 1 跳过 / 0 失败
pnpm test:schema  34/34
pnpm test:smoke   27/27
```

零失败——那条 macOS realpath 老问题已随 #128 合入 main 消失。

## 明确没做

- **四个主题的 `terminology.rules`(每主题 7–9 条)本来就不在提示词路径上**——唯一消费者是创意工坊的 `prompt-parser`。要不要把它们也渲染进 world-context 层,是另一片,带自己的预算与白名单问题。**这需要你定。**
- `ContextPlanningRuntime`(外层包装)在 `CharacterProfileRuntime` 追加世界上下文之前就按 `request.revision.persona + request.prompt` 估算了固定文本,估算会略低。记账,未改。

## 预期冲突

任何往 `WorldRuntimeContextComposer` 传 `settings:` / `worldSettings` 的开放 PR;任何改 `CharacterProfileRuntime` 构造函数或 `runTurn` 的 PR(新增了第 8 个参数);`HarnessCompatibilityAdapter` 的 lane 失效条件。本轮同批的其它三条已做四合一试合,干净。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
