### PR TITLE
test(context): give the private-memory leak probe a marker that cannot be an id

### DIFF
--- a/packages/server/tests/conversation-context-hydration.test.ts
+++ b/packages/server/tests/conversation-context-hydration.test.ts
@@ -15,6 +15,17 @@ import { SqliteStore, memoryIndexTerms } from '@dsh-cyber/persistence'
 import { ConversationContextComposer } from '../src/services/conversation-context-composer.js'
 import { EmployeeConversationMemoryService } from '../src/services/employee-conversation-memory-service.js'
 
+/**
+ * The private secret these probes must never see leak.
+ *
+ * It carries letters outside hex on purpose. The marker used to be the bare
+ * digits `7391`, and `allLayerText` includes generated ids, so a memory whose
+ * uuid happened to end `…5bdf7391bee4` failed the leak assertion with nothing
+ * leaked — which is the worst way for a privacy guard to fail, because the
+ * next person to hit it is being taught that this test cries wolf.
+ */
+const VAULT_SECRET = 'ZQ7391XK'
+
 const stores: SqliteStore[] = []
 
 afterEach(() => {
@@ -289,7 +300,7 @@ describe('retrieved memory hydration', () => {
       session: direct,
       memory,
       ask: '记下金库处置方案',
-      answer: longAnswer('金库密码 7391'),
+      answer: longAnswer(`金库密码 ${VAULT_SECRET}`),
       runId: 'run-private',
     })
     for (let index = 2; index <= 12; index += 1) {
@@ -351,7 +362,7 @@ describe('retrieved memory hydration', () => {
       memoryBudgetTokens: 4_000,
     })
     expect(own.coverage.hydratedSourceMessageCount).toBeGreaterThan(0)
-    expect(own.envelope.retrievedMemories?.text ?? '').toContain('7391')
+    expect(own.envelope.retrievedMemories?.text ?? '').toContain(VAULT_SECRET)
 
     const result = await composer.compose({
       employee,
@@ -364,7 +375,7 @@ describe('retrieved memory hydration', () => {
     })
 
     expect(result.coverage.memoryScopes).toEqual(['group', 'task'])
-    expect(allLayerText(result)).not.toContain('7391')
+    expect(allLayerText(result)).not.toContain(VAULT_SECRET)
     const privateMessageIds = new Set(store.listMessages(direct.id).map((message) => message.id))
     const refs = result.envelope.retrievedMemories?.sourceRefs ?? []
     expect(refs.some((ref) => ref.kind === 'message' && privateMessageIds.has(ref.id))).toBe(false)
@@ -400,7 +411,7 @@ describe('retrieved memory hydration', () => {
     // boundary from the message's own session, so it must refuse.
     const memoryIds = (result.envelope.memoryIndex?.sourceRefs ?? []).map((ref) => ref.id)
     expect(memoryIds).toContain(privateMilestone.id)
-    expect(allLayerText(result)).not.toContain('7391')
+    expect(allLayerText(result)).not.toContain(VAULT_SECRET)
     const hydrated = (result.envelope.retrievedMemories?.text ?? '').split('[记忆原文]')[1] ?? ''
     expect(hydrated).not.toContain(privateMilestone.id)
     expect(hydrated).not.toContain('迁移方案要点')


### PR DESCRIPTION
一条**隐私守卫**测试会随机变红,而它红的时候什么都没泄漏。这在 [#170](https://github.com/cyber-ai-agent/dsh-cyber/pull/170) 的 CI 上真实发生了一次。

## 证据

`packages/server/tests/conversation-context-hydration.test.ts › retrieved memory hydration › never hydrates a private raw message into a group conversation` 断言私聊里的金库密码不会出现在群聊上下文的任何一层里。密码是字面量 **`7391`**,而 `allLayerText(result)` 扫的文本包含生成的 id。

CI 那次收到的文本里,`7391` 出现在这里:

```
- fbb72ad4-159a-4077-aeb8-5bdf7391bee4 · 2026-09-05 · 群聊
memory:fbb72ad4-159a-4077-aeb8-5bdf7391bee4
```

一个**随机记忆 UUID 的尾部**,而且那一行标着「群聊」——是合法的群聊作用域记忆引用。私聊那条 `金库密码 7391` 的原文并不在文本里。**隐私守卫本身是好的,坏的是探针。**

一个 4 字符的十六进制串,撞上一个 UUID 只是时间问题:每个 uuid 约 29 个位置 × (1/16)⁴ ≈ 万分之四,而每次组装里有好几个 id,再乘上跑过的次数。

## 为什么值得单独修

**一个会哭狼的隐私守卫比没有守卫更糟**——下一个撞上它的人学到的是「这条测试不可信」,然后就会去放宽它、跳过它,或者在真的泄漏时也当成误报。

标记改成 `ZQ7391XK`:带了十六进制之外的字母,**任何生成的 id 都不可能产出它**,于是这条断言只剩一种红法——真的泄漏。三处断言与那条私聊答案共用同一个常量,不再是四个各自独立的字面量。

## 验证

```
pnpm typecheck    通过
pnpm test         1633 通过 / 1 跳过 / 1 失败（local-harness.integration.test.ts）
                  ^ 干净 origin/main 上同样红，非本 PR 引入
pnpm test:smoke   30/30
```

其中 `conversation-context-hydration.test.ts` 本身 6 项全过(含正面断言:自己的会话里**必须**能取回这个密码,所以探针仍然在真正地探)。

## 明确没做

只改了这一条探针的标记。没有去扫其他测试里是否还有同类的短十六进制探针——如果你要,我可以做一遍。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
