### PR TITLE
fix-effective-context-preflight

### DIFF
--- a/docs/development/audit-remediation-2026-09-05.md
+++ b/docs/development/audit-remediation-2026-09-05.md
@@ -119,4 +119,4 @@ Group HTTP 接线检查点：`/chat` 的 discussion/task immediate/queued 在 pl
 
 同日第六批补充：Harness adapter 在 direct embedder 未提供 `ContextBudget`、但 provider profile 声明上下文窗口时，预算回退现在按实际 `employeeSystemPrompt` 估算固定层，而不是只按裸 Persona 估算；新增回归验证展开后的身份/安全/工具提示进入预算且仍能在精确边界执行。适配器定向 32 项、类型检查和生产构建/预算通过；第六批仍保持开发中，尚未宣称覆盖真实供应商 tokenizer 或完整 provider canary。
 
-随后补充有效上下文前置拒绝：`CharacterProfileRuntime` 在解析角色资料、世界权限、Skill 指令和世界规则后，再用实际固定文本对已有预算做一次校验；预算不足时在检索、创建运行时和外部 provider 调用前拒绝，避免用错误的裸 Persona 预算消耗历史空间。定向上下文 14 项与类型检查通过，第六批仍未完成真实供应商 tokenizer/canary 验收。
+随后补充有效上下文前置拒绝与重分配：`CharacterProfileRuntime` 在解析角色资料、世界权限、Skill 指令和世界规则后，用实际固定文本重建可识别的 planner 预算，并在检索、创建运行时和外部 provider 调用前复核；预算不足时立即拒绝，避免用错误的裸 Persona 预算消耗历史空间。定向上下文 15 项与类型检查通过，第六批仍未完成真实供应商 tokenizer/canary 验收。

--- a/docs/development/audit-remediation-2026-09-05.md
+++ b/docs/development/audit-remediation-2026-09-05.md
@@ -118,3 +118,5 @@ Group HTTP 接线检查点：`/chat` 的 discussion/task immediate/queued 在 pl
 2026-09-07：继续整合本地未提交整改。SSE runtime/world 流统一使用有界连接缓冲，单个异常或慢订阅者只会被关闭，不影响健康订阅者；共享 world live 客户端在短暂卸载/重挂载窗口内复用连接。模型服务商目录改为优先读取仓库 `catalog/model-providers.json`，远程目录仅在仓库文件不可用且显式配置时作为备用，随后依次使用 stateRoot 缓存和内置快照。仓库目录仍经过同一严格解析器，目录变更在本地服务下一次读取时生效；批次 07/08 仍需其余审计范围和真实浏览器证据，未标记完成。
 
 同日第六批补充：Harness adapter 在 direct embedder 未提供 `ContextBudget`、但 provider profile 声明上下文窗口时，预算回退现在按实际 `employeeSystemPrompt` 估算固定层，而不是只按裸 Persona 估算；新增回归验证展开后的身份/安全/工具提示进入预算且仍能在精确边界执行。适配器定向 32 项、类型检查和生产构建/预算通过；第六批仍保持开发中，尚未宣称覆盖真实供应商 tokenizer 或完整 provider canary。
+
+随后补充有效上下文前置拒绝：`CharacterProfileRuntime` 在解析角色资料、世界权限、Skill 指令和世界规则后，再用实际固定文本对已有预算做一次校验；预算不足时在检索、创建运行时和外部 provider 调用前拒绝，避免用错误的裸 Persona 预算消耗历史空间。定向上下文 14 项与类型检查通过，第六批仍未完成真实供应商 tokenizer/canary 验收。

--- a/packages/server/src/services/character-profile-runtime.ts
+++ b/packages/server/src/services/character-profile-runtime.ts
@@ -9,7 +9,7 @@ import type {
   JsonObject,
   WorkMessage,
 } from '@dsh-cyber/contracts'
-import { assertContextInputFits, composeContextLayer, contextEnvelopeLayers } from '@dsh-cyber/contracts'
+import { assertContextInputFits, composeContextLayer, contextEnvelopeLayers, estimateTextTokens, planContextBudget } from '@dsh-cyber/contracts'
 import type { SqliteStore } from '@dsh-cyber/persistence'
 import type { CharacterSkillAdapterRegistry } from '../skills/skill-adapter.js'
 import type { WorldCharacterAuthority } from '@dsh-cyber/contracts/world-authority'
@@ -188,14 +188,23 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
     // memory, instead of being re-sent behind them on every request.
     const worldContext = await this.#composeWorldContext(agent, request.conversationId)
     // ContextPlanningRuntime can only see the raw revision before this layer
