### PR TITLE
fix(harness): allow plain HTTP to private-network model endpoints at launch

### DIFF
--- a/packages/harness-adapter/src/profile.ts
+++ b/packages/harness-adapter/src/profile.ts
@@ -236,14 +236,18 @@ export function validateProviderProfile(profile: HarnessProviderProfile): void {
     throw new Error('Provider display name, API and model are required')
   }
   const endpoint = new URL(profile.baseURL)
-  // Plain HTTP is safe on a private network: loopback and RFC1918-style
-  // addresses follow the same policy the server applies when saving model
-  // profiles (model-url-policy.assertModelBaseUrl), so a LAN vLLM/Ollama box
-  // is not rejected at worker-launch time after passing the settings form.
-  // Anything else — public hosts, or hostnames that could resolve there —
-  // still requires HTTPS.
-  if (endpoint.protocol !== 'https:' && !isExplicitPrivateHostname(normalizeHostname(endpoint.hostname))) {
-    throw new Error('Provider URL must use HTTPS, except loopback or private-network HTTP endpoints')
+  // Only HTTP(S) transports are valid model endpoints. HTTPS is accepted
+  // anywhere; plain HTTP only on a private network (loopback and RFC1918-style
+  // addresses), matching the policy the server applies when saving model
+  // profiles (model-url-policy.assertModelBaseUrl) so a LAN vLLM/Ollama box is
+  // not rejected at worker-launch time after passing the settings form. Other
+  // schemes — ftp/ws/etc. — are rejected even on private hosts, and public
+  // hosts still require HTTPS.
+  if (
+    endpoint.protocol !== 'https:'
+    && !(endpoint.protocol === 'http:' && isExplicitPrivateHostname(normalizeHostname(endpoint.hostname)))
+  ) {
+    throw new Error('Provider URL must use HTTPS, except private-network HTTP endpoints')
   }
   if (profile.apiKeyEnv !== undefined && !/^[A-Z_][A-Z0-9_]*$/.test(profile.apiKeyEnv)) {
     throw new Error('Invalid provider credential environment variable')

--- a/packages/harness-adapter/src/profile.ts
+++ b/packages/harness-adapter/src/profile.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module'
+import { isIP } from 'node:net'
 import { lstat, mkdir, open, readFile, readlink, rename, symlink, unlink } from 'node:fs/promises'
 import { dirname, join, resolve } from 'node:path'
 import { randomUUID } from 'node:crypto'
@@ -229,15 +230,20 @@ async function ensurePackageLink(linkPath: string, targetPath: string): Promise<
   await symlink(resolve(targetPath), linkPath, 'junction')
 }
 
-function validateProviderProfile(profile: HarnessProviderProfile): void {
+export function validateProviderProfile(profile: HarnessProviderProfile): void {
   if (!/^[a-z0-9][a-z0-9-]*$/.test(profile.route)) throw new Error('Invalid provider route')
   if (!profile.displayName.trim() || !profile.api.trim() || !profile.model.id.trim()) {
     throw new Error('Provider display name, API and model are required')
   }
   const endpoint = new URL(profile.baseURL)
-  const local = endpoint.hostname === '127.0.0.1' || endpoint.hostname === 'localhost' || endpoint.hostname === '::1'
-  if (endpoint.protocol !== 'https:' && !(endpoint.protocol === 'http:' && local)) {
-    throw new Error('Provider URL must use HTTPS, except loopback HTTP endpoints')
+  // Plain HTTP is safe on a private network: loopback and RFC1918-style
+  // addresses follow the same policy the server applies when saving model
+  // profiles (model-url-policy.assertModelBaseUrl), so a LAN vLLM/Ollama box
+  // is not rejected at worker-launch time after passing the settings form.
+  // Anything else — public hosts, or hostnames that could resolve there —
+  // still requires HTTPS.
+  if (endpoint.protocol !== 'https:' && !isExplicitPrivateHostname(normalizeHostname(endpoint.hostname))) {
+    throw new Error('Provider URL must use HTTPS, except loopback or private-network HTTP endpoints')
   }
   if (profile.apiKeyEnv !== undefined && !/^[A-Z_][A-Z0-9_]*$/.test(profile.apiKeyEnv)) {
     throw new Error('Invalid provider credential environment variable')
@@ -249,4 +255,74 @@ function validateProviderProfile(profile: HarnessProviderProfile): void {
       throw new Error('Invalid web search credential environment variable')
     }
   }
+}
+
+function normalizeHostname(value: string): string {
+  return value.toLowerCase().replace(/^\[|\]$/g, '').replace(/\.$/, '')
+}
+
+function parseIpv4(value: string): readonly [number, number, number, number] | undefined {
+  const m = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(value)
+  if (m === null) return undefined
+  const o = m.slice(1).map(Number)
+  if (o.some((n) => n > 255)) return undefined
+  return o as [number, number, number, number]
+}
+
+function parseIpv6(value: string): bigint | undefined {
+  const m = /^([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4}):([0-9a-fA-F]{1,4})$/.exec(value)
+  if (m !== null) {
+    let result = 0n
+    for (let i = 1; i <= 8; i++) {
+      result = (result << 16n) | BigInt(parseInt(m[i]!, 16))
+    }
+    return result
+  }
+  // Handle :: compression
+  const parts = value.split('::')
+  if (parts.length === 2) {
+    const left = parts[0] ? parts[0].split(':') : []
+    const right = parts[1] ? parts[1].split(':') : []
+    const missing = 8 - left.length - right.length
+    const all = [...left, ...Array(missing).fill('0'), ...right]
+    if (all.length !== 8) return undefined
+    let result = 0n
+    for (const part of all) {
+      result = (result << 16n) | BigInt(parseInt(part, 16))
+    }
+    return result
+  }
+  return undefined
+}
+
+function inIpv6Range(value: bigint, rangeStr: string, prefixBits: number): boolean {
+  const range = parseIpv6(rangeStr)
+  if (range === undefined) return false
+  const mask = (~0n << BigInt(128 - prefixBits))
+  return (value & mask) === (range & mask)
+}
+
+function isPrivateAddress(address: string): boolean {
+  const normalized = normalizeHostname(address)
+  if (isIP(normalized) === 4) {
+    const octets = parseIpv4(normalized)
+    if (octets === undefined) return false
+    const [first, second] = octets
+    return first === 10 || first === 127
+      || (first === 172 && second >= 16 && second <= 31)
+      || (first === 192 && second === 168)
+  }
+  if (isIP(normalized) === 6) {
+    const value = parseIpv6(normalized)
+    if (value === undefined) return false
+    return inIpv6Range(value, 'fc00::', 7) || inIpv6Range(value, '::1', 128)
+  }
+  return false
+}
+
+function isExplicitPrivateHostname(hostname: string): boolean {
+  if (hostname === 'localhost' || hostname.endsWith('.localhost')
+    || hostname === 'host.docker.internal' || hostname === 'host.containers.internal'
+    || hostname.endsWith('.local')) return true
+  return isIP(hostname) !== 0 && isPrivateAddress(hostname)
 }

--- a/packages/harness-adapter/tests/provider-url-policy.test.ts
+++ b/packages/harness-adapter/tests/provider-url-policy.test.ts
@@ -47,6 +47,16 @@ describe('provider URL transport policy', () => {
     }
   })
 
+  it('rejects non-HTTP(S) transports even on private hosts', () => {
+    for (const url of [
+      'ftp://127.0.0.1/v1',
+      'ws://192.168.1.10:8080/v1',
+      'file:///C:/model',
+    ]) {
+      expect(() => validateProviderProfile(provider(url)), url).toThrow(/must use HTTPS/)
+    }
+  })
+
   it('172.16 boundary follows RFC1918: /12 in, 172.32 out', () => {
     expect(() => validateProviderProfile(provider('http://172.16.0.1:8000/v1'))).not.toThrow()
     expect(() => validateProviderProfile(provider('http://172.31.0.1:8000/v1'))).not.toThrow()

--- a/packages/harness-adapter/tests/provider-url-policy.test.ts
+++ b/packages/harness-adapter/tests/provider-url-policy.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { validateProviderProfile, type HarnessProviderProfile } from '../src/profile.js'
+
+function provider(baseURL: string): HarnessProviderProfile {
+  return {
+    route: 'local-gateway',
+    displayName: '局域网网关',
+    api: 'openai-completions',
+    baseURL,
+    model: { id: 'qwen-9b' },
+  }
+}
+
+describe('provider URL transport policy', () => {
+  it('accepts HTTPS anywhere, including public hosts', () => {
+    expect(() => validateProviderProfile(provider('https://api.deepseek.com/v1'))).not.toThrow()
+    expect(() => validateProviderProfile(provider('https://172.16.1.125:8000/v1'))).not.toThrow()
+  })
+
+  it('accepts plain HTTP on loopback and explicit private-network addresses', () => {
+    for (const url of [
+      'http://127.0.0.1:8000/v1',
+      'http://localhost:1234/v1',
+      'http://[::1]:8000/v1',
+      'http://10.0.3.7:8080/v1',
+      'http://172.16.1.125:8000/v1',
+      'http://172.31.255.255:8000/v1',
+      'http://192.168.0.9:8000/v1',
+      'http://[fc00::12]:8000/v1',
+      'http://box.local:8000/v1',
+      'http://host.docker.internal:8000/v1',
+    ]) {
+      expect(() => validateProviderProfile(provider(url)), url).not.toThrow()
+    }
+  })
+
+  it('rejects plain HTTP for public addresses, public hostnames and link-local', () => {
+    for (const url of [
+      'http://8.8.8.8/v1',
+      'http://172.32.0.1:8000/v1',
+      'http://11.16.1.1:8000/v1',
+      'http://169.254.1.1:8000/v1',
+      'http://models.example.com/v1',
+    ]) {
+      expect(() => validateProviderProfile(provider(url)), url).toThrow(/must use HTTPS/)
+    }
+  })
+
+  it('172.16 boundary follows RFC1918: /12 in, 172.32 out', () => {
+    expect(() => validateProviderProfile(provider('http://172.16.0.1:8000/v1'))).not.toThrow()
+    expect(() => validateProviderProfile(provider('http://172.31.0.1:8000/v1'))).not.toThrow()
+    expect(() => validateProviderProfile(provider('http://172.32.0.1:8000/v1'))).toThrow(/must use HTTPS/)
+  })
+
+  it('still validates the rest of the profile', () => {
+    expect(() => validateProviderProfile({ ...provider('http://127.0.0.1:8000/v1'), apiKeyEnv: 'bad-name' })).toThrow(/credential environment variable/)
+    expect(() => validateProviderProfile({ ...provider('https://api.example.com/v1'), webSearch: { baseURL: 'http://search.example.com/v1', apiKeyEnv: 'SEARCH_KEY' } })).toThrow(/search URL must use HTTPS/)
+  })
+})


### PR DESCRIPTION
## 问题

worker 启动期的 `validateProviderProfile` 只允许 loopback HTTP：

```
Provider URL must use HTTPS, except loopback HTTP endpoints
```

但设置表单侧的策略（`model-url-policy.assertModelBaseUrl`）**允许整个私有网段走 HTTP**，AGENTS.md 也白纸黑字："loopback、RFC1918 等私有地址可使用 HTTP(S)，禁止用'仅允许 127.0.0.1'误伤局域网 sub2api"。

两层不一致造成一个非常迷惑的故障形态：用户给角色分配局域网 vLLM/omlx（`http://172.16.x.x:8000/v1`）→ **设置保存通过、「测试连接」通过、模型发现通过**——然后每一条真实对话回合在 worker 启动时 0 秒失败，报上面那句。局域网推理盒子（跑 MLX/vLLM 的 Mac、另一台机器上的 Ollama）正是模型配置最典型的本地形态。

## 修复

- `validateProviderProfile` 的传输策略与 `model-url-policy` 对齐：HTTPS 不限；HTTP 仅当主机是**显式私有形态**——loopback（含 `[::1]`，顺带修了 IPv6 带方括号 hostname 的归一化）、10/8、172.16/12、192.168/16、fc00::/7、`localhost`/`*.local`/`host.docker.internal`/`host.containers.internal`
- 公网 IP、公网域名、链路本地（169.254）继续要求 HTTPS；其余校验（route/apiKeyEnv/webSearch HTTPS）不变
- 主机名判定基于**字面地址或显式私有后缀**，不做 DNS 解析——公网域名解析到内网 IP 的情况仍按域名拒绝（与 server 策略同一保守取向）

## 测试

`provider-url-policy.test.ts` 5 例：HTTPS 全域放行；HTTP 放行清单（127.0.0.1 / localhost / [::1] / 10.x / 172.16-172.31 / 192.168 / [fc00::] / *.local / host.docker.internal）；HTTP 拒绝清单（公网 IP、172.32 越界、11.x 形近、link-local、公网域名）；RFC1918 172.16/12 边界两侧；profile 其余字段校验不受影响。

全量：**286 文件 / 1504 通过 / 1 跳过**。

## 影响

设置里"测试连接"绿了但聊一句就 400 的局域网部署路径被打通；与模型档案发现链（目录里自报 `max_model_len` 的 omlx/vLLM）配合后，局域网模型从保存到运行首次全链路一致。
