### PR TITLE
fix(trace): notice a run status change that shares a millisecond with the write before it

### DIFF
--- a/packages/persistence/src/sqlite-store.ts
+++ b/packages/persistence/src/sqlite-store.ts
@@ -4903,11 +4903,24 @@ export class SqliteStore {
    * updated_at; task runs and context snapshots are append/terminal facts;
    * approvals stamp decided_at; knowledge jobs carry updated_at).
    */
+  /**
+   * A change detector for the trace's cached projection.
+   *
+   * Counts and max timestamps alone miss a status change that lands in the
+   * same millisecond as the write before it — a turn that fails immediately
+   * does exactly that, and the owner then keeps seeing a run that claims to
+   * be running. The run component therefore also carries a digest of the
+   * status column: the sum of first code points and the sum of lengths.
+   * Both move for any single transition among the five run statuses, whose
+   * (code point, length) pairs are all distinct.
+   */
   worldTraceWatermark(worldId: string): string {
     const row = this.database
       .prepare(
         `SELECT
-           (SELECT COUNT(1) || '@' || COALESCE(MAX(COALESCE(completed_at, started_at, created_at)), '') FROM agent_runs WHERE world_id = ?) AS runs,
+           (SELECT COUNT(1) || '@' || COALESCE(MAX(COALESCE(completed_at, started_at, created_at)), '')
+              || '@' || COALESCE(SUM(unicode(status)), 0) || '.' || COALESCE(SUM(length(status)), 0)
+            FROM agent_runs WHERE world_id = ?) AS runs,
            (SELECT COUNT(1) || '@' || COALESCE(MAX(created_at), '') FROM domain_events WHERE world_id = ?) AS events,
            (SELECT COUNT(1) || '@' || COALESCE(MAX(created_at), '') FROM messages WHERE session_id IN (SELECT id FROM work_sessions WHERE world_id = ?)) AS messages,
            (SELECT COUNT(1) || '@' || COALESCE(MAX(updated_at), '') FROM skill_actions WHERE world_id = ?) AS actions,

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -1492,3 +1492,51 @@ describe('SqliteStore', () => {
     expect(recovery.tables?.model_providers).toHaveLength(2)
   })
 })
+
+describe('world trace watermark', () => {
+  it('changes when a run changes status inside a single clock tick', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-cyber-'))
+    // A frozen clock turns "the two writes landed in the same millisecond" from
+    // a race that reproduces about once in six runs into a certainty. Real
+    // runs hit it whenever a turn fails immediately: `startAgentRun` and
+    // `failAgentRun` then carry the same timestamp.
+    const store = await SqliteStore.open(join(directory, 'cyber.sqlite'), { clock: () => '2026-09-05T00:00:00.000Z' })
+    stores.push(store)
+    const workspace = store.createWorkspace({ name: '水位工作区' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: '水位世界', templateId: 'cyber-company' })
+    store.saveBlueprint(blueprint({ id: 'watermark.worker', worldTemplateId: 'cyber-company' }))
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id, worldId: world.id, blueprintId: 'watermark.worker', blueprintVersion: 1,
+    })
+    const session = store.createSession({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      kind: 'direct',
+      title: '私聊',
+      participants: [{ participantId: 'owner', kind: 'owner' }, { participantId: employee.id, kind: 'employee' }],
+    })
+    const turn = store.createWorkTurn({
+      workspaceId: workspace.id, worldId: world.id, sessionId: session.id, interactionKind: 'chat',
+    })
+    const run = store.createAgentRun({
+      workspaceId: workspace.id, worldId: world.id, turnId: turn.id,
+      sessionId: session.id, employeeId: employee.id, ordinal: 1,
+    })
+
+    store.startAgentRun(run.id)
+    const whileRunning = store.worldTraceWatermark(world.id)
+    store.failAgentRun(run.id, 'model-timeout')
+
+    // The watermark is what the trace read model uses to decide whether its
+    // cached projection is still good. If it does not move here, the user
+    // keeps seeing a run that says it is running after it has failed.
+    expect(store.worldTraceWatermark(world.id)).not.toBe(whileRunning)
+  })
+
+  it('stays byte-identical when nothing changed', async () => {
+    const { store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: '稳定工作区' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: '稳定世界', templateId: 'cyber-company' })
+    expect(store.worldTraceWatermark(world.id)).toBe(store.worldTraceWatermark(world.id))
+  })
+})


### PR DESCRIPTION
审计 [#165](https://github.com/cyber-ai-agent/dsh-cyber/pull/165) 时查出来的一个真实缺陷,与那个 PR 无关,所以单独一片。**2 个提交,不改 schema,不加迁移,一处 SQL 改动加两条测试。**

## 症状:轨迹卡片说角色还在跑,其实已经失败了

`WorldTraceService` 用 `SqliteStore.worldTraceWatermark(worldId)` 判断缓存的投影还能不能用。它的 `agent_runs` 分量是:

```sql
COUNT(1) || '@' || COALESCE(MAX(COALESCE(completed_at, started_at, created_at)), '')
```

**里面没有 status。** 一次运行从 `running` 变成 `failed`,条数不变;如果这次写入与上一次落在**同一毫秒**,最大时间戳也不变——指纹逐字节相同,缓存投影被原样复用,状态变化对用户不可见。

立即失败的回合正好就是这种情况:`startAgentRun` 与 `failAgentRun` 之间几乎没有间隔。

这一直在污染测试:`world-trace-service.test.ts › rebuilds the cached projection when a run changes status without adding messages` 是间歇红的。我在未改动的基线上整文件跑 6 次,复现到 1 次红;单独跑那一条则 6 次全绿——它太快,反而躲开了竞态。

## 修法

`agent_runs` 分量额外携带一个 status 摘要:**首字符码点之和** 与 **长度之和**,两个分量分开放。

五个运行状态的 (码点, 长度) 两两不同——`queued`(113,6)、`running`(114,7)、`completed`(99,9)、`failed`(102,6)、`interrupted`(105,11)——所以任何单次状态迁移都会让两个和至少动一个,哪怕条数和最大时间戳纹丝不动。

这是**变更检测器,不是身份**:理论上两次同时发生的迁移可以在两个和里同时抵消,但那还要求条数与最大时间戳也都不动——除非时钟被冻结,现实中不会同时成立。这一点写在了代码注释里,没有假装它是哈希。

## 先红证据(独立提交)

冻结时钟把「两次写入落在同一毫秒」从六分之一的概率变成必然:

```
× changes when a run changes status inside a single clock tick
AssertionError: expected '1@2026-09-05T00:00:00.000Z|6@2026-09-…' not to be '1@2026-09-05T00:00:00.000Z|6@2026-09-…'
```

修复后两条测试都绿;原先间歇红的那条 `world-trace-service.test.ts` **整文件跑 6 次,6 次全绿**。

第二条测试钉的是契约的另一半:**什么都没变时水位必须稳定**,否则每次读取都会重建投影。

## 验证

```
pnpm typecheck    通过
pnpm test         1622 通过 / 1 跳过 / 1 失败（local-harness.integration.test.ts）
                  ^ 干净 origin/main 上同样红，非本 PR 引入
pnpm test:smoke   30/30
```

那条 `local-harness.integration.test.ts` 在干净的 `origin/main` 上就是红的(macOS 专属:它选的越界写入路径落在平台临时目录里,而那是 DSH 当前世界模式的原生例外;GitHub CI 是 Linux,那边绿)。不是本 PR 引入的。

## 明确没做:同样形状的另外三处

`worldTraceWatermark` 里还有三个分量是同一个形状——有 status 或决策列,指纹却只看条数与最大时间戳:

- `work_tasks`:`MAX(updated_at)`
- `task_runs`:`MAX(COALESCE(completed_at, started_at))`
- `approval_requests`:`MAX(COALESCE(decided_at, created_at))`

它们**暴露在同一个缺陷下**,但我没有像 `agent_runs` 那样先复现出来。照着改一遍很容易,可那就是没有证据的改动——正是我要求子 agent 不要做的事。要我把这三处也补上(每处一条冻结时钟的测试),说一声。

## 需要你决定

同一毫秒内的写入不可区分,根子上是时间戳只有毫秒精度。真正一劳永逸的做法是给这些表加一个单调递增的修订号,指纹只看它——但那要改 schema,而且会碰到正在排队的迁移 41 / 42。本片刻意只做无迁移的最小修复。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