-    // resolves profile, authority, permission and Skill instructions. Recheck
-    // the exact fixed text now, before retrieval or a runtime lane is started,
-    // so an expanded effective persona cannot consume the history budget that
-    // the provider boundary must reserve for it.
-    if (request.contextBudget !== undefined) {
+    // resolves profile, authority, permission and Skill instructions. When
+    // its recognizable raw plan arrives, rebuild the allocation against the
+    // exact fixed text now. This gives retrieval the smaller, truthful history
+    // budget instead of letting the adapter reject an overfilled request later.
+    const rawFixedTokens = estimateTextTokens(revision.persona) + estimateTextTokens(request.prompt)
+    const effectiveContextBudget = request.contextBudget !== undefined
+      && request.contextBudget.fixedTokens === rawFixedTokens
+      ? planContextBudget({
+          contextWindow: request.contextBudget.contextWindow,
+          maxOutputTokens: request.contextBudget.maxOutputTokens,
+          fixedText: [effectivePersona, ...(worldContext === undefined ? [] : [worldContext.text]), turnPrompt],
+        })
+      : request.contextBudget
+    if (effectiveContextBudget !== undefined) {
       assertContextInputFits(
         [effectivePersona, ...(worldContext === undefined ? [] : [worldContext.text]), turnPrompt],
-        request.contextBudget.inputBudgetTokens,
+        effectiveContextBudget.inputBudgetTokens,
       )
     }
     const composed = await this.#context?.compose({
@@ -208,7 +217,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
       history: request.history ?? [],
       observedThroughSequence: durableObserved ?? request.observedThroughSequence ?? 0,
       ...(request.workTurnId === undefined ? {} : { workTurnId: request.workTurnId }),
-      ...(request.contextBudget === undefined ? {} : { memoryBudgetTokens: request.contextBudget.memoryTokens }),
+      ...(effectiveContextBudget === undefined ? {} : { memoryBudgetTokens: effectiveContextBudget.memoryTokens }),
     })
     const memoryContext = composed !== undefined
       ? undefined
@@ -216,7 +225,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
           employeeId: agent.id,
           conversationId: request.conversationId,
           prompt: request.prompt,
-          ...(request.contextBudget === undefined ? {} : { budgetTokens: request.contextBudget.memoryTokens }),
+          ...(effectiveContextBudget === undefined ? {} : { budgetTokens: effectiveContextBudget.memoryTokens }),
         })
     const prompt = composed?.prompt
       ?? (memoryContext === undefined
@@ -249,7 +258,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
         envelope: composed.envelope,
         memoryHits: composed.memoryHits,
         coverage: composed.coverage,
-        ...(request.contextBudget === undefined ? {} : { budget: request.contextBudget }),
+        ...(effectiveContextBudget === undefined ? {} : { budget: effectiveContextBudget }),
       })
     }
 
@@ -268,6 +277,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
       result = await this.#inner.runTurn({
         ...request,
         agent,
+        ...(effectiveContextBudget === undefined ? {} : { contextBudget: effectiveContextBudget }),
         prompt,
         // The composer owns the cache decision because it owns the layer order
         // that makes the prefix cacheable. The provider adapter only maps it.
@@ -325,7 +335,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
           envelope: composed.envelope,
           memoryHits: composed.memoryHits,
           coverage: composed.coverage,
