### PR TITLE
fix(web): pinned dock surfaces all get their own closable tab

### DIFF
--- a/e2e/workbench.spec.ts
+++ b/e2e/workbench.spec.ts
@@ -120,7 +120,7 @@ test('opens low-frequency dock surfaces from More as closable restored tabs', as
   await expect(dock.getByRole('tab', { name: '知识', exact: true })).toBeVisible()
   await openDockTab(dock, '日程')
   await expect(dock.getByRole('tab', { name: '日程', exact: true })).toHaveAttribute('aria-selected', 'true')
-  await expect(dock.getByRole('tab', { name: '知识', exact: true })).toHaveCount(0)
+  await expect(dock.getByRole('tab', { name: '知识', exact: true })).toBeVisible()
 
   await openDockTab(dock, '知识')
   await dock.getByRole('button', { name: '关闭知识页签' }).click()
@@ -132,7 +132,7 @@ test('opens low-frequency dock surfaces from More as closable restored tabs', as
 
   await page.reload()
   const restoredDock = page.getByRole('region', { name: '世界与角色侧边栏' })
-  await expect(restoredDock.getByRole('tab', { name: '日程', exact: true })).toHaveCount(0)
+  await expect(restoredDock.getByRole('tab', { name: '日程', exact: true })).toBeVisible()
   await expect(restoredDock.getByRole('tab', { name: '知识', exact: true })).toHaveCount(0)
   await expect(restoredDock.getByRole('tab', { name: '角色', exact: true })).toHaveCount(0)
 

--- a/packages/web/src/components/WorldSideDock.tsx
+++ b/packages/web/src/components/WorldSideDock.tsx
@@ -131,9 +131,12 @@ export function WorldSideDock({
 
   const localizedFixedTabs = FIXED_TABS.map((tab) => ({ ...tab, label: t(`dock.${tab.id}`, tab.label) }))
   const localizedSecondaryTabs = SECONDARY_TABS.map((tab) => ({ ...tab, label: t(`dock.${tab.id === 'dossier' ? 'roles' : tab.id}`, tab.label) }))
-  // Keep the header calm: secondary surfaces remain remembered in More, but
-  // only the one the user is actively viewing is promoted into the tab row.
-  const visibleSecondaryTabs = localizedSecondaryTabs.filter((tab) => tab.id === activeTab)
+  // The product rule promotes every pinned surface into its own closable tab,
+  // in the order this world opened them; the tab strip scrolls when narrow.
+  const visibleSecondaryTabs = openTabs.flatMap((id) => {
+    const tab = localizedSecondaryTabs.find((item) => item.id === id)
+    return tab === undefined ? [] : [tab]
+  })
   const visibleTabs = [...localizedFixedTabs, ...visibleSecondaryTabs]
 
   const selectTab = (tab: DockTab) => {

--- a/packages/web/tests/world-side-dock-tabs.test.ts
+++ b/packages/web/tests/world-side-dock-tabs.test.ts
@@ -14,7 +14,7 @@ afterEach(() => {
 })
 
 describe('WorldSideDock dynamic tabs', () => {
-  it('shows only the active More item while remembering recent surfaces per World', async () => {
+  it('promotes every pinned surface into its own closable tab, per World', async () => {
     const host = document.createElement('div')
     document.body.append(host)
     let root = createRoot(host)
@@ -27,18 +27,24 @@ describe('WorldSideDock dynamic tabs', () => {
     expect(tabLabels(host)).toEqual(['世界', '轨迹', '角色'])
     await click(host, '更多')
     await click(host, '日程')
-    expect(tabLabels(host)).toEqual(['世界', '轨迹', '日程'])
+    // Both pinned surfaces stay promoted; only one can be the active view.
+    expect(tabLabels(host)).toEqual(['世界', '轨迹', '角色', '日程'])
+    expect(host.querySelector('[role="tab"][aria-selected="true"]')?.getAttribute('aria-label')).toBe('日程')
     await click(host, '关闭日程页签')
     expect(host.querySelector('[role="tab"][aria-selected="true"]')?.getAttribute('aria-label')).toBe('角色')
     expect(tabLabels(host)).toEqual(['世界', '轨迹', '角色'])
     expect(JSON.parse(window.localStorage.getItem('dsh-cyber:world-dock-tabs:world-a') ?? '[]')).toEqual(['dossier'])
 
+    await click(host, '更多')
+    const checks = Array.from(host.querySelectorAll('[role="menuitemcheckbox"]')).map((item) => `${item.textContent}:${item.getAttribute('aria-checked')}`)
+    expect(checks).toContain('角色:true')
+    expect(checks).toContain('日程:false')
+
     await act(async () => { root.unmount() })
     root = createRoot(host)
     await act(async () => { root.render(createElement(Harness, { world: world('world-a') })) })
-    expect(tabLabels(host)).toEqual(['世界', '轨迹'])
-    await click(host, '更多')
-    expect(host.querySelector('[role="menuitemcheckbox"][aria-checked="true"]')?.textContent).toContain('角色')
+    // Restoring the world brings every remembered tab back as its own entry.
+    expect(tabLabels(host)).toEqual(['世界', '轨迹', '角色'])
 
     await act(async () => { root.render(createElement(Harness, { key: 'world-b', world: world('world-b') })) })
     expect(tabLabels(host)).toEqual(['世界', '轨迹'])


### PR DESCRIPTION
## 问题（用户报告）

「更多」菜单里勾选了多个页面（角色、日程…），但侧栏页签栏**永远只显示当前激活的那一个**——刚勾选下一项，前一项的页签就消失。

## 根因

`WorldSideDock.tsx` 一行的推导漂移：

```ts
// Keep the header calm: … only the one the user is actively viewing is promoted
const visibleSecondaryTabs = localizedSecondaryTabs.filter((tab) => tab.id === activeTab)
```

多页签的全部基础设施其实都在：`openTabs` 数组、按世界的 localStorage 持久化与顺序恢复、每个页签独立的关闭按钮、`overflow-x: auto` + 隐藏滚动条的窄屏样式。**只是这一行把其余已勾选的页签挡在了渲染之外**（More 里的勾选态仍然显示，加深了"勾了却没出现"的困惑）。

这与 AGENTS.md 产品信息架构三条明文冲突：
- 「点击后将对应页面提升为可关闭的一级**临时页签**（复数）」
- 「并**按世界**在本机**恢复打开顺序**」（顺序→需要多个）
- 「窄屏时**临时页签区可横向滚动**」（区域→需要多个）

## 修复

- `visibleSecondaryTabs` 改为按 `openTabs` 顺序全量呈现（每项可关闭）
- 按测试纪律更新**编码了错误行为**的既有断言（AGENTS.md：规格冲突时更新测试，不迁就旧行为）：
  - 单测 `world-side-dock-tabs.test.ts`：改为断言"多页签并存/逐个关闭/重载恢复"，并新增 More 勾选态检查
  - e2e `workbench.spec.ts`：两处 `toHaveCount(0)`（激活新页签后旧页签必须消失 / 重载后页签不可见）→ 并存可见

## 验证
- 真实浏览器（Edge/Playwright，完整用户路径）：勾 角色+日程 → 页签 `[世界,轨迹,角色,日程]` 并存，各自带 ×；关日程 → 角色保留；**reload → 页签恢复**；1440 下 `overflow-x:auto` 生效；全程 0 pageerror
- 三视口截图 + 控制台记录：`.private/ui-fix-verification/dock-multitab-{1440,1920,3840}.png` + `dock-multitab-console.log`；3840 下无横向溢出、无 warn
- 全量单测：**285 文件 / 1499 通过 / 1 跳过**；`tsc -b` 干净
- e2e 规格已按新行为更新，待 CI 跑 Chromium 套件确认
