### PR TITLE
feat(work-system): a task remembers the turn that asked for it

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,7 @@
 import type { WorldCharacterAuthority } from './world-authority.js'
 import type { UiLocale } from './locales.js'
 
-export const CYBER_SCHEMA_VERSION = 40 as const
+export const CYBER_SCHEMA_VERSION = 41 as const
 
 export * from './runtime-access.js'
 export * from './locales.js'

--- a/packages/contracts/src/work-system.ts
+++ b/packages/contracts/src/work-system.ts
@@ -18,6 +18,23 @@ export interface WorkTask {
   currentPlanRevision: number
   createdAt: IsoTimestamp
   updatedAt: IsoTimestamp
+  /**
+   * The conversation turn whose message asked for this task.
+   *
+   * A turn owns at most one task (the database enforces it), so resending,
+   * recovering or retrying that turn finds this task again instead of minting
+   * a duplicate. Absent for tasks created from the board or a schedule, and
+   * released when the settled turn is pruned from history.
+   */
+  sourceWorkTurnId?: string
+  /** The owner message inside that turn that carried the instruction. Outlives the turn: messages are never pruned. */
+  sourceMessageId?: string
+}
+
+/** The one task a conversation turn owns, and whether this call is the one that created it. */
+export interface WorkTaskFromSource {
+  task: WorkTask
+  created: boolean
 }
 
 export type TaskPlanRevisionStatus = 'draft' | 'active' | 'superseded' | 'completed' | 'failed'

--- a/packages/contracts/tests/world-knowledge.test.ts
+++ b/packages/contracts/tests/world-knowledge.test.ts
@@ -49,6 +49,6 @@ describe('World knowledge contracts', () => {
       document: { workspaceId: 'workspace-1', chunkCount: 0 },
       chunk: { worldId: 'world-1', documentId: 'document-1' },
     })
