### PR TITLE
ci: move browser checks out of required gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,9 @@ jobs:
   verify:
     name: required
     runs-on: ubuntu-latest
-    timeout-minutes: 40
+    # Keep the protected PR gate short enough for rapid pre-alpha iteration.
+    # Browser and delivery-pack checks run in the non-blocking Full E2E workflow.
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -39,19 +41,6 @@ jobs:
         run: pnpm test
       - name: Migration replay and schema contracts
         run: pnpm test:migration && pnpm test:schema
-      - name: Install Chromium for required smoke
-        run: pnpm exec playwright install --with-deps chromium
-      - name: Required smoke E2E
-        run: pnpm test:smoke
-      # The binary Marketplace package is checked in for offline delivery, but
-      # remains reproducible from the pinned CC0 source. Rebuild it in-place,
-      # parse it through the production VRM loader, then require a byte-for-byte
-      # clean worktree so source, provenance and delivered binary cannot drift.
-      - name: Verify official CC0 avatar pack delivery
-        run: |
-          pnpm avatar:build-official
-          pnpm avatar:verify-official
-          git diff --exit-code -- marketplace/plugins/official-avatar-base-v1
       # The status can only be written to a commit inside this repository.
       # For fork pull requests the head sha lives in the contributor's fork,
       # where GITHUB_TOKEN has no write access (403), so skip instead of failing.
@@ -68,4 +57,4 @@ jobs:
             --header "Accept: application/vnd.github+json" \
             --header "X-GitHub-Api-Version: 2022-11-28" \
             "https://api.github.com/repos/${GITHUB_REPOSITORY}/statuses/${TARGET_SHA}" \
-            --data '{"state":"success","context":"CI / required","description":"typecheck and unit/integration tests passed"}'
+            --data '{"state":"success","context":"CI / required","description":"fast typecheck, unit/integration, migration and schema checks passed"}'

--- a/.github/workflows/full-e2e.yml
+++ b/.github/workflows/full-e2e.yml
@@ -6,6 +6,10 @@ on:
     - cron: '0 18 * * *'
   push:
     branches: [main]
+  # Draft PRs stay fast by default. Add the `run-full-e2e` label when a PR
+  # needs an opt-in browser run before it is merged.
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
 
 permissions:
   contents: read
@@ -17,6 +21,8 @@ concurrency:
 jobs:
   chromium:
     name: chromium
+    if: >-
+      ${{ github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-full-e2e') }}
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
@@ -34,3 +40,11 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm exec playwright install --with-deps chromium
       - run: pnpm test:e2e
+      # The binary Marketplace package is checked in for offline delivery, but
+      # remains reproducible from the pinned CC0 source. Keep this verification
+      # with the browser/release-oriented workflow instead of blocking every PR.
+      - name: Verify official CC0 avatar pack delivery
+        run: |
+          pnpm avatar:build-official
+          pnpm avatar:verify-official
+          git diff --exit-code -- marketplace/plugins/official-avatar-base-v1

--- a/docs/development/ci-strategy.md
+++ b/docs/development/ci-strategy.md
@@ -4,7 +4,7 @@ DSH Cyber 当前处于 Pre-Alpha / 架构快速演进期。CI 的目标是尽早
 
 ## 分层原则
 
-### L1 — Required PR CI
+### L1 — Required PR CI（快速门禁）
 
 每个 Pull Request 和 `main` push 都运行：
 
@@ -14,7 +14,6 @@ pnpm typecheck
 pnpm test
 pnpm test:migration
 pnpm test:schema
-pnpm test:smoke
 ```
 
 这层是当前唯一 Required Gate，保护：
@@ -28,9 +27,17 @@ pnpm test:smoke
 - Workshop service；
 - migration / backup 等核心逻辑。
 
-### L2 — Required Smoke E2E
+### L2 — Opt-in Chromium Smoke / Full E2E
 
-Core Reliability & Work System V1 起进入 Required，覆盖：
+浏览器验证不再阻塞每一个开发 PR。`full-e2e.yml` 默认运行于：
+
+- `main` push；
+- nightly schedule；
+- GitHub Actions 手动触发。
+
+对需要在合并前检查浏览器回归的 PR，添加 `run-full-e2e` label 即可启动同一 workflow；未添加 label 的 Draft/开发 PR 会被快速跳过。
+
+它覆盖：
 
 - 首次启动；
 - 创建世界；
@@ -41,17 +48,11 @@ Core Reliability & Work System V1 起进入 Required，覆盖：
 - Task → 多角色执行 → Deliverable → Review → 新版本；
 - Package/Artifact 核心闭环。
 
-目标运行时间不超过数分钟，并在进入 Alpha 后升级为 Required。
+官方 CC0 avatar base pack 的重建、运行时解析和 byte-for-byte 工作树校验也在这一层执行。
 
-### L3 — Full Chromium E2E
+Pre-Alpha Draft PR 不要求 Full E2E 每次提交都通过。准备把大型重构 PR 标记为 Ready for review 或准备合并 `main` 时，应添加 label 或手动运行完整 E2E 并处理仍然有效的回归。
 
-完整 Playwright 回归目前运行于：
-
-- `main` push；
-- GitHub Actions 手动触发；
-- nightly schedule。
-
-Pre-Alpha Draft PR 不要求 Full E2E 每次提交都通过。准备把大型重构 PR 标记为 Ready for review 或准备合并 `main` 时，应手动运行完整 E2E 并处理仍然有效的回归。
+进入 Alpha 后可把核心 Smoke E2E 提升为 Required；完整 Chromium 回归仍保留在更慢的非阻塞层。
 
 ### L4 — Release Validation
 
@@ -87,8 +88,8 @@ E2E 应验证：
 
 | 阶段 | Required Gate |
 | --- | --- |
-| Pre-Alpha（当前） | Typecheck + Unit/Integration + Migration/Schema + Smoke E2E |
-| Alpha | + 完整 Work System / Backup Restore smoke |
+| Pre-Alpha（当前） | Typecheck + Unit/Integration + Migration/Schema |
+| Alpha | + 核心 Smoke E2E |
 | Beta | + Full E2E |
 | Stable | + Migration + Backup/Restore + OS matrix |
 | Release | + Real Harness Canary + package/release validation |


### PR DESCRIPTION
## Summary
- Keep the protected CI / required job focused on install, typecheck, unit/integration, migration, and schema checks.
- Move Chromium E2E and official avatar delivery verification to the non-blocking Full E2E workflow.
- Allow maintainers to opt a PR into browser validation with the run-full-e2e label.
- Keep the CI / required status context unchanged for branch protection.

## Validation
- pnpm typecheck
- pnpm test:migration && pnpm test:schema
- node scripts/check-workflow-action-pins.mjs
- pnpm test (1 pre-existing local-harness integration timeout; 272 files and 1414 tests passed)