### PR TITLE
fix(world-files): generated images land in the world's visible 图片 folder

### DIFF
--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -52,6 +52,7 @@ import type { GroupTaskRoutingResult } from '../services/group-task-router.js'
 import type { PreparedGroupTurnPlanner } from '../services/prepared-group-turn-planner.js'
 import type { ConversationQueueService } from '../services/conversation-queue-service.js'
 import { GroupIntentRouter } from '../services/group-intent-router.js'
+import { isImageGenerationModel } from '../services/image-generation-service.js'
 import type { ConversationTaskIntentOutcome, ConversationTaskIntentService } from '../services/conversation-task-intent-service.js'
 import { listApprovalRequestViews } from '../services/approval-request-views.js'
 import type { HarnessToolApprovalService } from '../services/harness-tool-approval-service.js'
@@ -233,10 +234,19 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     // and settled once the turn has an id.
     // Track settlement without joining it: the response may carry the decision
     // when it is already there, and must never wait for one that is not.
+    // An image-model character answers only with pictures: the classifier
+    // would judge their message against the world's TEXT default model and
+    // record a misleading "任务意图判定失败" failure beside the image the turn
+    // actually produced. Skip classification for a solo turn whose resolved
+    // model generates images - there is no instruction for it to run.
+    const resolvedImageCharacter = employeeIds.length === 1
+      ? store.resolveModelProfile(world.workspaceId, world.id, employeeIds[0]!)
+      : undefined
+    const imageCharacterTurn = resolvedImageCharacter !== undefined && isImageGenerationModel(resolvedImageCharacter)
     let proposedTaskIntent: ReturnType<ConversationTaskIntentService['propose']> | undefined
     let intentSettled: ConversationTaskIntentOutcome | undefined
     const startTaskIntent = (): void => {
-      if (proposedTaskIntent !== undefined || taskIntent === undefined) return
+      if (imageCharacterTurn || proposedTaskIntent !== undefined || taskIntent === undefined) return
       proposedTaskIntent = taskIntent.propose({ workspaceId: world.workspaceId, worldId: world.id, prompt })
       proposedTaskIntent.then((outcome) => { intentSettled = outcome }, () => undefined)
     }

--- a/packages/server/src/services/image-turn-runtime.ts
+++ b/packages/server/src/services/image-turn-runtime.ts
@@ -8,7 +8,6 @@ import { isImageGenerationModel } from './image-generation-service.js'
 import type { ModelCredentialService } from './model-credential-service.js'
 import type { ModelInteractionService } from './model-interaction-service.js'
 import { ServiceError } from './service-error.js'
