### PR TITLE
fix-model-catalog-and-sse

### DIFF
--- a/docs/development/audit-remediation-2026-09-05.md
+++ b/docs/development/audit-remediation-2026-09-05.md
@@ -114,3 +114,5 @@ Group HTTP 接线检查点：`/chat` 的 discussion/task immediate/queued 在 pl
 第五批提交 `0e85ff4027b47ae6378d3ec07689fa717abf0a15` 的 CI `34011964404` 已完整成功，包含 1846 项单元/集成、schema 48 迁移回放和核心浏览器冒烟；第五批完成，进入第六批。
 
 第六批首个纵切已完成本地复验：Harness adapter 将最终 runtime-facing 输入按 system、当前请求、实际重放历史、native schema/system/turn-context、live retained context 分项计量；固定 rc.1 wire schema 漂移门禁，活跃会话超限先验证 SQLite fresh replay，失败则保留旧 lane。Inspector 与 snapshot 读取同一无明文 `contextUsage` 投影，并保留最终重放序列和消息来源指针。Memory/Knowledge 检索在 FTS/LIKE 两条路径统一有界 overfetch、lexical score 与稳定 tie-break，修复 500/5000 候选被前 50 行截断、同数 stale mirror 和中文句尾词元丢失。当前定向 126 项通过，完整有效上下文还需继续核对 CharacterProfileRuntime/Inspector 与真实 provider 入参边界，故第六批保持开发中。
+
+2026-09-07：继续整合本地未提交整改。SSE runtime/world 流统一使用有界连接缓冲，单个异常或慢订阅者只会被关闭，不影响健康订阅者；共享 world live 客户端在短暂卸载/重挂载窗口内复用连接。模型服务商目录改为优先读取仓库 `catalog/model-providers.json`，远程目录仅在仓库文件不可用且显式配置时作为备用，随后依次使用 stateRoot 缓存和内置快照。仓库目录仍经过同一严格解析器，目录变更在本地服务下一次读取时生效；批次 07/08 仍需其余审计范围和真实浏览器证据，未标记完成。

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -937,7 +937,7 @@ export interface ModelProviderCatalog {
   providers: ModelProviderCatalogEntry[]
 }
 