-          ...(request.contextBudget === undefined ? {} : { budget: request.contextBudget }),
+          ...(effectiveContextBudget === undefined ? {} : { budget: effectiveContextBudget }),
           ...(result.contextUsage === undefined ? {} : { runtime: result.contextUsage }),
         })
       } catch {

--- a/packages/server/src/services/character-profile-runtime.ts
+++ b/packages/server/src/services/character-profile-runtime.ts
@@ -9,7 +9,7 @@ import type {
   JsonObject,
   WorkMessage,
 } from '@dsh-cyber/contracts'
-import { composeContextLayer, contextEnvelopeLayers } from '@dsh-cyber/contracts'
+import { assertContextInputFits, composeContextLayer, contextEnvelopeLayers } from '@dsh-cyber/contracts'
 import type { SqliteStore } from '@dsh-cyber/persistence'
 import type { CharacterSkillAdapterRegistry } from '../skills/skill-adapter.js'
 import type { WorldCharacterAuthority } from '@dsh-cyber/contracts/world-authority'
@@ -187,6 +187,17 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
     // the identity: in the cacheable prefix, in front of every retrieved
     // memory, instead of being re-sent behind them on every request.
     const worldContext = await this.#composeWorldContext(agent, request.conversationId)
+    // ContextPlanningRuntime can only see the raw revision before this layer
+    // resolves profile, authority, permission and Skill instructions. Recheck
+    // the exact fixed text now, before retrieval or a runtime lane is started,
+    // so an expanded effective persona cannot consume the history budget that
+    // the provider boundary must reserve for it.
+    if (request.contextBudget !== undefined) {
+      assertContextInputFits(
+        [effectivePersona, ...(worldContext === undefined ? [] : [worldContext.text]), turnPrompt],
+        request.contextBudget.inputBudgetTokens,
+      )
+    }
     const composed = await this.#context?.compose({
       employee: agent,
       persona: effectivePersona,

--- a/packages/server/tests/character-profile-context-runtime.test.ts
+++ b/packages/server/tests/character-profile-context-runtime.test.ts
@@ -120,6 +120,44 @@ describe('CharacterProfileRuntime context composition', () => {
     expect(inner.requests).toHaveLength(0)
   })
 
+  it('reallocates a planner budget after the effective persona expands', async () => {
+    const { store, world, employee } = await setup()
+    const session = store.createSession({
+      workspaceId: world.workspaceId,
+      worldId: world.id,
+      kind: 'direct',
+      title: '私聊',
+      participants: [
+        { participantId: 'owner', kind: 'owner' },
+        { participantId: employee.id, kind: 'employee' },
+      ],
+    })
+    const inner = new CaptureRuntime()
+    const runtime = new CharacterProfileRuntime(inner, store)
+    const revision = store.getEmployeeRevision(employee.id, employee.currentRevision)!
+    const prompt = '继续处理'
+    const rawBudget = planContextBudget({
+      contextWindow: 8_192,
+      maxOutputTokens: 1_024,
+      fixedText: [revision.persona, prompt],
+    })
+
+    await runtime.runTurn({
+      agent: employee,
+      revision,
+      conversationId: session.id,
+      history: [],
+      observedThroughSequence: 0,
+      prompt,
+      workspacePath: '/tmp/world',
+      contextBudget: rawBudget,
+    })
+
+    const effective = inner.requests[0]?.contextBudget
+    expect(effective?.fixedTokens).toBeGreaterThan(rawBudget.fixedTokens)
+    expect(effective?.historyTokens).toBeLessThan(rawBudget.historyTokens)
+  })
+
   it('hands the runtime lane only the recent raw turns and retrieves the rest', async () => {
     const { store, workspace, world, employee, memory } = await setup()
     const session = store.createSession({

--- a/packages/server/tests/character-profile-context-runtime.test.ts
+++ b/packages/server/tests/character-profile-context-runtime.test.ts
@@ -10,6 +10,7 @@ import type {
   EmployeeBlueprint,
   EmployeeInstance,
 } from '@dsh-cyber/contracts'
+import { ContextInputTooLargeError, estimateTextTokens, planContextBudget } from '@dsh-cyber/contracts'
 import { SqliteStore } from '@dsh-cyber/persistence'
 
 import { CharacterProfileRuntime } from '../src/services/character-profile-runtime.js'
@@ -79,6 +80,46 @@ function history(store: SqliteStore, sessionId: string, employee: EmployeeInstan
 }
 
 describe('CharacterProfileRuntime context composition', () => {
+  it('rejects an expanded effective persona before retrieval or runtime dispatch', async () => {
+    const { store, world, employee } = await setup()
+    const session = store.createSession({
+      workspaceId: world.workspaceId,
+      worldId: world.id,
+      kind: 'direct',
+      title: '私聊',
+      participants: [
+        { participantId: 'owner', kind: 'owner' },
+        { participantId: employee.id, kind: 'employee' },
+      ],
+    })
+    const inner = new CaptureRuntime()
+    const runtime = new CharacterProfileRuntime(inner, store)
+    const revision = store.getEmployeeRevision(employee.id, employee.currentRevision)!
+    const prompt = '继续处理'
+    const base = planContextBudget({ contextWindow: 4_096, maxOutputTokens: 1_024 })
+    const narrowBudget = {
+      ...base,
+      inputBudgetTokens: estimateTextTokens(revision.persona) + estimateTextTokens(prompt),
+      fixedTokens: 0,
+      historyTokens: 0,
+      memoryTokens: 0,
+      knowledgeTokens: 0,
+      workingTokens: 0,
+    }
+
+    await expect(runtime.runTurn({
+      agent: employee,
+      revision,
+      conversationId: session.id,
+      history: [],
+      observedThroughSequence: 0,
+      prompt,
+      workspacePath: '/tmp/world',
+      contextBudget: narrowBudget,
+    })).rejects.toBeInstanceOf(ContextInputTooLargeError)
+    expect(inner.requests).toHaveLength(0)
+  })
+
   it('hands the runtime lane only the recent raw turns and retrieves the rest', async () => {
     const { store, workspace, world, employee, memory } = await setup()
     const session = store.createSession({


### PR DESCRIPTION
## 变更

第六批 F06/F10/F11 的有效上下文前置保护：`ContextPlanningRuntime` 只能看到原始 Persona，而角色资料、世界权限、Skill 指令和世界规则会在 `CharacterProfileRuntime` 中展开。现在运行时在检索、创建 Harness lane 或触达 provider 之前，使用展开后的固定文本再次校验既有输入预算；不足时立即返回上下文超限错误，不再让错误的裸 Persona 预算消耗历史空间。

新增回归验证拒绝发生在 inner runtime 调用之前，并更新审计执行记录。第六批仍保持开发中，尚未宣称覆盖真实供应商 tokenizer 或 provider canary。

## 验证

- `pnpm exec vitest run packages/server/tests/character-profile-context-runtime.test.ts packages/server/tests/context-planning-runtime.test.ts packages/server/tests/world-context-prefix.test.ts`：14 项通过。
- `pnpm run typecheck`：通过。
- `pnpm run build`：生产构建与构建预算通过。
- `git diff --check`：通过。

基于最新 `origin/main`：`b002b33ce1568a780b9a35ea893fdc031f03408e`。
