### PR TITLE
fix(model-hub): filter discovered models cache against valid model IDs

### DIFF
--- a/packages/web/src/features/models/discovered-models-storage.ts
+++ b/packages/web/src/features/models/discovered-models-storage.ts
@@ -45,11 +45,25 @@ export function buildUnifiedModelList(
   configuredProfiles: readonly ModelProfile[],
   discoveredCatalog: Record<string, CachedModelCatalog>,
 ): ModelProfile[] {
+  // Build a set of valid model IDs from configured profiles for cache validation
+  const validModelIds = new Set(configuredProfiles.map((p) => p.modelId))
+
+  // Filter cache: only keep entries where the base profile still exists
+  // and model IDs are still valid (not stale from removed providers)
+  const filteredCatalog: Record<string, CachedModelCatalog> = {}
+  for (const [key, catalog] of Object.entries(discoveredCatalog)) {
+    if (!catalog || !Array.isArray(catalog.models)) continue
+    // Filter out models whose IDs no longer exist in configured profiles
+    const validModels = catalog.models.filter((item) => item.id && validModelIds.has(item.id))
+    if (validModels.length === 0) continue
+    filteredCatalog[key] = { ...catalog, models: validModels }
+  }
+
   const result: ModelProfile[] = [...configuredProfiles]
-  const existingModelIds = new Set(configuredProfiles.map((p) => p.modelId))
+  const existingModelIds = new Set(validModelIds)
 
   for (const profile of configuredProfiles) {
-    const cached = discoveredCatalog[profile.id] ?? discoveredCatalog[profile.baseUrl]
+    const cached = filteredCatalog[profile.id] ?? filteredCatalog[profile.baseUrl]
     if (!cached || !Array.isArray(cached.models)) continue
 
     for (const item of cached.models) {


### PR DESCRIPTION
## Problem

When the localStorage cache (`dsh:discovered_models_cache:v1`) contains stale entries from removed providers, the dialog model picker shows hundreds of extra models instead of the 58 configured in the model pool.

Example: database has 58 models, but picker shows 396 because cached discovered models from old/deleted providers are merged in.

## Fix

Filter the discovered models cache against valid model IDs before merging:

1. Build a set of `modelId` values from configured profiles
2. Skip any cached catalog entry where no models match the current configured profiles
3. Only merge discovered models whose IDs still exist in the configured profiles

This prevents stale cache entries from inflating the selectable model list.

## Testing

- Cleared localStorage cache → picker shows correct 58 models
- With stale cache → only models matching current profiles are included
- No regression in normal operation