### PR TITLE
fix-context-budget-fallback

### DIFF
--- a/docs/development/audit-remediation-2026-09-05.md
+++ b/docs/development/audit-remediation-2026-09-05.md
@@ -116,3 +116,5 @@ Group HTTP 接线检查点：`/chat` 的 discussion/task immediate/queued 在 pl
 第六批首个纵切已完成本地复验：Harness adapter 将最终 runtime-facing 输入按 system、当前请求、实际重放历史、native schema/system/turn-context、live retained context 分项计量；固定 rc.1 wire schema 漂移门禁，活跃会话超限先验证 SQLite fresh replay，失败则保留旧 lane。Inspector 与 snapshot 读取同一无明文 `contextUsage` 投影，并保留最终重放序列和消息来源指针。Memory/Knowledge 检索在 FTS/LIKE 两条路径统一有界 overfetch、lexical score 与稳定 tie-break，修复 500/5000 候选被前 50 行截断、同数 stale mirror 和中文句尾词元丢失。当前定向 126 项通过，完整有效上下文还需继续核对 CharacterProfileRuntime/Inspector 与真实 provider 入参边界，故第六批保持开发中。
 
 2026-09-07：继续整合本地未提交整改。SSE runtime/world 流统一使用有界连接缓冲，单个异常或慢订阅者只会被关闭，不影响健康订阅者；共享 world live 客户端在短暂卸载/重挂载窗口内复用连接。模型服务商目录改为优先读取仓库 `catalog/model-providers.json`，远程目录仅在仓库文件不可用且显式配置时作为备用，随后依次使用 stateRoot 缓存和内置快照。仓库目录仍经过同一严格解析器，目录变更在本地服务下一次读取时生效；批次 07/08 仍需其余审计范围和真实浏览器证据，未标记完成。
+
+同日第六批补充：Harness adapter 在 direct embedder 未提供 `ContextBudget`、但 provider profile 声明上下文窗口时，预算回退现在按实际 `employeeSystemPrompt` 估算固定层，而不是只按裸 Persona 估算；新增回归验证展开后的身份/安全/工具提示进入预算且仍能在精确边界执行。适配器定向 32 项、类型检查和生产构建/预算通过；第六批仍保持开发中，尚未宣称覆盖真实供应商 tokenizer 或完整 provider canary。

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -982,7 +982,7 @@ function requiredConversationId(value: string | undefined): string {
  * limits must preserve its legacy behavior rather than invent a window.
  */
 function resolveAdapterContextBudget(
-  request: Pick<EmployeeTurnRequest, 'contextBudget' | 'revision' | 'prompt'>,
+  request: Pick<EmployeeTurnRequest, 'contextBudget' | 'employee' | 'revision' | 'prompt'>,
   providerProfile: HarnessProviderProfile | undefined,
 ): AgentTurnRequest['contextBudget'] | undefined {
   if (request.contextBudget !== undefined) return request.contextBudget
@@ -991,7 +991,12 @@ function resolveAdapterContextBudget(
   return planContextBudget({
     ...(model.contextWindow === undefined ? {} : { contextWindow: model.contextWindow }),
     ...(model.maxTokens === undefined ? {} : { maxOutputTokens: model.maxTokens }),
-    fixedText: [request.revision.persona, request.prompt],
+    // The fallback is used by direct adapter embedders that do not run the
+    // server's ContextPlanningRuntime. Count the exact system prompt that the
+    // worker will receive, rather than only the raw persona; otherwise the
+    // planner allocates history against tokens that the runtime has already
+    // reserved for identity, safety and tool-use instructions.
+    fixedText: [employeeSystemPrompt(request.employee, request.revision), request.prompt],
   })
 }
 

--- a/packages/harness-adapter/tests/adapter.test.ts
+++ b/packages/harness-adapter/tests/adapter.test.ts
@@ -172,6 +172,56 @@ describe('Harness profile and adapter', () => {
     await adapter.close()
   })
 
+  it('counts the expanded system prompt when a provider fallback builds the budget', async () => {
+    const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-provider-budget-'))
+    const currentEmployee = employee()
+    const currentRevision = revision()
+    const prompt = '保留真实边界'
+    const profile = { homeDir: stateRoot, profileDir: stateRoot, profileManifestPath: stateRoot, profilePatchPath: stateRoot, settingsPath: stateRoot }
+    const systemPrompt = workerEnvironment({}, {
+      employee: currentEmployee,
+      revision: currentRevision,
+      profile,
+      workspacePath: stateRoot,
+      sessionsRoot: join(stateRoot, 'sessions'),
+      permissionMode: 'read-only',
+    }).DSH_SYSTEM_PROMPT!
+    const expandedFixedTokens = estimateTextTokens(systemPrompt) + estimateTextTokens(prompt)
+    const rawPersonaTokens = estimateTextTokens(currentRevision.persona) + estimateTextTokens(prompt)
+    expect(expandedFixedTokens).toBeGreaterThan(rawPersonaTokens)
+    const contextWindow = expandedFixedTokens + 1_024 + 512
+    let runs = 0
+    const adapter = new HarnessCompatibilityAdapter({
+      stateRoot,
+      providerProfile: {
+        route: 'fallback-model',
+        displayName: 'Fallback model',
+        api: 'openai-completions',
+        baseURL: 'http://127.0.0.1:1/v1',
+        model: { id: 'fallback-model', contextWindow, maxTokens: 1_024 },
+      },
+      runtimeFactory: () => ({
+        async run() {
+          runs += 1
+          return { finalResponse: 'ok', notifications: [] }
+        },
+        async close() {},
+      }),
+    })
+
+    await adapter.runEmployeeTurn({
+      employee: currentEmployee,
+      revision: currentRevision,
+      conversationId: 'provider-budget-fallback',
+      history: [],
+      observedThroughSequence: 0,
+      prompt,
+      workspacePath: stateRoot,
+    })
+    expect(runs).toBe(1)
+    await adapter.close()
+  })
+
   it('counts native tool schemas before creating a runtime', async () => {
     const stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-native-schema-budget-'))
     const prompt = '边界'


### PR DESCRIPTION
## 变更

第六批上下文整改的补充纵切：当 Harness adapter 被直接嵌入且没有显式 `ContextBudget`、但 provider profile 声明了上下文窗口时，回退预算现在按实际 `employeeSystemPrompt` 计算固定层，覆盖角色身份、安全说明和工具调度提示，避免只按裸 Persona 分配历史空间。新增精确边界回归，确认展开后的固定文本被纳入预算。

更新审计执行记录；第六批仍在开发中，真实供应商 tokenizer、完整 provider 入参和 canary 证据仍待后续验收。

## 验证

- `pnpm exec vitest run packages/harness-adapter/tests/adapter.test.ts`：32 项通过。
- `pnpm --filter @dsh-cyber/harness-adapter typecheck`：通过。
- `pnpm run build`：生产构建与构建预算通过。
- `git diff --check`：通过。

基于最新 `origin/main`：`d45d17b6b003badfe3977d77a615aa17f95d36b8`。