-    expect(CYBER_SCHEMA_VERSION).toBe(40)
+    expect(CYBER_SCHEMA_VERSION).toBe(41)
   })
 })

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -2055,6 +2055,32 @@ const MIGRATIONS: readonly Migration[] = [
         );
     `,
   },
+  {
+    version: 41,
+    name: 'work-task-source-link',
+    sql: `
+      -- A task that grew out of a conversation remembers the turn that asked
+      -- for it and the owner message inside that turn. The turn id is the one
+      -- identity a resend, a recovery pass and a retry all share, so "one task
+      -- per turn" is a unique index the database enforces rather than a check
+      -- a process has to remember. NULLs are distinct to SQLite: tasks created
+      -- from the board or a schedule carry no source and are unaffected.
+      --
+      -- pruneHistory deletes settled turns. The link is released (SET NULL)
+      -- and the task survives: the task is the durable work fact, the
+      -- transcript is not. Messages are never pruned, so the message reference
+      -- outlives the turn. No backfill: rows that predate this migration have
+      -- no source and stay exactly as they are.
+      ALTER TABLE work_tasks ADD COLUMN source_work_turn_id TEXT
+        REFERENCES work_turns(id) ON DELETE SET NULL;
+      ALTER TABLE work_tasks ADD COLUMN source_message_id TEXT
+        REFERENCES messages(id) ON DELETE SET NULL;
+      CREATE UNIQUE INDEX work_tasks_source_work_turn_idx
+        ON work_tasks(source_work_turn_id);
+      CREATE INDEX work_tasks_source_message_idx
+        ON work_tasks(source_message_id) WHERE source_message_id IS NOT NULL;
+    `,
+  },
 ]
 
 /**

--- a/packages/persistence/src/work-system-repository.ts
+++ b/packages/persistence/src/work-system-repository.ts
@@ -12,6 +12,7 @@ import type {
   TaskRun,
   WorkTask,
   WorkTaskDetail,
+  WorkTaskFromSource,
   WorkTaskPriority,
   WorkTaskStatus,
   TaskCollaborationPlan,
@@ -43,8 +44,52 @@ export class WorkSystemRepository {
     return this.getTask(id)!
   }
 
+  /**
+   * The one task a conversation turn owns.
+   *
+   * Creates it on the first call and returns it on every later one — a resend
+   * of the same message, the recovery pass after a restart, a retry of the
+   * turn. Two callers racing for the same turn both get the same task because
+   * the decision is the unique index on `source_work_turn_id`, not a lookup
+   * this process did a moment earlier: the loser's insert is a no-op and the
+   * read that follows returns the winner. A later call never rewrites an
+   * existing task, even when it derived a different title this time; the
+   * owner may have edited it since.
+   */
+  createTaskFromSource(input: { workspaceId: string; worldId: string; workTurnId: string; title: string; description: string; priority: WorkTaskPriority; dueAt?: string; coordinatorEmployeeId?: string; createdBy: string }): WorkTaskFromSource {
+    const turn = this.#database.prepare('SELECT workspace_id, world_id, session_id FROM work_turns WHERE id = ?').get(input.workTurnId) as
+      | { workspace_id: string; world_id: string; session_id: string }
+      | undefined
+    if (turn === undefined) throw new EntityNotFoundError(`Source work turn not found: ${input.workTurnId}`)
+    if (turn.workspace_id !== input.workspaceId || turn.world_id !== input.worldId) throw new PersistenceError('Source work turn does not belong to this world')
+    // The same rule the queue uses to find a turn's prompt again after a restart.
+    const message = this.#database.prepare(
+      `SELECT id FROM messages
+       WHERE session_id = ? AND kind = 'user' AND json_extract(metadata_json, '$.workTurnId') = ?
+       ORDER BY sequence LIMIT 1`,
+    ).get(turn.session_id, input.workTurnId) as { id: string } | undefined
+    if (message === undefined) throw new PersistenceError('Source work turn has no owner message')
+    const now = this.#clock()
+    const inserted = this.#database.prepare(
+      `INSERT INTO work_tasks
+       (id, workspace_id, world_id, title, description, status, priority, due_at,
+        budget_json, created_by, coordinator_employee_id, current_plan_revision, created_at, updated_at,
+        source_work_turn_id, source_message_id)
+       VALUES (?, ?, ?, ?, ?, 'draft', ?, ?, '{}', ?, ?, 0, ?, ?, ?, ?)
+       ON CONFLICT (source_work_turn_id) DO NOTHING`,
+    ).run(this.#id(), input.workspaceId, input.worldId, input.title, input.description, input.priority, input.dueAt ?? null, input.createdBy, input.coordinatorEmployeeId ?? null, now, now, input.workTurnId, message.id)
+    const task = this.getTaskBySourceWorkTurn(input.workTurnId)
+    if (task === undefined) throw new PersistenceError(`Work Task for source turn ${input.workTurnId} is missing after insert`)
+    return { task, created: Number(inserted.changes) === 1 }
+  }
+
   getTask(taskId: string): WorkTask | undefined {
     const row = this.#database.prepare('SELECT * FROM work_tasks WHERE id = ?').get(taskId)
+    return row === undefined ? undefined : mapTask(row)
+  }
+
+  getTaskBySourceWorkTurn(workTurnId: string): WorkTask | undefined {
+    const row = this.#database.prepare('SELECT * FROM work_tasks WHERE source_work_turn_id = ?').get(workTurnId)
     return row === undefined ? undefined : mapTask(row)
   }
 
@@ -226,7 +271,7 @@ export class WorkSystemRepository {
 
 const json = <T>(value: unknown): T => JSON.parse(String(value)) as T
 const optional = (value: unknown): string | undefined => typeof value === 'string' ? value : undefined
-function mapTask(row: object): WorkTask { const v = row as Record<string, unknown>; return { id: String(v.id), workspaceId: String(v.workspace_id), worldId: String(v.world_id), title: String(v.title), description: String(v.description), status: v.status as WorkTaskStatus, priority: v.priority as WorkTaskPriority, budget: json<JsonObject>(v.budget_json), createdBy: String(v.created_by), currentPlanRevision: Number(v.current_plan_revision), createdAt: String(v.created_at), updatedAt: String(v.updated_at), ...(optional(v.due_at) === undefined ? {} : { dueAt: optional(v.due_at)! }), ...(optional(v.coordinator_employee_id) === undefined ? {} : { coordinatorEmployeeId: optional(v.coordinator_employee_id)! }) } }
+function mapTask(row: object): WorkTask { const v = row as Record<string, unknown>; return { id: String(v.id), workspaceId: String(v.workspace_id), worldId: String(v.world_id), title: String(v.title), description: String(v.description), status: v.status as WorkTaskStatus, priority: v.priority as WorkTaskPriority, budget: json<JsonObject>(v.budget_json), createdBy: String(v.created_by), currentPlanRevision: Number(v.current_plan_revision), createdAt: String(v.created_at), updatedAt: String(v.updated_at), ...(optional(v.due_at) === undefined ? {} : { dueAt: optional(v.due_at)! }), ...(optional(v.coordinator_employee_id) === undefined ? {} : { coordinatorEmployeeId: optional(v.coordinator_employee_id)! }), ...(optional(v.source_work_turn_id) === undefined ? {} : { sourceWorkTurnId: optional(v.source_work_turn_id)! }), ...(optional(v.source_message_id) === undefined ? {} : { sourceMessageId: optional(v.source_message_id)! }) } }
 function mapPlan(row: object): TaskPlanRevision { const v = row as Record<string, unknown>; return { id: String(v.id), taskId: String(v.task_id), revision: Number(v.revision), status: v.status as TaskPlanRevision['status'], summary: String(v.summary), executionMode: v.execution_mode as TaskPlanRevision['executionMode'], createdBy: String(v.created_by), createdAt: String(v.created_at) } }
 function mapStep(row: object): TaskPlanStep { const v = row as Record<string, unknown>; return { id: String(v.id), planRevisionId: String(v.plan_revision_id), ordinal: Number(v.ordinal), title: String(v.title), description: String(v.description), requiredSkills: json<string[]>(v.required_skills_json), assignedEmployeeIds: json<string[]>(v.assigned_employee_ids_json), dependsOn: json<string[]>(v.depends_on_json), executionMode: v.execution_mode as TaskPlanStep['executionMode'], expectedOutput: String(v.expected_output), status: v.status as TaskPlanStep['status'] } }
 function mapAssignment(row: object): TaskAssignment { const v = row as Record<string, unknown>; return { id: String(v.id), taskId: String(v.task_id), planRevisionId: String(v.plan_revision_id), stepId: String(v.step_id), employeeId: String(v.employee_id), assignmentReason: json<JsonObject>(v.assignment_reason_json), requiredSkills: json<string[]>(v.required_skills_json), status: v.status as TaskAssignment['status'], createdAt: String(v.created_at), updatedAt: String(v.updated_at) } }

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -11,6 +11,7 @@ import {
   DatabaseCorruptError,
   SecretPersistenceError,
   SqliteStore,
+  WorkSystemRepository,
   exportReadonlyRecovery,
 } from '../src/index.js'
 
@@ -942,6 +943,10 @@ describe('SqliteStore', () => {
     // keeping every milestone that database already held.
     const legacy = new DatabaseSync(path)
     legacy.exec(`