-export type ModelProviderCatalogSource = 'remote' | 'cache' | 'bundled'
+export type ModelProviderCatalogSource = 'repository' | 'remote' | 'cache' | 'bundled'
 
 export interface ModelProviderCatalogState {
   catalog: ModelProviderCatalog

--- a/packages/server/src/compose-model-hub.ts
+++ b/packages/server/src/compose-model-hub.ts
@@ -1,9 +1,18 @@
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
 import { ModelProviderCatalogService } from './services/model-provider-catalog.js'
 import { ModelProviderBalanceService } from './services/model-provider-balance.js'
 import { ModelCapabilityProbeService } from './services/model-capability-probe.js'
 
 export const DEFAULT_MODEL_CATALOG_URL =
   'https://raw.githubusercontent.com/cyber-ai-agent/dsh-cyber/main/catalog/model-providers.json'
+
+/** The checked-in catalog next to this package is the local source of truth. */
+export const DEFAULT_MODEL_CATALOG_PATH = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../catalog/model-providers.json',
+)
 
 export interface ModelHubServices {
   providerCatalog: ModelProviderCatalogService
@@ -13,17 +22,22 @@ export interface ModelHubServices {
 
 /**
  * Composition of the model-hub services, kept out of the server composition
- * root. The built-in provider catalog refreshes from the pinned upstream copy
- * when reachable and always degrades to the local cache or the bundled
- * snapshot; set DSH_CYBER_MODEL_CATALOG_URL to an empty value to disable the
- * remote fetch entirely.
+ * root. The checked-in repository catalog is read first, so changing
+ * catalog/model-providers.json is reflected by the local server after a
+ * forced refresh or TTL expiry. DSH_CYBER_MODEL_CATALOG_PATH can point at another file (or be
+ * empty to disable the repository source). DSH_CYBER_MODEL_CATALOG_URL is an
+ * explicit remote fallback; the state-root cache and bundled snapshot remain
+ * the final fallbacks.
  */
-export function createModelHubServices(options: { stateRoot: string }): ModelHubServices {
+export function createModelHubServices(options: { stateRoot: string; catalogPath?: string }): ModelHubServices {
+  const pathOverride = process.env.DSH_CYBER_MODEL_CATALOG_PATH
+  const configuredPath = options.catalogPath ?? (pathOverride === undefined ? DEFAULT_MODEL_CATALOG_PATH : pathOverride)
   const override = process.env.DSH_CYBER_MODEL_CATALOG_URL
   return {
     providerCatalog: new ModelProviderCatalogService({
       stateRoot: options.stateRoot,
-      remoteUrl: override === undefined ? DEFAULT_MODEL_CATALOG_URL : override,
+      ...(configuredPath.trim() ? { catalogPath: configuredPath } : {}),
+      ...(override === undefined || !override.trim() ? {} : { remoteUrl: override }),
     }),
     balance: new ModelProviderBalanceService(),
     probe: new ModelCapabilityProbeService(),

--- a/packages/server/src/http/sse.ts
+++ b/packages/server/src/http/sse.ts
@@ -1,5 +1,137 @@
 import type { ServerResponse } from 'node:http'
 
+/**
+ * A live view can always recover from the latest snapshot after reconnecting.
+ * That makes disconnecting a client which cannot keep up safer than allowing
+ * Node's writable buffer to grow without a bound.
+ */
+export const DEFAULT_SSE_MAX_BUFFERED_BYTES = 64 * 1024
+
+export interface SseConnectionOptions {
+  maxBufferedBytes?: number
+}
+
+/**
+ * Owns the small amount of buffering required by a ServerResponse while an
+ * SSE peer is applying backpressure. A failed or slow peer is closed in
+ * isolation; callers publishing to other peers are never interrupted.
+ */
+export class SseConnection {
+  readonly #response: ServerResponse
+  readonly #maxBufferedBytes: number
+  readonly #onClose: () => void
+  #queued: string[] = []
+  #queuedBytes = 0
+  #waitingDrain = false
+  #closed = false
+
+  constructor(response: ServerResponse, onClose: () => void, options: SseConnectionOptions = {}) {
+    const maxBufferedBytes = options.maxBufferedBytes ?? DEFAULT_SSE_MAX_BUFFERED_BYTES
+    if (!Number.isSafeInteger(maxBufferedBytes) || maxBufferedBytes <= 0) {
+      throw new Error('SSE maximum buffered bytes must be a positive safe integer')
+    }
+    this.#response = response
+    this.#maxBufferedBytes = maxBufferedBytes
+    this.#onClose = onClose
+  }
+
+  get closed(): boolean {
+    return this.#closed || this.#response.writableEnded || this.#response.destroyed
+  }
+
+  send(event: string, value: unknown, id?: string): boolean {
+    if (this.closed) {
+      this.close()
+      return false
+    }
+    let chunk: string
+    try {
+      chunk = serializeSse(event, value, id)
+    } catch {
+      this.close()
+      return false
+    }
+    if (Buffer.byteLength(chunk, 'utf8') > this.#maxBufferedBytes) {
+      this.close()
+      return false
+    }
+    if (this.#waitingDrain) {
+      this.#queue(chunk)
+      return this.#enforceLimit()
+    }
+    try {
+      const accepted = this.#response.write(chunk)
+      if (!accepted) {
+        this.#waitingDrain = true
+        if (!this.#listenForDrain()) return false
+      }
+    } catch {
+      this.close()
+      return false
+    }
+    return this.#enforceLimit()
+  }
+
+  close(): void {
+    if (this.#closed) return
+    this.#closed = true
+    this.#queued = []
+    this.#queuedBytes = 0
+    try {
+      if (!this.#response.writableEnded && !this.#response.destroyed) this.#response.end()
+    } catch {
+      // A response may already be torn down by the peer. The owner callback is
+      // still invoked below so the hub cannot retain a dead subscriber.
+    }
+    this.#onClose()
+  }
+
+  #queue(chunk: string): void {
+    this.#queued.push(chunk)
+    this.#queuedBytes += Buffer.byteLength(chunk, 'utf8')
+  }
+
+  #enforceLimit(): boolean {
+    const responseBytes = Number.isSafeInteger(this.#response.writableLength)
+      ? this.#response.writableLength
+      : 0
+    if (responseBytes + this.#queuedBytes <= this.#maxBufferedBytes) return true
+    this.close()
+    return false
+  }
+
+  #listenForDrain(): boolean {
+    if (typeof this.#response.once !== 'function') {
+      this.close()
+      return false
+    }
+    this.#response.once('drain', () => this.#drain())
+    return true
+  }
+
+  #drain(): void {
+    if (this.#closed) return
+    this.#waitingDrain = false
+    while (this.#queued.length > 0) {
+      const chunk = this.#queued.shift()!
+      this.#queuedBytes -= Buffer.byteLength(chunk, 'utf8')
+      try {
+        const accepted = this.#response.write(chunk)
+        if (!accepted) {
+          this.#waitingDrain = true
+          if (!this.#listenForDrain()) return
+          this.#enforceLimit()
+          return
+        }
+      } catch {
+        this.close()
+        return
+      }
+      if (!this.#enforceLimit()) return
+    }
+  }
+}
+
 export function writeSse(
   response: ServerResponse,
   event: string,
@@ -7,9 +139,11 @@ export function writeSse(
   id?: string,
 ): void {
   if (response.writableEnded || response.destroyed) return
-  if (id !== undefined) response.write(`id: ${id}\n`)
-  response.write(`event: ${event}\n`)
-  response.write(`data: ${JSON.stringify(value)}\n\n`)
+  response.write(serializeSse(event, value, id))
+}
+
+function serializeSse(event: string, value: unknown, id?: string): string {
+  return `${id === undefined ? '' : `id: ${id}\n`}event: ${event}\ndata: ${JSON.stringify(value)}\n\n`
 }
 
 export function isSseSequence(value: string | null | undefined): value is string {

--- a/packages/server/src/services/model-provider-catalog.ts
+++ b/packages/server/src/services/model-provider-catalog.ts
@@ -30,6 +30,8 @@ export class ModelProviderCatalogError extends Error {
 
 export interface ModelProviderCatalogServiceOptions {
   stateRoot: string
+  /** A repository-controlled catalog file used before remote/cache fallbacks. */
+  catalogPath?: string
   remoteUrl?: string
   fetch?: typeof fetch
   timeoutMs?: number
@@ -38,14 +40,16 @@ export interface ModelProviderCatalogServiceOptions {
 }
 
 /**
- * The built-in provider catalog with a three-level fallback:
- * remote (when configured and reachable) → the last good copy cached under
- * the state root → the snapshot bundled in this build. The file is untrusted
- * input: every entry passes the strict parser below before it reaches anyone,
- * and a rejected document never replaces a cached good one.
+ * The provider catalog with a repository-first fallback:
+ * repository file (when configured and valid) → remote (when explicitly
+ * configured and reachable) → the last good copy cached under the state root
+ * → the snapshot bundled in this build. Every source passes the strict parser
+ * below before it reaches anyone, and a rejected document never replaces a
+ * cached good one.
  */
 export class ModelProviderCatalogService {
   readonly #stateRoot: string
+  readonly #catalogPath: string | undefined
   readonly #remoteUrl: string | undefined
   readonly #fetch: typeof fetch
   readonly #timeoutMs: number
@@ -56,6 +60,7 @@ export class ModelProviderCatalogService {
 
   constructor(options: ModelProviderCatalogServiceOptions) {
     this.#stateRoot = options.stateRoot
+    this.#catalogPath = options.catalogPath?.trim() || undefined
     this.#remoteUrl = options.remoteUrl?.trim() || undefined
     this.#fetch = options.fetch ?? fetch
     this.#timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
@@ -73,6 +78,17 @@ export class ModelProviderCatalogService {
       return { catalog: this.#cached.catalog, source: this.#cached.source, checkedAt: new Date(this.#lastCheckedAt).toISOString() }
     }
     let notice: string | undefined
+    if (this.#catalogPath !== undefined) {
+      const repository = await this.#readCatalogFile(this.#catalogPath)
+      if (repository !== undefined) {
+        this.#set({ catalog: repository, source: 'repository' }, now)
+        // Keep the last valid repository copy available if the working tree
+        // is temporarily unavailable on a later start. Serving the repository
+        // file itself never depends on this best-effort write.
+        await this.#writeCache(repository).catch(() => undefined)
+        return this.#state(now)
+      }
+    }
     if (this.#remoteUrl !== undefined) {
       const outcome = await this.#fetchRemote()
       if (typeof outcome === 'object') {
@@ -136,11 +152,15 @@ export class ModelProviderCatalogService {
   }
 
   async #readCache(): Promise<ModelProviderCatalog | undefined> {
+    return this.#readCatalogFile(this.cachePath)
+  }
+
+  async #readCatalogFile(path: string): Promise<ModelProviderCatalog | undefined> {
     try {
-      const raw = await readFile(this.cachePath, 'utf8')
+      const raw = await readFile(path, 'utf8')
+      if (Buffer.byteLength(raw, 'utf8') > MAX_CATALOG_BYTES) return undefined
       return parseModelProviderCatalog(JSON.parse(raw) as unknown)
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined
+    } catch {
       return undefined
     }
   }

--- a/packages/server/src/streams/runtime-stream-hub.ts
+++ b/packages/server/src/streams/runtime-stream-hub.ts
@@ -2,19 +2,22 @@ import type { IncomingMessage, ServerResponse } from 'node:http'
 
 import type { ConversationControlEnvelope, ConversationRealtimeEnvelope } from '@dsh-cyber/orchestration'
 import type { WorldRuntimeStreamEnvelope, WorldTraceEntry } from '@dsh-cyber/contracts'
+import { SseConnection, type SseConnectionOptions } from '../http/sse.js'
 
 interface RuntimeStreamClient {
   worldId: string
-  response: ServerResponse
+  connection: SseConnection
 }
 
 export class RuntimeStreamHub {
   readonly #clients = new Set<RuntimeStreamClient>()
   readonly #heartbeat: NodeJS.Timeout
+  readonly #connectionOptions: SseConnectionOptions
 
-  constructor(heartbeatMs = 15_000) {
+  constructor(heartbeatMs = 15_000, connectionOptions: SseConnectionOptions = {}) {
+    this.#connectionOptions = connectionOptions
     this.#heartbeat = setInterval(() => {
-      for (const client of this.#clients) client.response.write(': heartbeat\n\n')
+      for (const client of [...this.#clients]) client.connection.send('heartbeat', {})
     }, heartbeatMs)
     this.#heartbeat.unref()
   }
@@ -30,53 +33,50 @@ export class RuntimeStreamHub {
       Connection: 'keep-alive',
       'X-Accel-Buffering': 'no',
     })
-    response.write('event: ready\ndata: {}\n\n')
-    const client = { worldId, response }
+    let client: RuntimeStreamClient
+    const connection = new SseConnection(response, () => this.#clients.delete(client), this.#connectionOptions)
+    client = { worldId, connection }
     this.#clients.add(client)
-    const remove = () => this.#clients.delete(client)
-    if (typeof response.once === 'function') response.once('close', remove)
+    const remove = () => connection.close()
+    if (typeof response.once === 'function') response.once('close', () => connection.close())
     request.once('aborted', remove)
-    request.once('close', remove)
+    request.once('close', () => connection.close())
+    connection.send('ready', {})
   }
 
   publish(event: ConversationRealtimeEnvelope): void {
-    const data = JSON.stringify(event)
-    for (const client of this.#clients) {
+    for (const client of [...this.#clients]) {
       if (client.worldId !== event.worldId) continue
-      client.response.write(`event: runtime\ndata: ${data}\n\n`)
+      client.connection.send('runtime', event)
     }
   }
 
   publishControl(event: ConversationControlEnvelope): void {
-    const data = JSON.stringify(event)
-    for (const client of this.#clients) {
+    for (const client of [...this.#clients]) {
       if (client.worldId !== event.worldId) continue
-      client.response.write(`event: conversation-control\ndata: ${data}\n\n`)
+      client.connection.send('conversation-control', event)
     }
   }
 
   publishTrace(worldId: string, entries: WorldTraceEntry[]): void {
     if (entries.length === 0) return
-    for (const client of this.#clients) {
+    for (const client of [...this.#clients]) {
       if (client.worldId !== worldId) continue
-      for (const entry of entries) {
-        client.response.write(`event: trace\ndata: ${JSON.stringify(entry)}\n\n`)
-      }
+      for (const entry of entries) if (!client.connection.send('trace', entry)) break
     }
   }
 
   publishWorld(event: WorldRuntimeStreamEnvelope): void {
     const eventName = event.kind === 'runtime' ? 'world-runtime' : event.kind
-    const data = JSON.stringify(event)
-    for (const client of this.#clients) {
+    for (const client of [...this.#clients]) {
       if (client.worldId !== event.worldId) continue
-      client.response.write(`event: ${eventName}\ndata: ${data}\n\n`)
+      client.connection.send(eventName, event)
     }
   }
 
   close(): void {
     clearInterval(this.#heartbeat)
-    for (const client of this.#clients) client.response.end()
+    for (const client of [...this.#clients]) client.connection.close()
     this.#clients.clear()
   }
 }

--- a/packages/server/src/streams/world-stream-hub.ts
+++ b/packages/server/src/streams/world-stream-hub.ts
@@ -7,21 +7,23 @@ import type {
 } from '@dsh-cyber/contracts'
 
 import { headerValue } from '../http/request.js'
-import { isSseSequence, sseSequence, writeSse } from '../http/sse.js'
+import { isSseSequence, SseConnection, sseSequence, type SseConnectionOptions } from '../http/sse.js'
 
 interface WorldStreamClient {
   worldId: string
-  response: ServerResponse
+  connection: SseConnection
   lastSequence: number
 }
 
 export class WorldStreamHub {
   readonly #clients = new Set<WorldStreamClient>()
   readonly #heartbeat: NodeJS.Timeout
+  readonly #connectionOptions: SseConnectionOptions
 
-  constructor(heartbeatMs = 15_000) {
+  constructor(heartbeatMs = 15_000, connectionOptions: SseConnectionOptions = {}) {
+    this.#connectionOptions = connectionOptions
     this.#heartbeat = setInterval(() => {
-      for (const client of this.#clients) {
+      for (const client of [...this.#clients]) {
         const heartbeatEvent: WorldRuntimeStreamEnvelope = {
           contractVersion: 1,
           id: String(client.lastSequence),
@@ -31,7 +33,7 @@ export class WorldStreamHub {
           payload: {},
           createdAt: new Date().toISOString(),
         }
-        writeSse(client.response, 'heartbeat', heartbeatEvent, heartbeatEvent.id)
+        client.connection.send('heartbeat', heartbeatEvent, heartbeatEvent.id)
       }
     }, heartbeatMs)
     this.#heartbeat.unref()
@@ -58,6 +60,12 @@ export class WorldStreamHub {
       Connection: 'keep-alive',
       'X-Accel-Buffering': 'no',
     })
+    let client: WorldStreamClient
+    const connection = new SseConnection(response, () => this.#clients.delete(client), this.#connectionOptions)
+    client = { worldId, connection, lastSequence: snapshot.sequence }
+    this.#clients.add(client)
+    if (typeof response.once === 'function') response.once('close', () => connection.close())
+    request.once('close', () => connection.close())
     if (invalidCursor || after !== snapshot.sequence) {
       const recoveryRequired: WorldRuntimeStreamEnvelope = {
         contractVersion: 1,
@@ -72,7 +80,7 @@ export class WorldStreamHub {
         },
         createdAt: new Date().toISOString(),
       }
-      writeSse(response, 'recovery-required', recoveryRequired, recoveryRequired.id)
+      connection.send('recovery-required', recoveryRequired, recoveryRequired.id)
       const recoveryState: WorldRuntimeStreamEnvelope = {
         contractVersion: 1,
         id: String(snapshot.sequence),
@@ -82,9 +90,9 @@ export class WorldStreamHub {
         payload: snapshot as unknown as JsonObject,
         createdAt: new Date().toISOString(),
       }
-      writeSse(response, 'world-state', recoveryState, recoveryState.id)
+      connection.send('world-state', recoveryState, recoveryState.id)
     } else {
-      writeSse(response, 'ready', {
+      connection.send('ready', {
         contractVersion: 1,
         id: String(snapshot.sequence),
         worldId,
@@ -94,22 +102,19 @@ export class WorldStreamHub {
         createdAt: new Date().toISOString(),
       }, String(snapshot.sequence))
     }
-    const client = { worldId, response, lastSequence: snapshot.sequence }
-    this.#clients.add(client)
-    request.once('close', () => this.#clients.delete(client))
   }
 
   publish(event: WorldRuntimeStreamEnvelope): void {
-    for (const client of this.#clients) {
+    for (const client of [...this.#clients]) {
       if (client.worldId !== event.worldId) continue
-      writeSse(client.response, event.kind, event, event.id)
+      client.connection.send(event.kind, event, event.id)
       client.lastSequence = Math.max(client.lastSequence, event.sequence)
     }
   }
 
   close(): void {
     clearInterval(this.#heartbeat)
-    for (const client of this.#clients) client.response.end()
+    for (const client of [...this.#clients]) client.connection.close()
     this.#clients.clear()
   }
 }

--- a/packages/server/tests/http-infrastructure.test.ts
+++ b/packages/server/tests/http-infrastructure.test.ts
@@ -43,6 +43,34 @@ class FakeResponse {
   }
 }
 
+class ThrowingResponse extends FakeResponse {
+  override write(_value: string | Buffer): boolean {
+    throw new Error('subscriber write failed')
+  }
+}
+
+class SlowResponse extends FakeResponse {
+  writableLength = 0
+  readonly #drainListeners: Array<() => void> = []
+
+  override write(value: string | Buffer): boolean {
+    const chunk = String(value)
+    this.chunks.push(chunk)
+    this.writableLength += Buffer.byteLength(chunk, 'utf8')
+    return false
+  }
+
+  once(event: string, listener: (...args: any[]) => void): this {
+    if (event === 'drain') this.#drainListeners.push(() => listener())
+    return this
+  }
+
+  drain(): void {
+    this.writableLength = 0
+    for (const listener of this.#drainListeners.splice(0)) listener()
+  }
+}
+
 function request(
   url: string,
   headers: IncomingMessage['headers'] = {},
@@ -229,6 +257,62 @@ describe('stream lifecycle', () => {
     expect(fake.text()).toContain('event: world-runtime')
     incoming.emit('close')
     expect(hub.clientCount).toBe(0)
+    hub.close()
+  })
+
+  it('isolates a subscriber write failure from healthy subscribers', () => {
+    const hub = new RuntimeStreamHub(60_000)
+    const throwing = new ThrowingResponse()
+    hub.connect('world-1', request('/api/worlds/world-1/live'), throwing as unknown as ServerResponse)
+    const healthy = response()
+    hub.connect('world-1', request('/api/worlds/world-1/live'), healthy.node)
+
+    hub.publish({
+      workspaceId: 'workspace-1',
+      worldId: 'world-1',
+      sessionId: 'session-1',
+      agentId: 'employee-1',
+      event: {
+        kind: 'turn.started',
+        source: 'test',
+        sourceSessionId: 'agent-session-1',
+        sourceSequence: 1,
+        metadata: {},
+      },
+    })
+
+    expect(hub.clientCount).toBe(1)
+    expect(healthy.fake.text()).toContain('event: runtime')
+    hub.close()
+  })
+
+  it('bounds a slow subscriber buffer and removes it without affecting healthy peers', () => {
+    const hub = new RuntimeStreamHub(60_000, { maxBufferedBytes: 512 })
+    const slow = new SlowResponse()
+    hub.connect('world-1', request('/api/worlds/world-1/live'), slow as unknown as ServerResponse)
+    const healthy = response()
+    hub.connect('world-1', request('/api/worlds/world-1/live'), healthy.node)
+
+    for (let index = 0; index < 10; index += 1) {
+      hub.publish({
+        workspaceId: 'workspace-1',
+        worldId: 'world-1',
+        sessionId: 'session-1',
+        agentId: 'employee-1',
+        event: {
+          kind: 'assistant.message',
+          source: 'test',
+          sourceSessionId: 'agent-session-1',
+          sourceSequence: index,
+          content: 'x'.repeat(100),
+          metadata: {},
+        },
+      })
+    }
+
+    expect(hub.clientCount).toBe(1)
+    expect(slow.writableEnded).toBe(true)
+    expect(healthy.fake.text()).toContain('event: runtime')
     hub.close()
   })
 

--- a/packages/server/tests/model-hub-routes.test.ts
+++ b/packages/server/tests/model-hub-routes.test.ts
@@ -11,7 +11,7 @@ const servers: CyberServer[] = []
 const roots: string[] = []
 
 beforeAll(() => {
-  // Offline deterministic catalog: the bundled snapshot, never the network.
+  // Offline deterministic catalog: the checked-in repository file, never the network.
   process.env.DSH_CYBER_MODEL_CATALOG_URL = ''
 })
 
@@ -54,11 +54,11 @@ async function call(origin: string, method: string, path: string, body?: unknown
 }
 
 describe('model hub routes', () => {
-  it('serves the bundled catalog offline with signup guidance', async () => {
+  it('serves the repository catalog offline with signup guidance', async () => {
     const { origin } = await startServer()
     const state = await call(origin, 'GET', '/api/model-provider-catalog')
     expect(state.status).toBe(200)
-    expect(state.body.source).toBe('bundled')
+    expect(state.body.source).toBe('repository')
     const deepseek = state.body.catalog.providers.find((entry: { id: string }) => entry.id === 'deepseek')
     expect(deepseek.signup.url).toContain('https://platform.deepseek.com')
     expect(deepseek.balance).toBe('deepseek')

--- a/packages/server/tests/model-provider-catalog.test.ts
+++ b/packages/server/tests/model-provider-catalog.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createRequire } from 'node:module'
@@ -62,13 +62,51 @@ describe('parseModelProviderCatalog', () => {
     expect(parsed.providers[1]!.popularModels).toEqual(['ok'])
   })
 
-  it('keeps the repository catalog and the bundled snapshot identical', async () => {
+  it('accepts the repository catalog as a separately deployable source', async () => {
     const raw = await readFile(REPO_CATALOG_PATH, 'utf8')
-    expect(JSON.parse(raw) as unknown).toEqual(BUNDLED_MODEL_PROVIDER_CATALOG)
+    const parsed = parseModelProviderCatalog(JSON.parse(raw) as unknown)
+    expect(parsed.providers.length).toBeGreaterThan(5)
+    const root = await stateRoot()
+    const service = new ModelProviderCatalogService({ stateRoot: root, catalogPath: REPO_CATALOG_PATH })
+    await expect(service.state()).resolves.toMatchObject({ source: 'repository', catalog: parsed })
   })
 })
 
 describe('ModelProviderCatalogService fallback chain', () => {
+  it('prefers the repository file over an explicitly configured remote', async () => {
+    const root = await stateRoot()
+    const repository = { ...structuredClone(BUNDLED_MODEL_PROVIDER_CATALOG), version: 'repository-1' }
+    const fetchMock = vi.fn<typeof fetch>(async () => response({ ...repository, version: 'remote-1' }))
+    const catalogPath = join(root, 'model-providers.json')
+    await writeFile(catalogPath, JSON.stringify(repository), 'utf8')
+    const service = new ModelProviderCatalogService({
+      stateRoot: root,
+      catalogPath,
+      remoteUrl: 'https://example.test/catalog.json',
+      fetch: fetchMock,
+    })
+    const state = await service.state()
+    expect(state.source).toBe('repository')
+    expect(state.catalog.version).toBe('repository-1')
+    expect(fetchMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to a cached copy when the repository catalog is invalid', async () => {
+    const root = await stateRoot()
+    const seed = new ModelProviderCatalogService({
+      stateRoot: root,
+      remoteUrl: 'https://example.test/catalog.json',
+      fetch: vi.fn<typeof fetch>(async () => response({ ...BUNDLED_MODEL_PROVIDER_CATALOG, version: 'cached-1' })),
+    })
+    await seed.state()
+    const catalogPath = join(root, 'model-providers.json')
+    await writeFile(catalogPath, JSON.stringify({ schemaVersion: 1, version: 'broken', providers: [{ id: 'missing-fields' }] }), 'utf8')
+    const service = new ModelProviderCatalogService({ stateRoot: root, catalogPath })
+    const state = await service.state()
+    expect(state.source).toBe('cache')
+    expect(state.catalog.version).toBe('cached-1')
+  })
+
   it('uses a reachable remote and caches it', async () => {
     const root = await stateRoot()
     const remote = { ...structuredClone(BUNDLED_MODEL_PROVIDER_CATALOG), version: 'remote-1' }

--- a/packages/web/tests/world-live-client.test.ts
+++ b/packages/web/tests/world-live-client.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { subscribeWorldLive } from '../src/world-live-client.js'
 
@@ -50,6 +50,7 @@ beforeEach(() => {
 })
 
 afterEach(() => {
+  vi.useRealTimers()
   delete (globalThis as { EventSource?: unknown }).EventSource
 })
 
@@ -92,5 +93,21 @@ describe('subscribeWorldLive', () => {
     expect(FakeEventSource.instances.filter((item) => item.url.includes('world-c'))).toHaveLength(1)
     stopA()
     stopB()
+  })
+
+  it('keeps the shared connection through a short unmount/remount gap', () => {
+    vi.useFakeTimers()
+    const stop = subscribeWorldLive('world-grace', 'runtime', () => {})
+    const source = FakeEventSource.instances.at(-1)!
+    stop()
+
+    vi.advanceTimersByTime(249)
+    const remountedStop = subscribeWorldLive('world-grace', 'trace', () => {})
+    expect(FakeEventSource.instances.filter((item) => item.url.includes('world-grace'))).toHaveLength(1)
+    expect(source.closed).toBe(false)
+
+    remountedStop()
+    vi.advanceTimersByTime(250)
+    expect(source.closed).toBe(true)
   })
 })


### PR DESCRIPTION
## 变更

- 将仓库 `catalog/model-providers.json` 接为本地模型服务商目录的首选来源；目录变更在强制刷新或缓存 TTL 到期后生效。
- 保留严格解析与安全降级：显式远程目录仅作备用，随后使用 stateRoot 缓存和内置快照。
- 为 runtime/world SSE 增加每连接有界缓冲、异常订阅者隔离和共享连接短暂卸载重挂载复用。
- 补充目录来源、SSE 慢连接/异常连接和连接生命周期回归测试，并记录整改计划进度。

## 验证

- `pnpm exec vitest run --maxWorkers=4`：330 个测试文件，1863 项通过，1 项跳过。
- `pnpm run build`：生产构建与构建预算通过。
- `pnpm run typecheck`：通过。
- `git diff --check`：通过。

基于最新 `origin/main`：`d88cf4115f453dc9e79a1fda535fd19b1d6dd23f`。
