### PR TITLE
merge-image-model-world-files

### DIFF
--- a/packages/server/src/routes/conversation-routes.ts
+++ b/packages/server/src/routes/conversation-routes.ts
@@ -52,6 +52,7 @@ import type { GroupTaskRoutingResult } from '../services/group-task-router.js'
 import type { PreparedGroupTurnPlanner } from '../services/prepared-group-turn-planner.js'
 import type { ConversationQueueService } from '../services/conversation-queue-service.js'
 import { GroupIntentRouter } from '../services/group-intent-router.js'
+import { isImageGenerationModel } from '../services/image-generation-service.js'
 import type { ConversationTaskIntentOutcome, ConversationTaskIntentService } from '../services/conversation-task-intent-service.js'
 import { listApprovalRequestViews } from '../services/approval-request-views.js'
 import type { HarnessToolApprovalService } from '../services/harness-tool-approval-service.js'
@@ -233,10 +234,19 @@ export function registerConversationRoutes(router: Router, dependencies: Convers
     // and settled once the turn has an id.
     // Track settlement without joining it: the response may carry the decision
     // when it is already there, and must never wait for one that is not.
+    // An image-model character answers only with pictures: the classifier
+    // would judge their message against the world's TEXT default model and
+    // record a misleading "任务意图判定失败" failure beside the image the turn
+    // actually produced. Skip classification for a solo turn whose resolved
+    // model generates images - there is no instruction for it to run.
+    const resolvedImageCharacter = employeeIds.length === 1
+      ? store.resolveModelProfile(world.workspaceId, world.id, employeeIds[0]!)
+      : undefined
+    const imageCharacterTurn = resolvedImageCharacter !== undefined && isImageGenerationModel(resolvedImageCharacter)
     let proposedTaskIntent: ReturnType<ConversationTaskIntentService['propose']> | undefined
     let intentSettled: ConversationTaskIntentOutcome | undefined
     const startTaskIntent = (): void => {
-      if (proposedTaskIntent !== undefined || taskIntent === undefined) return
+      if (imageCharacterTurn || proposedTaskIntent !== undefined || taskIntent === undefined) return
       proposedTaskIntent = taskIntent.propose({ workspaceId: world.workspaceId, worldId: world.id, prompt })
       proposedTaskIntent.then((outcome) => { intentSettled = outcome }, () => undefined)
     }

--- a/packages/server/src/services/world-file-service.ts
+++ b/packages/server/src/services/world-file-service.ts
@@ -79,10 +79,11 @@ export class WorldFileService {
   }
 
   /**
-   * Persist a model-generated image under the same attachment convention as
-   * user uploads, so chat rendering, the assets route and backup bundles all
-   * treat one generated picture exactly like any other attachment. The size
-   * cap is larger: generated PNGs legitimately exceed a manual upload.
+   * Persist a model-generated image as a real, visible world file under
+   * `files/图片/` - the folder the world file browser, backup bundles and the
+   * character's own file permission all see. The chat attachment references
+   * the world-file read endpoint, so the transcript renders the very same
+   * bytes instead of a hidden assets copy the owner cannot find.
    */
   async saveGeneratedImage(worldId: string, input: { bytes: Buffer; mimeType: 'image/png' | 'image/jpeg' | 'image/webp'; name: string }): Promise<ChatAttachment> {
     const MAX_GENERATED_IMAGE_BYTES = 20 * 1024 * 1024
@@ -91,35 +92,21 @@ export class WorldFileService {
     }
     const root = await this.#roots.ensure(worldId)
     const id = randomUUID()
-    const fileName = `${id}.${input.mimeType === 'image/jpeg' ? 'jpg' : input.mimeType === 'image/webp' ? 'webp' : 'png'}`
-    const attachmentDirectory = join(root.assetsPath, 'attachments')
-    await mkdir(attachmentDirectory, { recursive: true })
-    const safeDirectory = await safeAttachmentDirectory(root.assetsPath, attachmentDirectory)
+    const extension = input.mimeType === 'image/jpeg' ? 'jpg' : input.mimeType === 'image/webp' ? 'webp' : 'png'
+    const baseName = `${input.name.trim().slice(0, 120) || '生成图片'}-${id.slice(0, 8)}`.replace(/[\\/]/gu, '').replace(/[\u0000-\u001f]/gu, '')
+    const fileName = `${baseName}.${extension}`
+    const picturesDirectory = join(root.filesPath, '图片')
+    await mkdir(picturesDirectory, { recursive: true })
+    const safeDirectory = await safeAttachmentDirectory(root.filesPath, picturesDirectory)
     const destination = join(safeDirectory, fileName)
-    const metadataPath = join(safeDirectory, `${id}.json`)
-    const metadata: WorldAttachmentMetadata = {
-      schemaVersion: 1,
-      id,
+    await writeAtomically(destination, input.bytes)
+    const relativePath = `图片/${fileName}`
+    return {
+      assetId: relativePath,
       name: input.name.trim().slice(0, 180) || '生成的图片',
       mimeType: input.mimeType,
       byteLength: input.bytes.length,
-      sha256: sha256(input.bytes),
-      fileName,
-      createdAt: new Date().toISOString(),
-    }
-    try {
-      await writeAtomically(destination, input.bytes)
-      await writeAtomically(metadataPath, Buffer.from(`${JSON.stringify(metadata, null, 2)}\n`, 'utf8'))
-    } catch (error) {
-      await Promise.all([unlink(destination).catch(() => undefined), unlink(metadataPath).catch(() => undefined)])
-      throw error
-    }
-    return {
-      assetId: id,
-      name: metadata.name,
-      mimeType: input.mimeType,
-      byteLength: input.bytes.length,
-      url: `/api/worlds/${encodeURIComponent(worldId)}/assets/${encodeURIComponent(id)}`,
+      url: `/api/worlds/${encodeURIComponent(worldId)}/file?path=${encodeURIComponent(relativePath)}`,
     }
   }
 

--- a/packages/server/tests/conversation-task-from-chat.test.ts
+++ b/packages/server/tests/conversation-task-from-chat.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, readdir, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
@@ -107,7 +107,7 @@ async function start(intent: ConversationTaskIntentPort) {
   const workspace = server.store.listWorkspaces()[0]!
   const world = server.store.listWorlds(workspace.id)[0]!
   const employee = server.store.listEmployees(world.id)[0]!
-  return { origin, server, runtime, workspace, world, employee }
+  return { origin, server, runtime, workspace, world, employee, stateRoot }
 }
 
 async function json(origin: string, path: string, init?: RequestInit): Promise<{ status: number; body: any }> {
@@ -298,7 +298,7 @@ describe('a chat instruction becomes one task in the task list', () => {
       : realFetch(url as never, init as never))
     vi.stubGlobal('fetch', fetchMock as never)
     try {
-      const { origin, server, world, employee } = await start(intent)
+      const { origin, server, world, employee, stateRoot } = await start(intent)
       // Bind the character to a marked image generator. An instruction-shaped
       // message to such a character must never reach the classifier (it would
       // judge against the world's text default and record noise next to the
@@ -322,6 +322,12 @@ describe('a chat instruction becomes one task in the task list', () => {
       expect(server.work.list(world.id)).toEqual([])
       // The turn still answered with the picture's caption.
       expect(answered.body.replies?.length ?? 0).toBeGreaterThan(0)
+      // The generated image is a real, visible world file under files/图片,
+      // browsable like any other world file - not a hidden assets copy.
+      const picturesDirectory = join(stateRoot, 'worlds', world.id, 'files', '图片')
+      const pictures = await readdir(picturesDirectory)
+      expect(pictures).toHaveLength(1)
+      expect(pictures[0]).toMatch(/\.png$/u)
     } finally {
       vi.unstubAllGlobals()
     }

--- a/packages/server/tests/conversation-task-from-chat.test.ts
+++ b/packages/server/tests/conversation-task-from-chat.test.ts
@@ -2,7 +2,7 @@ import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { AgentRuntimePort, AgentTurnRequest, WorkTask, WorkTaskDetail, WorldTraceEntry } from '@dsh-cyber/contracts'
 
 import { createCyberServer, type CyberServer } from '../src/index.js'
@@ -284,5 +284,46 @@ describe('a chat instruction becomes one task in the task list', () => {
     const failures = (trace.body.items as WorldTraceEntry[]).filter((entry) => entry.summary.includes('任务意图'))
     expect(failures).toHaveLength(3)
     expect(failures.every((entry) => entry.status === 'failed')).toBe(true)
+  })
+
+  it('does not classify an image-model character at all, and still delivers the picture', async () => {
+    const intent = stubIntent({})
+    // Deterministic image endpoint: inline bytes, no real gateway. Stubbed
+    // BEFORE the server composes so ImageGenerationService captures it; every
+    // other request passes through to the real server.
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0x00, 0x00, 0x01])
+    const realFetch = globalThis.fetch.bind(globalThis)
+    const fetchMock = vi.fn(async (url: string | URL | Request, init?: RequestInit) => String(url).endsWith('/images/generations')
+      ? new Response(JSON.stringify({ data: [{ b64_json: pngBytes.toString('base64') }] }), { status: 200, headers: { 'content-type': 'application/json' } })
+      : realFetch(url as never, init as never))
+    vi.stubGlobal('fetch', fetchMock as never)
+    try {
+      const { origin, server, world, employee } = await start(intent)
+      // Bind the character to a marked image generator. An instruction-shaped
+      // message to such a character must never reach the classifier (it would
+      // judge against the world's text default and record noise next to the
+      // picture the turn is about to produce).
+      const profile = server.store.saveModelProfile({
+        workspaceId: world.workspaceId,
+        displayName: '形象生成器',
+        providerKind: 'openai-compatible-remote',
+        baseUrl: 'https://images.example.test/v1',
+        modelId: 'gpt-image-test',
+        api: 'openai-completions',
+        isDefault: false,
+        settings: { imageGeneration: true },
+      })
+      server.store.saveModelAssignment({ workspaceId: world.workspaceId, scope: 'employee', scopeId: employee.id, modelProfileId: profile.id })
+      const answered = await json(origin, `/api/worlds/${world.id}/chat`, post({ employeeIds: [employee.id], prompt: INSTRUCTION }))
+      expect(answered.status).toBe(200)
+      expect(answered.body.proposedTask).toBeUndefined()
+      // The classifier never ran: no draft, no misleading failure event.
+      expect(intent.prompts).toEqual([])
+      expect(server.work.list(world.id)).toEqual([])
+      // The turn still answered with the picture's caption.
+      expect(answered.body.replies?.length ?? 0).toBeGreaterThan(0)
+    } finally {
+      vi.unstubAllGlobals()
+    }
   })
 })


### PR DESCRIPTION
## 变更

该 PR 线性整合远程 #180 与 #181 的实际功能提交：

- 图像生成模型角色跳过不适用的任务意图判定，避免产生误导性任务失败轨迹。
- 生成图片写入世界可见的 `files/图片/` 目录，聊天附件直接指向世界文件读取端点。
- 保留原有图片回合与产物登记行为，并补充回归验证。

这是 #180/#181 的无冲突替代合并 PR；原 PR 分支被主分支保护策略阻塞，功能提交未改写。

## 验证

- 远程 required CI 将执行类型检查、全量单元/集成、迁移/schema 与核心浏览器冒烟。
- 原 #181 required CI `34082118444` 已通过。
- 本分支基于最新 `origin/main` `3067e2b1e3ab670a085cd008504c1d83273e9d7b`。