+      DROP INDEX work_tasks_source_message_idx;
+      DROP INDEX work_tasks_source_work_turn_idx;
+      ALTER TABLE work_tasks DROP COLUMN source_message_id;
+      ALTER TABLE work_tasks DROP COLUMN source_work_turn_id;
       DROP TABLE agent_run_context_snapshots;
       DROP TABLE IF EXISTS employee_memory_index_fts;
       DROP TABLE employee_memory_index;
@@ -1023,6 +1028,10 @@ describe('SqliteStore', () => {
     // keeping every row that database already held.
     const legacy = new DatabaseSync(path)
     legacy.exec(`
+      DROP INDEX work_tasks_source_message_idx;
+      DROP INDEX work_tasks_source_work_turn_idx;
+      ALTER TABLE work_tasks DROP COLUMN source_message_id;
+      ALTER TABLE work_tasks DROP COLUMN source_work_turn_id;
       DROP TABLE agent_run_context_snapshots;
       DROP INDEX model_profiles_provider_model_idx;
       ALTER TABLE model_profiles DROP COLUMN provider_id;
@@ -1397,6 +1406,10 @@ describe('SqliteStore', () => {
     // the whole stack the way a 36 database in the field would.
     const downgraded = new DatabaseSync(path)
     downgraded.exec(`
+      DROP INDEX work_tasks_source_message_idx;
+      DROP INDEX work_tasks_source_work_turn_idx;
+      ALTER TABLE work_tasks DROP COLUMN source_message_id;
+      ALTER TABLE work_tasks DROP COLUMN source_work_turn_id;
       DROP TABLE agent_run_context_snapshots;
       ALTER TABLE employee_milestones DROP COLUMN origin;
       DROP TABLE employee_memory_index;
@@ -1463,6 +1476,10 @@ describe('SqliteStore', () => {
     // that v39 allowed so the forward migration must preserve them.
     const legacy = new DatabaseSync(path)
     legacy.exec(`
+      DROP INDEX work_tasks_source_message_idx;
+      DROP INDEX work_tasks_source_work_turn_idx;
+      ALTER TABLE work_tasks DROP COLUMN source_message_id;
+      ALTER TABLE work_tasks DROP COLUMN source_work_turn_id;
       DROP INDEX model_profiles_provider_model_idx;
       ALTER TABLE model_profiles DROP COLUMN provider_id;
       ALTER TABLE model_profiles DROP COLUMN origin;
@@ -1490,5 +1507,63 @@ describe('SqliteStore', () => {
     await exportReadonlyRecovery(path, recoveryPath)
     const recovery = JSON.parse(await readFile(recoveryPath, 'utf8')) as { tables?: { model_providers?: unknown[] } }
     expect(recovery.tables?.model_providers).toHaveLength(2)
+  })
+
+  it('adds the task source link after v40 without rewriting existing tasks', async () => {
+    const { directory, path, store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: '任务来源迁移工作区' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: '任务来源世界', templateId: 'cyber-company' })
+    store.saveBlueprint(blueprint({ id: 'source.worker', worldTemplateId: 'cyber-company' }))
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id, worldId: world.id, blueprintId: 'source.worker', blueprintVersion: 1,
+    })
+    const session = store.createSession({
+      workspaceId: workspace.id, worldId: world.id, kind: 'direct', title: '私聊',
+      participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: employee.id, kind: 'employee' }],
+    })
+    const turn = store.createWorkTurn({ workspaceId: workspace.id, worldId: world.id, sessionId: session.id, interactionKind: 'chat' })
+    const message = store.appendMessage({
+      sessionId: session.id, senderId: 'owner', senderKind: 'owner', kind: 'user', content: '请整理本周周报。', metadata: { workTurnId: turn.id },
+    })
+    const legacyTask = new WorkSystemRepository(store.database).createTask({
+      workspaceId: workspace.id, worldId: world.id, title: '迁移前的任务', description: '在来源关联存在之前创建。', priority: 'normal', createdBy: 'owner',
+    })
+    store.close()
+    stores.splice(stores.indexOf(store), 1)
+
+    // Rewind only the source-link migration, keeping every row the file held.
+    const legacy = new DatabaseSync(path)
+    legacy.exec(`
+      DROP INDEX work_tasks_source_message_idx;
+      DROP INDEX work_tasks_source_work_turn_idx;
+      ALTER TABLE work_tasks DROP COLUMN source_message_id;
+      ALTER TABLE work_tasks DROP COLUMN source_work_turn_id;
+      DELETE FROM schema_migrations WHERE version > 40;
+      PRAGMA user_version = 40;
+    `)
+    legacy.close()
+
+    const migrated = await SqliteStore.open(path)
+    stores.push(migrated)
+    expect((await readdir(directory)).some((file) => file.startsWith('cyber.sqlite.pre-migration-v40-'))).toBe(true)
+    expect(migrated.database.prepare('PRAGMA foreign_key_check').all()).toEqual([])
+    expect(migrated.doctor()).toMatchObject({ ok: true, schemaVersion: CYBER_SCHEMA_VERSION })
+
+    // Additive only: the task that predates the migration reads back exactly
+    // as it was and gains no invented source. One task per turn is a database
+    // rule (a unique index), not something the process has to remember.
+    const repository = new WorkSystemRepository(migrated.database)
+    expect(repository.getTask(legacyTask.id)).toEqual(legacyTask)
+    expect(migrated.database.prepare(
+      `SELECT "unique" AS isUnique, partial FROM pragma_index_list('work_tasks') WHERE name = 'work_tasks_source_work_turn_idx'`,
+    ).get()).toMatchObject({ isUnique: 1, partial: 0 })
+    const source = {
+      workspaceId: workspace.id, worldId: world.id, workTurnId: turn.id,
+      title: '整理本周周报', description: '把本周的会议纪要整理成一页周报。', priority: 'normal' as const, createdBy: 'owner',
+    }
+    const linked = repository.createTaskFromSource(source)
+    expect(linked).toMatchObject({ created: true, task: { sourceWorkTurnId: turn.id, sourceMessageId: message.id } })
+    expect(repository.createTaskFromSource(source)).toEqual({ created: false, task: linked.task })
+    expect(repository.listTasks(world.id).map((task) => task.id).sort()).toEqual([legacyTask.id, linked.task.id].sort())
   })
 })

--- a/packages/persistence/tests/work-task-source-link.test.ts
+++ b/packages/persistence/tests/work-task-source-link.test.ts
@@ -1,0 +1,215 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+
+import type { EmployeeBlueprint } from '@dsh-cyber/contracts'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { EntityNotFoundError, PersistenceError, SqliteStore, WorkSystemRepository } from '../src/index.js'
+
+/**
+ * A task that grew out of a conversation is keyed by the WorkTurn that asked
+ * for it. Resend, recovery and retry all share that turn id, so "one task per
+ * turn" has to hold in the database itself — not only in the process that
+ * happened to run the first create.
+ */
+
+const stores: SqliteStore[] = []
+const connections: DatabaseSync[] = []
+
+afterEach(() => {
+  for (const connection of connections.splice(0)) connection.close()
+  for (const store of stores.splice(0)) store.close()
+})
+
+async function testDatabase(): Promise<{ path: string; store: SqliteStore }> {
+  const directory = await mkdtemp(join(tmpdir(), 'dsh-cyber-task-source-'))
+  const path = join(directory, 'cyber.sqlite')
+  const store = await SqliteStore.open(path)
+  stores.push(store)
+  return { path, store }
+}
+
+interface Conversation { workspaceId: string; worldId: string; sessionId: string; employeeId: string }
+
+function conversation(store: SqliteStore, name: string): Conversation {
+  const workspace = store.createWorkspace({ name: `${name}工作区` })
+  const world = store.createWorld({ workspaceId: workspace.id, name, templateId: 'cyber-company' })
+  const employee = recruit(store, workspace.id, world.id, `${name}助手`)
+  const session = store.createSession({
+    workspaceId: workspace.id, worldId: world.id, kind: 'direct', title: '私聊',
+    participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: employee.id, kind: 'employee' }],
+  })
+  return { workspaceId: workspace.id, worldId: world.id, sessionId: session.id, employeeId: employee.id }
+}
+
+/** What the orchestrator writes for one sent message: a turn and the owner message stamped with it. */
+function send(store: SqliteStore, context: Conversation, content: string, clientTurnId?: string) {
+  const turn = store.createWorkTurn({
+    workspaceId: context.workspaceId, worldId: context.worldId, sessionId: context.sessionId, interactionKind: 'chat',
+    ...(clientTurnId === undefined ? {} : { clientTurnId }),
+  })
+  const message = store.appendMessage({
+    sessionId: context.sessionId, senderId: 'owner', senderKind: 'owner', kind: 'user', content,
+    metadata: { workTurnId: turn.id, ...(clientTurnId === undefined ? {} : { clientTurnId }) },
+  })
+  return { turn, message }
+}
+
+function draft(context: Conversation, workTurnId: string, overrides: Partial<{ title: string; description: string }> = {}) {
+  return {
+    workspaceId: context.workspaceId, worldId: context.worldId, workTurnId,
+    title: '整理本周周报', description: '把本周的会议纪要整理成一页周报。', priority: 'normal' as const, createdBy: 'owner',
+    ...overrides,
+  }
+}
+
+describe('WorkTask source link', () => {
+  it('creates one task per source turn and hands the same task back on a resend', async () => {
+    const { store } = await testDatabase()
+    const context = conversation(store, '来源世界')
+    const repository = new WorkSystemRepository(store.database)
+    const { turn, message } = send(store, context, '请整理本周周报。', 'client-turn-1')
+
+    const first = repository.createTaskFromSource(draft(context, turn.id))
+    expect(first.created).toBe(true)
+    expect(first.task).toMatchObject({
+      status: 'draft', title: '整理本周周报', sourceWorkTurnId: turn.id, sourceMessageId: message.id, createdBy: 'owner',
+    })
+
+    // A resend carries the same turn: the existing task comes back untouched,
+    // even when the caller derived a slightly different title this time.
+    const again = repository.createTaskFromSource(draft(context, turn.id, { title: '整理周报（重发）' }))
+    expect(again.created).toBe(false)
+    expect(again.task).toEqual(first.task)
+    expect(repository.getTaskBySourceWorkTurn(turn.id)).toEqual(first.task)
+    expect(repository.listTasks(context.worldId).map((task) => task.id)).toEqual([first.task.id])
+    expect(repository.detail(first.task.id).task).toEqual(first.task)
+  })
+
+  it('gives a different turn its own task', async () => {
+    const { store } = await testDatabase()
+    const context = conversation(store, '双回合世界')
+    const repository = new WorkSystemRepository(store.database)
+    const first = send(store, context, '整理周报。')
+    const second = send(store, context, '再写一封邮件。')
+
+    const a = repository.createTaskFromSource(draft(context, first.turn.id))
+    const b = repository.createTaskFromSource(draft(context, second.turn.id, { title: '写一封邮件' }))
+    expect(a.created && b.created).toBe(true)
+    expect(a.task.id).not.toBe(b.task.id)
+    expect(b.task).toMatchObject({ sourceWorkTurnId: second.turn.id, sourceMessageId: second.message.id })
+    expect(repository.listTasks(context.worldId)).toHaveLength(2)
+  })
+
+  it('is enforced by the database when the application check is bypassed', async () => {
+    const { store } = await testDatabase()
+    const context = conversation(store, '直写世界')
+    const repository = new WorkSystemRepository(store.database)
+    const { turn, message } = send(store, context, '整理周报。')
+    repository.createTaskFromSource(draft(context, turn.id))
+
+    const now = new Date().toISOString()
+    expect(() => store.database.prepare(
+      `INSERT INTO work_tasks
+       (id, workspace_id, world_id, title, description, status, priority, due_at, budget_json,
+        created_by, coordinator_employee_id, current_plan_revision, created_at, updated_at,
+        source_work_turn_id, source_message_id)
+       VALUES ('bypass', ?, ?, '绕过应用层', '直接写库', 'draft', 'normal', NULL, '{}', 'owner', NULL, 0, ?, ?, ?, ?)`,
+    ).run(context.workspaceId, context.worldId, now, now, turn.id, message.id))
+      .toThrow(/UNIQUE constraint failed: work_tasks\.source_work_turn_id/)
+    expect(repository.listTasks(context.worldId)).toHaveLength(1)
+  })
+
+  it('converges two connections that cannot see each other on one task', async () => {
+    const { path, store } = await testDatabase()
+    const context = conversation(store, '并发世界')
+    const { turn } = send(store, context, '整理周报。')
+    const mine = new WorkSystemRepository(store.database)
+
+    // A second connection has no memory of what the first one did: only the
+    // unique index can tell it the turn is already taken.
+    const other = new DatabaseSync(path)
+    connections.push(other)
+    other.exec('PRAGMA foreign_keys = ON; PRAGMA busy_timeout = 5000')
+    const theirs = new WorkSystemRepository(other)
+
+    const first = theirs.createTaskFromSource(draft(context, turn.id))
+    const second = mine.createTaskFromSource(draft(context, turn.id))
+    expect([first.created, second.created]).toEqual([true, false])
+    expect(second.task.id).toBe(first.task.id)
+    expect(store.database.prepare('SELECT COUNT(*) AS count FROM work_tasks WHERE source_work_turn_id = ?').get(turn.id))
+      .toMatchObject({ count: 1 })
+  })
+
+  it('leaves tasks without a source alone, however many there are', async () => {
+    const { store } = await testDatabase()
+    const context = conversation(store, '看板世界')
+    const repository = new WorkSystemRepository(store.database)
+    const plain = { workspaceId: context.workspaceId, worldId: context.worldId, title: '看板任务', description: '从任务看板创建。', priority: 'normal' as const, createdBy: 'owner' }
+    const a = repository.createTask(plain)
+    const b = repository.createTask(plain)
+    expect(a.id).not.toBe(b.id)
+    expect(a).not.toHaveProperty('sourceWorkTurnId')
+    expect(a).not.toHaveProperty('sourceMessageId')
+    expect(repository.listTasks(context.worldId)).toHaveLength(2)
+  })
+
+  it('refuses a turn it cannot vouch for: unknown, from another world, or without an owner message', async () => {
+    const { store } = await testDatabase()
+    const home = conversation(store, '本世界')
+    const elsewhere = conversation(store, '他世界')
+    const repository = new WorkSystemRepository(store.database)
+    const foreign = send(store, elsewhere, '他世界的消息。')
+    const silent = store.createWorkTurn({ workspaceId: home.workspaceId, worldId: home.worldId, sessionId: home.sessionId, interactionKind: 'peer' })
+    store.appendMessage({ sessionId: home.sessionId, senderId: 'system', senderKind: 'system', kind: 'system', content: '角色协作目标：无', metadata: { workTurnId: silent.id } })
+
+    expect(() => repository.createTaskFromSource(draft(home, 'missing-turn'))).toThrow(EntityNotFoundError)
+    expect(() => repository.createTaskFromSource(draft(home, foreign.turn.id))).toThrow(PersistenceError)
+    expect(() => repository.createTaskFromSource(draft(home, foreign.turn.id))).toThrow(/world/)
+    expect(() => repository.createTaskFromSource(draft(home, silent.id))).toThrow(/owner message/)
+    expect(repository.listTasks(home.worldId)).toEqual([])
+    expect(repository.listTasks(elsewhere.worldId)).toEqual([])
+  })
+
+  it('keeps the task and its message reference when the settled source turn is pruned', async () => {
+    const { store } = await testDatabase()
+    const context = conversation(store, '清理世界')
+    const repository = new WorkSystemRepository(store.database)
+    const { turn, message } = send(store, context, '整理周报。')
+    const { task } = repository.createTaskFromSource(draft(context, turn.id))
+    store.startWorkTurn(turn.id)
+    store.completeWorkTurn(turn.id)
+
+    const pruned = store.pruneHistory({ before: '2999-01-01T00:00:00.000Z' })
+    expect(pruned.workTurns).toBeGreaterThanOrEqual(1)
+    expect(store.getWorkTurn(turn.id)).toBeUndefined()
+
+    // The transcript is not the work fact: the task survives, the turn link is
+    // released, and the message (never pruned) is still the recorded source.
+    const survivor = repository.getTask(task.id)
+    expect(survivor).toMatchObject({ id: task.id, title: task.title, sourceMessageId: message.id })
+    expect(survivor).not.toHaveProperty('sourceWorkTurnId')
+    expect(repository.getTaskBySourceWorkTurn(turn.id)).toBeUndefined()
+    expect(store.database.prepare('PRAGMA foreign_key_check').all()).toEqual([])
+  })
+})
+
+function recruit(store: SqliteStore, workspaceId: string, worldId: string, displayName: string) {
+  const blueprint: EmployeeBlueprint = {
+    schemaVersion: 1,
+    id: `test.${worldId}.${displayName}`,
+    version: 1,
+    worldTemplateId: 'cyber-company',
+    displayName,
+    role: '协作角色',
+    summary: '任务来源测试角色',
+    persona: '保持当前世界边界。',
+    requestedSkills: [],
+    requestedCapabilities: [],
+    createdAt: '2026-09-04T00:00:00.000Z',
+  }
+  store.saveBlueprint(blueprint)
+  return store.recruitEmployee({ workspaceId, worldId, blueprintId: blueprint.id, blueprintVersion: 1, displayName })
+}

--- a/packages/server/src/services/work-system-service.ts
+++ b/packages/server/src/services/work-system-service.ts
@@ -1,4 +1,4 @@
-import type { Deliverable, Review, WorkTask, WorkTaskDetail, WorkTaskPriority, WorkTaskStatus } from '@dsh-cyber/contracts'
+import { parseCreateWorkTask, type Deliverable, type Review, type WorkTask, type WorkTaskDetail, type WorkTaskFromSource, type WorkTaskPriority, type WorkTaskStatus } from '@dsh-cyber/contracts'
 import { SqliteUnitOfWork, WorkSystemRepository, type SqliteStore } from '@dsh-cyber/persistence'
 
 import type { GroupTaskCollaborationService } from './group-task-collaboration-service.js'
@@ -23,7 +23,37 @@ export class WorkSystemService {
     return this.#repository.createTask({ ...input, createdBy: 'owner' })
   }
 
+  /**
+   * The task a conversation turn asked for.
+   *
+   * Created on the first call; found again when the same turn comes back
+   * through a resend, the recovery pass after a restart or a retry — never a
+   * second task for one turn, and never an error the UI cannot act on: the
+   * later caller gets the earlier caller's task with `created: false`. This
+   * only records the task. Execution stays with the queue and the Run that
+   * already own the turn.
+   */
+  createFromSource(input: { worldId: string; workTurnId: string; title: string; description: string; priority?: WorkTaskPriority; dueAt?: string; coordinatorEmployeeId?: string }): WorkTaskFromSource {
+    const world = this.#store.getWorld(input.worldId)
+    if (world === undefined || world.status === 'archived') throw new Error('任务世界不可用')
+    const turn = this.#store.getWorkTurn(input.workTurnId)
+    if (turn === undefined) throw new Error('来源回合不存在')
+    if (turn.workspaceId !== world.workspaceId || turn.worldId !== world.id) throw new Error('来源回合不属于当前世界')
+    const draft = parseCreateWorkTask({
+      title: input.title,
+      description: input.description,
+      priority: input.priority,
+      dueAt: input.dueAt,
+      coordinatorEmployeeId: input.coordinatorEmployeeId,
+    })
+    if (draft.coordinatorEmployeeId !== undefined) this.#requireEmployee(world.id, draft.coordinatorEmployeeId)
+    return this.#uow.run(() => this.#repository.createTaskFromSource({
+      ...draft, workspaceId: world.workspaceId, worldId: world.id, workTurnId: turn.id, createdBy: 'owner',
+    }))
+  }
+
   list(worldId: string, status?: WorkTaskStatus): WorkTask[] { return this.#repository.listTasks(worldId, status) }
+  taskForSourceTurn(workTurnId: string): WorkTask | undefined { return this.#repository.getTaskBySourceWorkTurn(workTurnId) }
   detail(taskId: string): WorkTaskDetail { return this.#repository.detail(taskId) }
   currentWork(employeeId: string): WorkTaskDetail[] { return this.#repository.currentWork(employeeId) }
   taskForDeliverable(deliverableId: string): WorkTask | undefined { return this.#repository.taskForDeliverable(deliverableId) }

--- a/packages/server/tests/work-task-source-link.test.ts
+++ b/packages/server/tests/work-task-source-link.test.ts
@@ -1,0 +1,147 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+import { WorkSystemContractError, type EmployeeBlueprint } from '@dsh-cyber/contracts'
+import { SqliteStore } from '@dsh-cyber/persistence'
+
+import type { GroupTaskCollaborationService } from '../src/services/group-task-collaboration-service.js'
+import { WorkSystemService } from '../src/services/work-system-service.js'
+
+/**
+ * The service entry point the conversation route will call once the intent
+ * router decides a message is an instruction: hand it the turn the queue just
+ * minted, get back the one task that turn owns — created now or found from an
+ * earlier send, recovery pass or retry — never a duplicate and never an error
+ * the UI cannot act on.
+ */
+
+const stores: SqliteStore[] = []
+
+afterEach(() => {
+  for (const store of stores.splice(0)) store.close()
+})
+
+async function open(path?: string): Promise<{ path: string; store: SqliteStore }> {
+  const target = path ?? join(await mkdtemp(join(tmpdir(), 'dsh-cyber-task-source-service-')), 'cyber.sqlite')
+  const store = await SqliteStore.open(target)
+  stores.push(store)
+  return { path: target, store }
+}
+
+/** createFromSource must only record the task; nothing may run because of it. */
+const neverRuns = {
+  run: async () => { throw new Error('createFromSource must not start a run') },
+} as unknown as GroupTaskCollaborationService
+
+function service(store: SqliteStore): WorkSystemService {
+  return new WorkSystemService({ store, groupTasks: neverRuns })
+}
+
+interface Conversation { workspaceId: string; worldId: string; sessionId: string; employeeId: string }
+
+function conversation(store: SqliteStore, name: string): Conversation {
+  const workspace = store.createWorkspace({ name: `${name}工作区` })
+  const world = store.createWorld({ workspaceId: workspace.id, name, templateId: 'cyber-company' })
+  const blueprint: EmployeeBlueprint = {
+    schemaVersion: 1, id: `test.${world.id}.assistant`, version: 1, worldTemplateId: 'cyber-company',
+    displayName: `${name}助手`, role: '助理', summary: '任务来源测试角色', persona: '保持当前世界边界。',
+    requestedSkills: [], requestedCapabilities: [], createdAt: '2026-09-04T00:00:00.000Z',
+  }
+  store.saveBlueprint(blueprint)
+  const employee = store.recruitEmployee({ workspaceId: workspace.id, worldId: world.id, blueprintId: blueprint.id, blueprintVersion: 1 })
+  const session = store.createSession({
+    workspaceId: workspace.id, worldId: world.id, kind: 'direct', title: '私聊',
+    participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: employee.id, kind: 'employee' }],
+  })
+  return { workspaceId: workspace.id, worldId: world.id, sessionId: session.id, employeeId: employee.id }
+}
+
+function send(store: SqliteStore, context: Conversation, content: string) {
+  const turn = store.createWorkTurn({ workspaceId: context.workspaceId, worldId: context.worldId, sessionId: context.sessionId, interactionKind: 'chat' })
+  const message = store.appendMessage({
+    sessionId: context.sessionId, senderId: 'owner', senderKind: 'owner', kind: 'user', content, metadata: { workTurnId: turn.id },
+  })
+  return { turn, message }
+}
+
+describe('WorkSystemService.createFromSource', () => {
+  it('resolves the same turn to one task: sent twice, double-created, and again after a restart', async () => {
+    const { path, store } = await open()
+    const context = conversation(store, '来源世界')
+    const { turn, message } = send(store, context, '请整理本周周报。')
+    const work = service(store)
+    const input = { worldId: context.worldId, workTurnId: turn.id, title: '整理本周周报', description: '请整理本周周报。' }
+
+    const first = work.createFromSource(input)
+    expect(first.created).toBe(true)
+    expect(first.task).toMatchObject({
+      worldId: context.worldId, status: 'draft', priority: 'normal', sourceWorkTurnId: turn.id, sourceMessageId: message.id,
+    })
+    expect(work.createFromSource(input)).toEqual({ created: false, task: first.task })
+
+    // Two creates racing for the same turn — what a resend that overtakes the
+    // first request looks like — still end on one task id.
+    const raced = await Promise.all([
+      Promise.resolve().then(() => work.createFromSource(input)),
+      Promise.resolve().then(() => work.createFromSource(input)),
+    ])
+    expect(raced.map((result) => result.task.id)).toEqual([first.task.id, first.task.id])
+    expect(raced.some((result) => result.created)).toBe(false)
+
+    // Recovery after a restart replays the intent from the durable turn and
+    // finds the task instead of minting another.
+    store.close()
+    stores.splice(stores.indexOf(store), 1)
+    const { store: reopened } = await open(path)
+    const recovered = service(reopened).createFromSource(input)
+    expect(recovered).toEqual({ created: false, task: first.task })
+    expect(service(reopened).list(context.worldId).map((task) => task.id)).toEqual([first.task.id])
+    expect(service(reopened).detail(first.task.id).task).toMatchObject({ sourceWorkTurnId: turn.id, sourceMessageId: message.id })
+  })
+
+  it('gives each turn its own task and honours the same limits as the task board', async () => {
+    const { store } = await open()
+    const context = conversation(store, '双回合世界')
+    const first = send(store, context, '整理周报。')
+    const second = send(store, context, '再写一封邮件。')
+    const work = service(store)
+
+    const a = work.createFromSource({ worldId: context.worldId, workTurnId: first.turn.id, title: '整理周报', description: '整理周报。' })
+    const b = work.createFromSource({
+      worldId: context.worldId, workTurnId: second.turn.id, title: '写一封邮件', description: '再写一封邮件。',
+      priority: 'high', coordinatorEmployeeId: context.employeeId,
+    })
+    expect(a.task.id).not.toBe(b.task.id)
+    expect(b.task).toMatchObject({ priority: 'high', coordinatorEmployeeId: context.employeeId, sourceWorkTurnId: second.turn.id })
+    expect(work.list(context.worldId)).toHaveLength(2)
+
+    expect(() => work.createFromSource({ worldId: context.worldId, workTurnId: second.turn.id, title: 'x'.repeat(161), description: '过长标题' }))
+      .toThrow(WorkSystemContractError)
+    expect(() => work.createFromSource({ worldId: context.worldId, workTurnId: second.turn.id, title: '缺少目标', description: '   ' }))
+      .toThrow(WorkSystemContractError)
+    expect(() => work.createFromSource({ worldId: context.worldId, workTurnId: first.turn.id, title: '陌生协调角色', description: '目标', coordinatorEmployeeId: 'nobody' }))
+      .toThrow('任务角色不可用')
+  })
+
+  it('refuses a turn from another world or an archived world without creating anything', async () => {
+    const { store } = await open()
+    const home = conversation(store, '本世界')
+    const elsewhere = conversation(store, '他世界')
+    const foreign = send(store, elsewhere, '他世界的指令。')
+    const work = service(store)
+
+    expect(() => work.createFromSource({ worldId: home.worldId, workTurnId: foreign.turn.id, title: '跨世界', description: '他世界的指令。' }))
+      .toThrow('来源回合不属于当前世界')
+    expect(() => work.createFromSource({ worldId: home.worldId, workTurnId: 'missing', title: '未知回合', description: '目标' }))
+      .toThrow('来源回合不存在')
+
+    const own = send(store, home, '本世界的指令。')
+    store.archiveWorld({ worldId: home.worldId })
+    expect(() => work.createFromSource({ worldId: home.worldId, workTurnId: own.turn.id, title: '归档世界', description: '本世界的指令。' }))
+      .toThrow('任务世界不可用')
+    expect(work.list(home.worldId)).toEqual([])
+    expect(work.list(elsewhere.worldId)).toEqual([])
+  })
+})


### PR DESCRIPTION
交接文档 A 组的第一件:**一条从会话长出来的任务,记住是哪一个回合要求的**。重发同一条消息、重启后的恢复、重试同一回合,都只对应**同一条任务**,而不是每次新建一条。

**这是合同层,不含意图识别。** 文档 A 组要求「明确执行意图自动形成任务清单,普通问答和讨论不要生成任务」——那一片(`conversation-routes.ts` 的意图判定)是下一个 PR,本片只交付它要用的持久合同与幂等入口,所以本 PR 不改任何会话路由,现有行为一行未变。

## 迁移 41

`work_tasks` 加两列,都可空、都是外键:

- `source_work_turn_id` → `work_turns(id)`,`ON DELETE SET NULL`,并建**唯一索引**。
- `source_message_id` → `messages(id)`,`ON DELETE SET NULL`,部分索引(非空时)。

**「一个回合一条任务」由数据库执行,不是由某个进程记得去检查。** SQLite 的唯一索引里 NULL 彼此不同,所以从任务板或日程创建的、没有来源的任务完全不受影响。

**不回填**:迁移之前的行没有来源,保持原样。`pruneHistory` 删掉已结算的回合时,链接被置空而**任务存活**——任务是持久的工作事实,聊天记录不是。消息从不被 prune,所以消息引用比回合活得久。

## 幂等靠的是索引,不是「刚才查过」

`createTaskFromSource` 先 `INSERT … ON CONFLICT (source_work_turn_id) DO NOTHING`,再按来源回合读回来。两个调用者同时抢同一个回合,双方拿到的是同一条任务:输的那次插入是空操作,随后的读取返回赢家的行。返回 `{ task, created }`,所以后到的调用者拿到的是**已存在的任务**,而不是一个界面无法处理的错误。

**已存在的任务永远不会被改写**,哪怕这次推导出的标题不一样——用户可能已经编辑过它。

入库前校验:来源回合必须存在、且属于当前 world/workspace(跨世界的回合 id 被拒),并且必须能按 `metadata_json.workTurnId` 找到该回合的用户消息(用的是队列在重启后找回合提示词的同一条规则)。服务层再走一遍现有的 `parseCreateWorkTask` 与协调角色校验,不新增第二套校验。

**只登记,不执行**:执行仍归已有的队列和 Run,没有第二套执行器。

## 测试

362 行新测试,分持久层与服务层两处:同一回合重复调用只得到一条任务(`created` 第二次为 false);两个调用交错竞争同一回合仍是一条;不同回合是不同任务;跨世界的来源回合被拒;没有用户消息的回合被拒;迁移前的无来源任务不受唯一索引影响;`pruneHistory` 之后任务存活且消息引用仍在。

## 验证

```
pnpm typecheck    通过
pnpm test         1631 通过 / 1 跳过 / 1 失败（local-harness.integration.test.ts）
                  ^ 干净 origin/main 上同样红，非本 PR 引入
pnpm test:migration38/38
pnpm test:schema  34/34
pnpm test:smoke   30/30
```

## 关于这份改动的来路,我必须说清楚

这是我派出的子 agent 的产出,但**它在跑自己的门禁之前就被停掉了**(额度原因),所以它没有留下自述报告,也没有「先红后绿」的证据——它的测试与实现在同两个提交里,无法拆出一个只含测试的红提交。上面的验证是**我自己重跑的完整门禁**,代码我逐行读过。要「先红」证据的话,我可以补一个只含测试的提交重跑,说一声。

## 明确没做

- 会话意图 → 任务清单的判定(A 组下一片,依赖本合同)。
- 现有任务的回填。
- `sourceMessageId` 目前只存不用;界面上「这条任务来自哪条消息」的跳转是后续。

## 需要你决定

1. **落地顺序**:本 PR 带迁移 41。任何其他带迁移的 PR(计划中 C 组的分块游标是 42)必须在它**之后**合并——迁移运行器是 `if (version <= userVersion) continue`,数据库一旦升到 42,41 就永远不会执行。
2. 回合被 prune 后链接置空,任务保留——确认这是你要的语义(另一种做法是保留一个只读的回合快照)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
