### PR TITLE
fix(knowledge): salvage truncated completions and retire superseded trace failures

### DIFF
--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -4680,7 +4680,12 @@ export class SqliteStore {
       .join('|')
   }
 
-  /** Recent failed knowledge consolidation jobs, newest first (world trace source). */
+  /**
+   * Recent failed knowledge consolidation jobs, newest first (world trace
+   * source). A failure a later completed job on the same source has overtaken
+   * is history, not a live problem — projecting it would keep stale red
+   * entries on the trace after the pipeline already recovered.
+   */
   listWorldConsolidationFailures(worldId: string, limit = 10): Array<{
     id: string
     sourceType: string
@@ -4691,10 +4696,15 @@ export class SqliteStore {
   }> {
     return this.database
       .prepare(
-        `SELECT id, source_type, source_id, error_code, attempt, updated_at
-         FROM knowledge_consolidation_jobs
-         WHERE world_id = ? AND status = 'failed'
-         ORDER BY updated_at DESC, id DESC
+        `SELECT f.id, f.source_type, f.source_id, f.error_code, f.attempt, f.updated_at
+         FROM knowledge_consolidation_jobs f
+         WHERE f.world_id = ? AND f.status = 'failed'
+           AND NOT EXISTS (
+             SELECT 1 FROM knowledge_consolidation_jobs c
+             WHERE c.world_id = f.world_id AND c.source_type = f.source_type AND c.source_id = f.source_id
+               AND c.status = 'completed' AND c.updated_at > f.updated_at
+           )
+         ORDER BY f.updated_at DESC, f.id DESC
          LIMIT ?`,
       )
       .all(worldId, limit)

--- a/packages/server/src/services/knowledge-extraction.ts
+++ b/packages/server/src/services/knowledge-extraction.ts
@@ -333,12 +333,53 @@ function parseJson(value: string): unknown {
   const start = cleaned.indexOf('{')
   const end = cleaned.lastIndexOf('}')
   if (start >= 0 && end > start) candidates.push(cleaned.slice(start, end + 1))
+  // A compatible gateway that caps completion mid-stream yields truncated JSON.
+  // Salvaging every whole member beats discarding the whole batch — and the
+  // next job's cursor already stops at the messages actually sent.
+  const repaired = start >= 0 ? repairTruncatedJson(cleaned.slice(start)) : undefined
+  if (repaired !== undefined) candidates.push(repaired)
   for (const candidate of candidates) {
     try { return JSON.parse(candidate) as unknown } catch {
       // Try the next shape.
     }
   }
   throw invalid('extraction_json_invalid', '知识抽取结果不是有效 JSON')
+}
+
+/**
+ * Close a JSON object the model never finished: keep everything up to the last
+ * complete element at ANY depth and close the open containers around it, so a
+ * completion capped mid-array still yields the entities and claims it finished.
+ * Returns undefined when the answer is too incomplete to salvage.
+ */
+export function repairTruncatedJson(text: string): string | undefined {
+  const stack: string[] = []
+  let inString = false
+  let escaped = false
+  let cutEnd = -1
+  let cutClosers = ''
+  for (let index = 0; index < text.length; index += 1) {
+    const char = text[index]
+    if (inString) {
+      if (escaped) escaped = false
+      else if (char === '\\') escaped = true
+      else if (char === '"') inString = false
+      continue
+    }
+    if (char === '"') { inString = true; continue }
+    if (char === '{' || char === '[') { stack.push(char); continue }
+    if (char === '}' || char === ']') {
+      stack.pop()
+      if (stack.length === 0) return undefined // already balanced — not truncated
+      // Any closed element is a safe cut: whatever remains open gets mirrored.
+      cutEnd = index
+      cutClosers = stack.map((open) => (open === '{' ? '}' : ']')).reverse().join('')
+    }
+  }
+  if (stack.length === 0 || cutEnd < 0) return undefined
+  const head = text.slice(0, cutEnd + 1).replace(/,\s*$/, '')
+  const candidate = `${head}${cutClosers}`
+  try { JSON.parse(candidate) as unknown; return candidate } catch { return undefined }
 }
 function strictRecord(value: unknown, label: string): Record<string, unknown> {
   if (value === null || typeof value !== 'object' || Array.isArray(value)) throw invalid('extraction_shape_invalid', label + '必须是对象')

--- a/packages/server/tests/world-knowledge-graph-service.test.ts
+++ b/packages/server/tests/world-knowledge-graph-service.test.ts
@@ -144,6 +144,20 @@ describe('strict knowledge extraction', () => {
     expect(result.entities[0]?.canonicalName).toBe('林澈')
   })
 
+  it('salvages whole members from an answer truncated mid-stream by the gateway', () => {
+    // max_tokens capped the completion: evidenceRefs and entities closed, the
+    // second claim died mid-key. Salvaging what completed beats losing it all.
+    const truncated = '{"evidenceRefs":[{"sourceType":"conversation","sourceId":"session-a","evidenceId":"evidence-a"}],"entities":[{"key":"lin","type":"character","canonicalName":"林澈","aliases":[],"evidenceRefs":["evidence-a"]}],"claims":[{"key":"c1","type":"fact","subjectKey":"lin","predicate":"负责","objectText":"观测站","confidence":0.9,"evidenceRefs":["evidence-a"]},{"key":"c2","type":"fact","subject'
+    const result = parseKnowledgeExtraction(truncated, { sourceType: 'conversation', sourceId: 'session-a', evidence: evidenceInput })
+    expect(result.entities.map((entity) => entity.canonicalName)).toEqual(['林澈'])
+    expect(result.claims.map((claim) => claim.key)).toEqual(['c1'])
+  })
+
+  it('fails cleanly when truncation dropped the required evidence root', () => {
+    const truncated = '{"entities":[{"key":"lin","type":"character","canonicalName":"林澈","aliases":[],"evidenceRefs":["evidence-a"]},{"key":"pa'
+    expect(() => parseKnowledgeExtraction(truncated, { sourceType: 'conversation', sourceId: 'session-a', evidence: evidenceInput })).toThrowError(KnowledgeExtractionError)
+  })
+
   it('degrades an unknown entity type to other and drops only the claim with an unknown type', () => {
     const parsed = parseKnowledgeExtraction({
       entities: [{ key: 'lin', type: '神秘生物', canonicalName: '林澈', aliases: [], evidenceRefs: ['evidence-a'] }],

--- a/packages/server/tests/world-trace-service.test.ts
+++ b/packages/server/tests/world-trace-service.test.ts
@@ -275,6 +275,23 @@ describe('World Trace projection', () => {
     }))
   })
 
+  it('drops a failed consolidation entry once a later completed job overtakes it', async () => {
+    const { store, workspace, world } = await fixture()
+    store.database.prepare(
+      `INSERT INTO knowledge_consolidation_jobs
+       (id, workspace_id, world_id, source_type, source_id, from_cursor, to_cursor, status, attempt, error_code, created_at, updated_at)
+       VALUES ('job-old-fail', ?, ?, 'conversation', 'session-x', 0, 5, 'failed', 2, 'extraction_json_invalid', ?, ?)`,
+    ).run(workspace.id, world.id, '2026-09-01T00:00:00.000Z', '2026-09-01T00:01:00.000Z')
+    store.database.prepare(
+      `INSERT INTO knowledge_consolidation_jobs
+       (id, workspace_id, world_id, source_type, source_id, from_cursor, to_cursor, status, attempt, created_at, updated_at)
+       VALUES ('job-later-ok', ?, ?, 'conversation', 'session-x', 5, 9, 'completed', 1, ?, ?)`,
+    ).run(workspace.id, world.id, '2026-09-01T00:10:00.000Z', '2026-09-01T00:11:00.000Z')
+    const service = new WorldTraceService({ store, actions: new MemoryActions() })
+    const page = await service.list(world.id)
+    expect(page.items.filter((entry) => entry.sourceKind === 'consolidation')).toEqual([])
+  })
+
   it('reuses the cached projection while the watermark holds and rebuilds after facts change', async () => {
     const context = await fixture()
     const { store, world } = context


### PR DESCRIPTION
## 背景

#142 合并后，知识整理在默认模型（agnes-2.5-flash，OpenAI 兼容网关）上仍剩一类失败：`extraction_json_invalid` ×3 + 超时 ×1（本地实测，群聊尾段 331→576）。抓响应确认根因：**网关在 max_tokens 处把 completion 拦腰截断**——一个写完 8 个实体、半路断在第 9 条 claim 键上的回答，此前整体作废；重试一次再截断即任务失败。

同时发现 #149 的 consolidation 投影有个体验缺陷：它列出"最近 10 条 failed"**不分年代**——管线早已恢复，陈旧红条仍霸占轨迹（用户实际被此困惑）。

## 修复（2 提交）

### 1 · 截断抢救 `repairTruncatedJson`（knowledge-extraction.ts）
- 括号栈扫描到**任意深度最后一个完整闭合元素**，镜像补全未闭合容器后重解析
- 效果粒度：半死的最后一行 → 只丢那一行；已完成的 entities/claims 照常入库
- 安全不变：太残缺（如截断发生在 evidenceRefs 之前）→ 如实 `extraction_field_required` 失败，**抢救永不伪造证据**；游标语义不变（仍只推进到实际发送处），失败范围下轮自动接续
- 测试：truncated 样例抢救出 evidenceRefs+entities+首条 claim；残缺样例干净失败

### 2 · 被取代的失败退场（sqlite-store.ts）
- `listWorldConsolidationFailures` 增加 `NOT EXISTS(同来源更晚 completed)`——"失败已被后续成功追上"即历史，不再投影进轨迹
- 测试：旧 fail + 更晚 completed 同来源 → 轨迹 consolidation 条目为空

## 验证
- 全量：**285 文件 / 1502 通过 / 1 跳过**；typecheck 干净；无迁移、无 contracts 变更
- **真实端到端**（默认 agnes 模型、未换模型未改配置）：
  ```
  重放原失败 job(331→576, 245 条消息) → completed t+36s
  图谱 22 实体 / 48 主张 / 20 关系；游标 576 全追上
  轨迹 API：42 条目，consolidation 失败投影 = 0（历史 4 条已被取代规则消音）
  ```
- 使用记录保留原始失败行（事实日志不篡改），但整理管线对截断已免疫、对超时/空响应自愈

## 关联
承接 #142（provider 容错）与 #149（consolidation 投影）的收尾加固，无冲突面（4 文件 +87/−5，两处均在上游版本上直接落地）。
