### PR TITLE
fix(chat): image-model characters skip task-intent classification

### DIFF
--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -52,6 +52,7 @@ import type { GroupTaskRoutingResult } from '../services/group-task-router.js'
 import type { PreparedGroupTurnPlanner } from '../services/prepared-group-turn-planner.js'
 import type { ConversationQueueService } from '../services/conversation-queue-service.js'
 import { GroupIntentRouter } from '../services/group-intent-router.js'
+import { isImageGenerationModel } from '../services/image-generation-service.js'
 import type { ConversationTaskIntentOutcome, ConversationTaskIntentService } from '../services/conversation-task-intent-service.js'
 import { listApprovalRequestViews } from '../services/approval-request-views.js'
 import type { HarnessToolApprovalService } from '../services/harness-tool-approval-service.js'
@@ -233,10 +234,19 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     // and settled once the turn has an id.
     // Track settlement without joining it: the response may carry the decision
     // when it is already there, and must never wait for one that is not.
+    // An image-model character answers only with pictures: the classifier
+    // would judge their message against the world's TEXT default model and
+    // record a misleading "任务意图判定失败" failure beside the image the turn
+    // actually produced. Skip classification for a solo turn whose resolved
+    // model generates images - there is no instruction for it to run.
+    const resolvedImageCharacter = employeeIds.length === 1
+      ? store.resolveModelProfile(world.workspaceId, world.id, employeeIds[0]!)
+      : undefined
+    const imageCharacterTurn = resolvedImageCharacter !== undefined && isImageGenerationModel(resolvedImageCharacter)
     let proposedTaskIntent: ReturnType<ConversationTaskIntentService['propose']> | undefined
     let intentSettled: ConversationTaskIntentOutcome | undefined
     const startTaskIntent = (): void => {
-      if (proposedTaskIntent !== undefined || taskIntent === undefined) return
+      if (imageCharacterTurn || proposedTaskIntent !== undefined || taskIntent === undefined) return
       proposedTaskIntent = taskIntent.propose({ workspaceId: world.workspaceId, worldId: world.id, prompt })
       proposedTaskIntent.then((outcome) => { intentSettled = outcome }, () => undefined)
     }

--- a/packages/server/tests/conversation-task-from-chat.test.ts
+++ b/packages/server/tests/conversation-task-from-chat.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentRuntimePort, AgentTurnRequest, WorkTask, WorkTaskDetail, WorldTraceEntry } from '@dsh-cyber/contracts'
 
 import { createCyberServer, type CyberServer } from '../src/index.js'
@@ -284,5 +284,46 @@ describe('a chat instruction becomes one task in the task list', () => {
     const failures = (trace.body.items as WorldTraceEntry[]).filter((entry) => entry.summary.includes('任务意图'))
     expect(failures).toHaveLength(3)
     expect(failures.every((entry) => entry.status === 'failed')).toBe(true)
+  })
+
+  it('does not classify an image-model character at all, and still delivers the picture', async () => {
+    const intent = stubIntent({})
+    // Deterministic image endpoint: inline bytes, no real gateway. Stubbed
+    // BEFORE the server composes so ImageGenerationService captures it; every
+    // other request passes through to the real server.
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x01])
+    const realFetch = globalThis.fetch.bind(globalThis)
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => String(url).endsWith('/images/generations')
+      ? new Response(JSON.stringify({ data: [{ b64_json: pngBytes.toString('base64') }] }), { status: 200, headers: { 'content-type': 'application/json' } })
+      : realFetch(url as never, init as never))
+    vi.stubGlobal('fetch', fetchMock as never)
+    try {
+      const { origin, server, world, employee } = await start(intent)
+      // Bind the character to a marked image generator. An instruction-shaped
+      // message to such a character must never reach the classifier (it would
+      // judge against the world's text default and record noise next to the
+      // picture the turn is about to produce).
+      const profile = server.store.saveModelProfile({
+        workspaceId: world.workspaceId,
+        displayName: '形象生成器',
+        providerKind: 'openai-compatible-remote',
+        baseUrl: 'https://images.example.test/v1',
+        modelId: 'gpt-image-test',
+        api: 'openai-completions',
+        isDefault: false,
+        settings: { imageGeneration: true },
+      })
+      server.store.saveModelAssignment({ workspaceId: world.workspaceId, scope: 'employee', scopeId: employee.id, modelProfileId: profile.id })
+      const answered = await json(origin, `/api/worlds/${world.id}/chat`, post({ employeeIds: [employee.id], prompt: INSTRUCTION }))
+      expect(answered.status).toBe(200)
+      expect(answered.body.proposedTask).toBeUndefined()
+      // The classifier never ran: no draft, no misleading failure event.
+      expect(intent.prompts).toEqual([])
+      expect(server.work.list(world.id)).toEqual([])
+      // The turn still answered with the picture's caption.
+      expect(answered.body.replies?.length ?? 0).toBeGreaterThan(0)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })


### PR DESCRIPTION
## 问题

图像模型角色的对话只出图、没有"任务"可言，但每条指令形消息仍会启动任务意图判定——判定器用的是**世界级/工作区默认的文本模型**（员工绑定被故意忽略），结果要么超时、要么误判，在轨迹里留下一笔 **"任务意图判定失败，未生成任务"**，恰好挨着本次回合真正产出的那张图，极容易误导用户以为生成失败了。

## 改动

单聊回合（`employeeIds.length === 1`）在 `propose` 之前解析该角色实际生效的模型（显式选择校验工作区后，回落 `resolveModelProfile` 员工→世界→工作区→默认链）；当它是**图像生成模型**时，直接跳过任务意图判定：

- 不产生误导性失败事件
- 不产生任务草稿
- 出图是唯一路径，一切照常

判定失败链路（`deferTaskIntent`/`settleTaskIntent`）在 pending 为空时天然无操作，无需额外改动。

## 验证

新增端到端用例（`conversation-task-from-chat.test.ts`）：给角色绑定标记过的图像生成模型（settings.imageGeneration=true），发送指令形消息，断言：

- 判定器 stub **零调用**（`prompts` 为空）
- 无 `proposedTask`、任务列表为空
- 回合正常应答（stub fetch 喂入内联 PNG 走完出图链路）

全量 server 测试 1752 通过。
