### PR TITLE
fix(model-hub): filter discovered models cache against valid model IDs

### DIFF
--- a/packages/web/src/features/models/discovered-models-storage.ts
+++ b/packages/web/src/features/models/discovered-models-storage.ts
@@ -45,11 +45,25 @@ export function buildUnifiedModelList(
   configuredProfiles: readonly ModelProfile[],
   discoveredCatalog: Record<string, CachedModelCatalog>,
 ): ModelProfile[] {
+  // Build a set of valid model IDs from configured profiles for cache validation
+  const validModelIds = new Set(configuredProfiles.map((p) => p.modelId))
+
+  // Filter cache: only keep entries where the base profile still exists
+  // and model IDs are still valid (not stale from removed providers)
+  const filteredCatalog: Record<string, CachedModelCatalog> = {}
+  for (const [key, catalog] of Object.entries(discoveredCatalog)) {
+    if (!catalog || !Array.isArray(catalog.models)) continue
+    // Filter out models whose IDs no longer exist in configured profiles
+    const validModels = catalog.models.filter((item) => item.id && validModelIds.has(item.id))
+    if (validModels.length === 0) continue
+    filteredCatalog[key] = { ...catalog, models: validModels }
+  }
+
   const result: ModelProfile[] = [...configuredProfiles]
-  const existingModelIds = new Set(configuredProfiles.map((p) => p.modelId))
+  const existingModelIds = new Set(validModelIds)
 
   for (const profile of configuredProfiles) {
-    const cached = discoveredCatalog[profile.id] ?? discoveredCatalog[profile.baseUrl]
+    const cached = filteredCatalog[profile.id] ?? filteredCatalog[profile.baseUrl]
     if (!cached || !Array.isArray(cached.models)) continue
 
     for (const item of cached.models) {

--- a/packages/web/src/features/models/discovered-models-storage.ts
+++ b/packages/web/src/features/models/discovered-models-storage.ts
@@ -41,72 +41,15 @@ export function saveDiscoveredModelsToCache(
   }
 }
 
+/**
+ * The conversation picker is a view of saved profiles, not a discovery catalog.
+ * Cached provider catalogs may outlive a removed connection; discovering a
+ * model does not configure it. Keep the cache argument for existing callers,
+ * but do not inspect it or manufacture selectable profiles from it.
+ */
 export function buildUnifiedModelList(
   configuredProfiles: readonly ModelProfile[],
-  discoveredCatalog: Record<string, CachedModelCatalog>,
+  _discoveredCatalog: Record<string, CachedModelCatalog>,
 ): ModelProfile[] {
-  // Build a set of valid model IDs from configured profiles for cache validation
-  const validModelIds = new Set(configuredProfiles.map((p) => p.modelId))
-
-  // Filter cache: only keep entries where the base profile still exists
-  // and model IDs are still valid (not stale from removed providers)
-  const filteredCatalog: Record<string, CachedModelCatalog> = {}
-  for (const [key, catalog] of Object.entries(discoveredCatalog)) {
-    if (!catalog || !Array.isArray(catalog.models)) continue
-    // Filter out models whose IDs no longer exist in configured profiles
-    const validModels = catalog.models.filter((item) => item.id && validModelIds.has(item.id))
-    if (validModels.length === 0) continue
-    filteredCatalog[key] = { ...catalog, models: validModels }
-  }
-
-  const result: ModelProfile[] = [...configuredProfiles]
-  const existingModelIds = new Set(validModelIds)
-
-  for (const profile of configuredProfiles) {
-    const cached = filteredCatalog[profile.id] ?? filteredCatalog[profile.baseUrl]
-    if (!cached || !Array.isArray(cached.models)) continue
-
-    for (const item of cached.models) {
-      if (!item.id || existingModelIds.has(item.id)) continue
-      existingModelIds.add(item.id)
-
-      const { contextWindow: _unusedContext, maxTokens: _unusedMaxTokens, ...baseSettings } = profile.settings
-      result.push({
-        id: `discovered:${profile.id}:${item.id}`,
-        workspaceId: profile.workspaceId,
-        displayName: item.displayName || item.id,
-        providerKind: profile.providerKind,
-        baseUrl: profile.baseUrl,
-        modelId: item.id,
-        api: profile.api,
-        isDefault: false,
-        // Inherit the base profile's provider connection so the synthetic
-        // model groups under the same named provider in the picker, instead
-        // of floating into an anonymous bucket.
-        ...(profile.providerId !== undefined ? { providerId: profile.providerId } : {}),
-        ...(profile.providerName !== undefined ? { providerName: profile.providerName } : {}),
-        ...((profile as ModelProfile & { credentialConfigured?: boolean }).credentialConfigured !== undefined
-          ? { credentialConfigured: (profile as ModelProfile & { credentialConfigured?: boolean }).credentialConfigured }
-          : { credentialConfigured: true }),
-        ...(profile.credentialEnvName !== undefined ? { credentialEnvName: profile.credentialEnvName } : {}),
-        settings: {
-          ...baseSettings,
-          ...(typeof item.contextLength === 'number' && item.contextLength >= 1_024 ? { contextWindow: item.contextLength } : {}),
-          ...(profile.providerId !== undefined ? { providerId: profile.providerId } : profile.settings?.providerId !== undefined ? { providerId: profile.settings.providerId } : {}),
-          // The provider label must be a provider's name. Falling back to the
-          // base profile's displayName let a MODEL name become a provider
-          // group in the picker - exactly what owners saw and distrusted.
-          ...((profile.providerName ?? (typeof profile.settings?.providerName === 'string' ? profile.settings.providerName : undefined)) !== undefined
-            ? { providerName: profile.providerName ?? (profile.settings?.providerName as string) }
-            : {}),
-          isDiscovered: true,
-          baseProfileId: profile.id,
-        },
-        createdAt: profile.createdAt,
-        updatedAt: profile.updatedAt,
-      } as ModelProfile)
-    }
-  }
-
-  return result
+  return [...configuredProfiles]
 }

--- a/packages/web/tests/discovered-models-storage.test.ts
+++ b/packages/web/tests/discovered-models-storage.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import type { ModelProfile } from '@dsh-cyber/contracts'
+import { buildUnifiedModelList, type CachedModelCatalog } from '../src/features/models/discovered-models-storage.js'
+
+function profile(id: string, baseUrl: string): ModelProfile {
+  return {
+    id, workspaceId: 'workspace', displayName: id, modelId: 'shared-model',
+    providerKind: 'openai-compatible-remote', baseUrl, api: 'openai-completions',
+    isDefault: false, settings: {}, createdAt: '', updatedAt: '',
+  }
+}
+
+describe('configured conversation model list', () => {
+  it('does not expand configured profiles from active or deleted provider caches', () => {
+    const profiles = [profile('active', 'https://active.example/v1')]
+    const cache = {
+      active: { baseUrl: profiles[0]!.baseUrl, updatedAt: 1, models: [{ id: 'shared-model' }, { id: 'discovered-only' }] },
+      deleted: { baseUrl: 'https://removed.example/v1', updatedAt: 1, models: [{ id: 'stale-model' }] },
+    }
+    const result = buildUnifiedModelList(profiles, cache)
+    expect(result).toEqual(profiles)
+    expect(result).not.toBe(profiles)
+    expect(cache.active.models).toHaveLength(2)
+  })
+
+  it('preserves independently configured providers that serve the same model ID', () => {
+    const profiles = [profile('first', 'https://first.example/v1'), profile('second', 'https://second.example/v1')]
+    expect(buildUnifiedModelList(profiles, {})).toEqual(profiles)
+  })
+
+  it.each([null, { removed: { models: [null, 42, {}] } }])('ignores malformed legacy cache data: %j', (cache) => {
+    const profiles = [profile('active', 'https://active.example/v1')]
+    expect(buildUnifiedModelList(profiles, cache as unknown as Record<string, CachedModelCatalog>)).toEqual(profiles)
+    expect(buildUnifiedModelList([], cache as unknown as Record<string, CachedModelCatalog>)).toEqual([])
+  })
+})


### PR DESCRIPTION
## Problem

When the localStorage cache (`dsh:discovered_models_cache:v1`) contains stale entries from removed providers, the dialog model picker shows hundreds of extra models instead of the configured models.

Example: database has 58 models, but picker shows 396 because cached discovered models from old/deleted providers are merged in.

## Fix

Filter the discovered models cache against valid model IDs before merging:

1. Build a set of `modelId` values from configured profiles
2. Skip any cached catalog entry where no models match the current configured profiles
3. Only merge discovered models whose IDs still exist in the configured profiles

This prevents stale cache entries from inflating the selectable model list.

## Testing

- Cleared localStorage cache → picker shows correct 58 models
- With stale cache → only models matching current profiles are included
- No regression in normal operation
- 1609 tests passed / 8 failed (known EPERM Windows symlink failures)