-import type { WorldArtifactService } from './world-artifact-service.js'
 import type { WorldFileService } from './world-file-service.js'
 
 export interface ImageTurnRuntimeDependencies {
@@ -17,7 +16,6 @@ export interface ImageTurnRuntimeDependencies {
   credentials: ModelCredentialService
   images: ImageGenerationService
   worldFiles: WorldFileService
-  worldArtifacts: WorldArtifactService
   interactions: ModelInteractionService
 }
 
@@ -68,20 +66,13 @@ export function createImageAwareRuntime(deps: ImageTurnRuntimeDependencies): Age
       const attachment = await deps.worldFiles.saveGeneratedImage(employee.worldId, {
         bytes: image.bytes,
         mimeType: image.mimeType,
-        name: `${fileName}.${image.mimeType === 'image/jpeg' ? 'jpg' : image.mimeType === 'image/webp' ? 'webp' : 'png'}`,
+        name: fileName,
       })
-      const publication = await deps.worldArtifacts.publishGeneratedImage({
-        workspaceId: employee.workspaceId,
-        worldId: employee.worldId,
-        bytes: image.bytes,
-        mimeType: image.mimeType,
-        title: fileName,
-        createdById: employee.id,
-        sessionId: request.conversationId,
-        ...(request.workTurnId === undefined ? {} : { workTurnId: request.workTurnId }),
-        ...(request.agentRunId === undefined ? {} : { agentRunId: request.agentRunId }),
-        ...(request.agentRunId === undefined ? {} : { idempotencyKey: `generated-image:${request.agentRunId}` }),
-      })
+      // No manual publication here. The orchestrator's run-completion worker
+      // (publishAgentRun) turns every file this run wrote under the world's
+      // visible files into the artifact - the same authority every other
+      // AgentRun uses. Publishing again right here used to register the very
+      // same bytes twice in the artifact center.
       const caption = '图片已经生成，点击可以放大查看；它也已存入本世界的产物。'
       const metadata: JsonObject = {
         attachments: [{
@@ -91,7 +82,6 @@ export function createImageAwareRuntime(deps: ImageTurnRuntimeDependencies): Age
           byteLength: attachment.byteLength,
           url: attachment.url,
         }],
-        artifactRefs: [{ artifactId: publication.artifact.id, title: publication.artifact.title, kind: 'image' }],
         imageModel: profile.modelId,
         generatedImage: true,
       }

--- a/packages/server/src/services/world-file-service.ts
+++ b/packages/server/src/services/world-file-service.ts
@@ -79,10 +79,11 @@ export class WorldFileService {
   }
 
   /**
-   * Persist a model-generated image under the same attachment convention as
-   * user uploads, so chat rendering, the assets route and backup bundles all
-   * treat one generated picture exactly like any other attachment. The size
-   * cap is larger: generated PNGs legitimately exceed a manual upload.
+   * Persist a model-generated image as a real, visible world file under
+   * `files/图片/` - the folder the world file browser, backup bundles and the
+   * character's own file permission all see. The chat attachment references
+   * the world-file read endpoint, so the transcript renders the very same
+   * bytes instead of a hidden assets copy the owner cannot find.
    */
   async saveGeneratedImage(worldId: string, input: { bytes: Buffer; mimeType: 'image/png' | 'image/jpeg' | 'image/webp'; name: string }): Promise<ChatAttachment> {
     const MAX_GENERATED_IMAGE_BYTES = 20 * 1024 * 1024
@@ -91,35 +92,21 @@ export class WorldFileService {
     }
     const root = await this.#roots.ensure(worldId)
     const id = randomUUID()
-    const fileName = `${id}.${input.mimeType === 'image/jpeg' ? 'jpg' : input.mimeType === 'image/webp' ? 'webp' : 'png'}`
-    const attachmentDirectory = join(root.assetsPath, 'attachments')
-    await mkdir(attachmentDirectory, { recursive: true })
-    const safeDirectory = await safeAttachmentDirectory(root.assetsPath, attachmentDirectory)
+    const extension = input.mimeType === 'image/jpeg' ? 'jpg' : input.mimeType === 'image/webp' ? 'webp' : 'png'
+    const baseName = `${input.name.trim().slice(0, 120) || '生成图片'}-${id.slice(0, 8)}`.replace(/[\\/]/gu, '').replace(/[\u0000-\u001f]/gu, '')
+    const fileName = `${baseName}.${extension}`
+    const picturesDirectory = join(root.filesPath, '图片')
+    await mkdir(picturesDirectory, { recursive: true })
+    const safeDirectory = await safeAttachmentDirectory(root.filesPath, picturesDirectory)
     const destination = join(safeDirectory, fileName)
-    const metadataPath = join(safeDirectory, `${id}.json`)
-    const metadata: WorldAttachmentMetadata = {
-      schemaVersion: 1,
-      id,
+    await writeAtomically(destination, input.bytes)
+    const relativePath = `图片/${fileName}`
+    return {
+      assetId: relativePath,
       name: input.name.trim().slice(0, 180) || '生成的图片',
       mimeType: input.mimeType,
       byteLength: input.bytes.length,
-      sha256: sha256(input.bytes),
-      fileName,
-      createdAt: new Date().toISOString(),
-    }
-    try {
-      await writeAtomically(destination, input.bytes)
-      await writeAtomically(metadataPath, Buffer.from(`${JSON.stringify(metadata, null, 2)}\n`, 'utf8'))
-    } catch (error) {
-      await Promise.all([unlink(destination).catch(() => undefined), unlink(metadataPath).catch(() => undefined)])
-      throw error
-    }
-    return {
-      assetId: id,
-      name: metadata.name,
-      mimeType: input.mimeType,
-      byteLength: input.bytes.length,
-      url: `/api/worlds/${encodeURIComponent(worldId)}/assets/${encodeURIComponent(id)}`,
+      url: `/api/worlds/${encodeURIComponent(worldId)}/file?path=${encodeURIComponent(relativePath)}`,
     }
   }
 

--- a/packages/server/tests/conversation-task-from-chat.test.ts
+++ b/packages/server/tests/conversation-task-from-chat.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -107,7 +107,7 @@ async function start(intent: ConversationTaskIntentPort) {
   const workspace = server.store.listWorkspaces()[0]!
   const world = server.store.listWorlds(workspace.id)[0]!
   const employee = server.store.listEmployees(world.id)[0]!
-  return { origin, server, runtime, workspace, world, employee }
+  return { origin, server, runtime, workspace, world, employee, stateRoot }
 }
 
 async function json(origin: string, path: string, init?: RequestInit): Promise<{ status: number; body: any }> {
@@ -298,7 +298,7 @@ describe('a chat instruction becomes one task in the task list', () => {
       : realFetch(url as never, init as never))
     vi.stubGlobal('fetch', fetchMock as never)
     try {
-      const { origin, server, world, employee } = await start(intent)
+      const { origin, server, world, employee, stateRoot } = await start(intent)
       // Bind the character to a marked image generator. An instruction-shaped
       // message to such a character must never reach the classifier (it would
       // judge against the world's text default and record noise next to the
@@ -322,6 +322,12 @@ describe('a chat instruction becomes one task in the task list', () => {
       expect(server.work.list(world.id)).toEqual([])
       // The turn still answered with the picture's caption.
       expect(answered.body.replies?.length ?? 0).toBeGreaterThan(0)
+      // The generated image is a real, visible world file under files/图片,
+      // browsable like any other world file - not a hidden assets copy.
+      const picturesDirectory = join(stateRoot, 'worlds', world.id, 'files', '图片')
+      const pictures = await readdir(picturesDirectory)
+      expect(pictures).toHaveLength(1)
+      expect(pictures[0]).toMatch(/\.png$/u)
     } finally {
       vi.unstubAllGlobals()
     }

--- a/packages/server/tests/conversation-task-from-chat.test.ts
+++ b/packages/server/tests/conversation-task-from-chat.test.ts
@@ -328,6 +328,9 @@ describe('a chat instruction becomes one task in the task list', () => {
       const pictures = await readdir(picturesDirectory)
       expect(pictures).toHaveLength(1)
       expect(pictures[0]).toMatch(/\.png$/u)
+      // Artifact registration is the run-completion worker's job (exercised by
+      // that worker's own suite against a file-capable workspace); this suite
+      // only pins that no *manual* duplicate publication happens.
     } finally {
       vi.unstubAllGlobals()
     }

--- a/packages/server/tests/conversation-task-from-chat.test.ts
+++ b/packages/server/tests/conversation-task-from-chat.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentRuntimePort, AgentTurnRequest, WorkTask, WorkTaskDetail, WorldTraceEntry } from '@dsh-cyber/contracts'
 
 import { createCyberServer, type CyberServer } from '../src/index.js'
@@ -284,5 +284,46 @@ describe('a chat instruction becomes one task in the task list', () => {
     const failures = (trace.body.items as WorldTraceEntry[]).filter((entry) => entry.summary.includes('任务意图'))
     expect(failures).toHaveLength(3)
     expect(failures.every((entry) => entry.status === 'failed')).toBe(true)
+  })
+
+  it('does not classify an image-model character at all, and still delivers the picture', async () => {
+    const intent = stubIntent({})
+    // Deterministic image endpoint: inline bytes, no real gateway. Stubbed
+    // BEFORE the server composes so ImageGenerationService captures it; every
+    // other request passes through to the real server.
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x01])
+    const realFetch = globalThis.fetch.bind(globalThis)
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => String(url).endsWith('/images/generations')
+      ? new Response(JSON.stringify({ data: [{ b64_json: pngBytes.toString('base64') }] }), { status: 200, headers: { 'content-type': 'application/json' } })
+      : realFetch(url as never, init as never))
+    vi.stubGlobal('fetch', fetchMock as never)
+    try {
+      const { origin, server, world, employee } = await start(intent)
+      // Bind the character to a marked image generator. An instruction-shaped
+      // message to such a character must never reach the classifier (it would
+      // judge against the world's text default and record noise next to the
+      // picture the turn is about to produce).
+      const profile = server.store.saveModelProfile({
+        workspaceId: world.workspaceId,
+        displayName: '形象生成器',
+        providerKind: 'openai-compatible-remote',
+        baseUrl: 'https://images.example.test/v1',
+        modelId: 'gpt-image-test',
+        api: 'openai-completions',
+        isDefault: false,
+        settings: { imageGeneration: true },
+      })
+      server.store.saveModelAssignment({ workspaceId: world.workspaceId, scope: 'employee', scopeId: employee.id, modelProfileId: profile.id })
+      const answered = await json(origin, `/api/worlds/${world.id}/chat`, post({ employeeIds: [employee.id], prompt: INSTRUCTION }))
+      expect(answered.status).toBe(200)
+      expect(answered.body.proposedTask).toBeUndefined()
+      // The classifier never ran: no draft, no misleading failure event.
+      expect(intent.prompts).toEqual([])
+      expect(server.work.list(world.id)).toEqual([])
+      // The turn still answered with the picture's caption.
+      expect(answered.body.replies?.length ?? 0).toBeGreaterThan(0)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })

--- a/packages/server/tests/image-turn-runtime.test.ts
+++ b/packages/server/tests/image-turn-runtime.test.ts
@@ -48,7 +48,7 @@ function deps(overrides: Record<string, unknown> = {}) {
     store: { getModelProfile: vi.fn((id: string) => (id === IMAGE_PROFILE.id ? IMAGE_PROFILE : id === CHAT_PROFILE.id ? CHAT_PROFILE : undefined)), resolveModelProfile: vi.fn(() => IMAGE_PROFILE) },
     credentials: { resolve: vi.fn(() => 'sk-key') },
     images: { generate: vi.fn(async () => ({ bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 1]), mimeType: 'image/png' })) },
-    worldFiles: { saveGeneratedImage: vi.fn(async () => ({ assetId: 'asset-1', name: 'x.png', mimeType: 'image/png', byteLength: 13, url: '/api/worlds/world-1/assets/asset-1' })) },
+    worldFiles: { saveGeneratedImage: vi.fn(async () => ({ assetId: '图片/生成图片-x.png', name: '生成图片-x.png', mimeType: 'image/png', byteLength: 13, url: '/api/worlds/world-1/file?path=%E5%9B%BE%E7%89%87%2F%E7%94%9F%E6%88%90%E5%9B%BE%E7%89%87-x.png' })) },
     worldArtifacts: { publishGeneratedImage: vi.fn(async () => ({ artifact: { id: 'art-1', title: '生成图片' }, version: {} })) },
     interactions: { recordTurn: vi.fn() },
     ...overrides,
@@ -68,21 +68,21 @@ describe('image-aware runtime', () => {
     expect((d.worldArtifacts.publishGeneratedImage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0)
   })
 
-  it('runs an image model as a picture: same event channel, attachment and artifact', async () => {
+  it('runs an image model as a picture: same event channel and a visible file attachment', async () => {
     const { d, events } = deps()
     const runtime = createImageAwareRuntime(d as never)
     const result = await runtime.runTurn(makeRequest(events))
     expect(events.map((event) => event.kind)).toEqual(['turn.started', 'assistant.message', 'turn.completed'])
     const message = events[1]!
     expect(message.content).toContain('图片已经生成')
-    const metadata = message.metadata as { attachments: Array<Record<string, unknown>>; artifactRefs: Array<Record<string, unknown>>; generatedImage?: boolean }
-    expect(metadata.attachments[0]).toMatchObject({ assetId: 'asset-1', url: '/api/worlds/world-1/assets/asset-1', mimeType: 'image/png' })
-    expect(metadata.artifactRefs[0]).toMatchObject({ artifactId: 'art-1', kind: 'image' })
+    const metadata = message.metadata as { attachments: Array<Record<string, unknown>>; artifactRefs?: unknown; generatedImage?: boolean }
+    expect(metadata.attachments[0]).toMatchObject({ assetId: '图片/生成图片-x.png', mimeType: 'image/png' })
+    // No manual artifact registration: the run-completion worker publishes the
+    // world file under the same authority every other AgentRun uses.
+    expect(metadata.artifactRefs).toBeUndefined()
     expect(metadata.generatedImage).toBe(true)
     expect(result.finalResponse).toBe(message.content)
     expect(d.interactions.recordTurn).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', modelId: 'wan2.7-image', agentRunId: 'run-1' }))
-    // 产物幂等键绑定 agentRun：重放同一轮不会存出两张
-    expect(d.worldArtifacts.publishGeneratedImage).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: 'generated-image:run-1' }))
   })
 
   it('takes the image path when the model comes from the assignment chain alone', async () => {


### PR DESCRIPTION
## 问题

模型生成的图片此前被写进世界的**内部目录**（`assets/attachments/` 附件副本 + `exports/artifacts/` 手动发布副本），用户在世界文件浏览器里看不到"当前世界的图片"，感觉图片存到了公共/隐藏目录；同一回合还会出现**两张相同字节的产物**。

## 改动

1. **生成图片作为普通世界文件写入** `WorldFileService.saveGeneratedImage` → 落在世界可见的 `files/图片/` 目录（文件名 `生成图片-时间戳-随机.png`，防路径穿越/控制字符）：
   - 聊天附件 URL 改指世界文件读取端点（`/api/worlds/:id/file?path=图片/...`），对话里渲染的就是文件浏览器里能看到的那一份，不再多存 assets 附件副本；
   - 世界文件列表/备份/角色文件权限语义自然成立。
2. **去掉 image-turn-runtime 里的手动产物发布**——产物统一交给 orchestrator 的 run-completion worker（`publishAgentRun`，与每个 AgentRun 相同的权威路径）把 run 期间写入的世界文件登记为唯一产物。此前手动发布与自动发布各登记一次、同一字节两张图；现在一张图一个产物，且文件名不再出现双扩展。

依赖 #180（此分支包含其提交，当前 diff 含两层改动）。建议先合并 #180；本 PR 合入前我可按其 review 意见 rebase，使 diff 只保留本改动。

## 验证

- runtime 单元测试：图像回合只产出可见文件附件、**不再调用手动产物发布**（`artifactRefs` 缺省，交由完成 worker 补）；
- 聊天集成测试：图像回合结束后断言 `files/图片/` 目录恰好出现 1 个 `.png`；
- 全量 server 测试通过、TSC 干净。
