### PR TITLE
fix(world-files): one generated image becomes exactly one artifact

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -318,7 +318,7 @@ async function createLeasedCyberServer(options: CyberServerOptions, onStoreOpene
   const loggingRuntime = new TurnInteractionLoggingRuntime({ inner: contextRuntime, service: interactions, resolveRoute(request) { return resolveHarnessRoute(store, request) } })
   // Image-model turns branch before the whole chat stack: the prompt goes to
   // the images endpoint and never becomes a conversational request.
-  const runtime = createImageAwareRuntime({ inner: loggingRuntime, store, credentials, images: new ImageGenerationService(), worldFiles, worldArtifacts, interactions })
+  const runtime = createImageAwareRuntime({ inner: loggingRuntime, store, credentials, images: new ImageGenerationService(), worldFiles, interactions })
   const completionWorker = composeCompletionWorker(store, worldArtifacts)
   const groupTurnPlanner = composeGroupTurnPlanner(store, credentials, options.groupTurnPlanner)
   const orchestrator = new ConversationOrchestrator({

--- a/packages/server/src/services/image-turn-runtime.ts
+++ b/packages/server/src/services/image-turn-runtime.ts
@@ -8,7 +8,6 @@ import { isImageGenerationModel } from './image-generation-service.js'
 import type { ModelCredentialService } from './model-credential-service.js'
 import type { ModelInteractionService } from './model-interaction-service.js'
 import { ServiceError } from './service-error.js'
-import type { WorldArtifactService } from './world-artifact-service.js'
 import type { WorldFileService } from './world-file-service.js'
 
 export interface ImageTurnRuntimeDependencies {
@@ -17,7 +16,6 @@ export interface ImageTurnRuntimeDependencies {
   credentials: ModelCredentialService
   images: ImageGenerationService
   worldFiles: WorldFileService
-  worldArtifacts: WorldArtifactService
   interactions: ModelInteractionService
 }
 
@@ -25,9 +23,13 @@ export interface ImageTurnRuntimeDependencies {
  * A chat turn whose resolved model is an image generator is not a conversation
  * with that model - it is a request for a picture. This port answers exactly
  * that: the user's message becomes the prompt, the generated image becomes an
- * attachment on the assistant message AND a durable Artifact, and the ordinary
- * runtime event sequence (turn.started / assistant.message / turn.completed)
- * keeps every downstream projection - trace, SSE, completion jobs - unchanged.
+ * attachment on the assistant message AND a real world file under
+ * `files/图片/`, and the ordinary runtime event sequence (turn.started /
+ * assistant.message / turn.completed) keeps every downstream projection -
+ * trace, SSE, completion jobs - unchanged. The run-completion worker then
+ * registers that world file as the run's one durable Artifact, through the
+ * same authoritative path as every other AgentRun - this port never publishes
+ * an artifact itself, so one generation cannot produce two.
  *
  * The chat pipeline normally sends system prompt + tools + history; image
  * models reject that shape entirely (the usage log's context-window and
@@ -65,22 +67,13 @@ export function createImageAwareRuntime(deps: ImageTurnRuntimeDependencies): Age
         ...(typeof profile.settings.imageSize === 'string' ? { size: profile.settings.imageSize } : {}),
       })
       const fileName = `生成图片-${shortTime(new Date())}`
+      // The file service derives and appends the extension itself, so the name
+      // must stay bare - otherwise the visible file ends up with two of them
+      // (生成图片-....png-<id8>.png).
       const attachment = await deps.worldFiles.saveGeneratedImage(employee.worldId, {
         bytes: image.bytes,
         mimeType: image.mimeType,
-        name: `${fileName}.${image.mimeType === 'image/jpeg' ? 'jpg' : image.mimeType === 'image/webp' ? 'webp' : 'png'}`,
-      })
-      const publication = await deps.worldArtifacts.publishGeneratedImage({
-        workspaceId: employee.workspaceId,
-        worldId: employee.worldId,
-        bytes: image.bytes,
-        mimeType: image.mimeType,
-        title: fileName,
-        createdById: employee.id,
-        sessionId: request.conversationId,
-        ...(request.workTurnId === undefined ? {} : { workTurnId: request.workTurnId }),
-        ...(request.agentRunId === undefined ? {} : { agentRunId: request.agentRunId }),
-        ...(request.agentRunId === undefined ? {} : { idempotencyKey: `generated-image:${request.agentRunId}` }),
+        name: fileName,
       })
       const caption = '图片已经生成，点击可以放大查看；它也已存入本世界的产物。'
       const metadata: JsonObject = {
@@ -91,7 +84,6 @@ export function createImageAwareRuntime(deps: ImageTurnRuntimeDependencies): Age
           byteLength: attachment.byteLength,
           url: attachment.url,
         }],
-        artifactRefs: [{ artifactId: publication.artifact.id, title: publication.artifact.title, kind: 'image' }],
         imageModel: profile.modelId,
         generatedImage: true,
       }

--- a/packages/server/tests/image-turn-runtime.test.ts
+++ b/packages/server/tests/image-turn-runtime.test.ts
@@ -48,8 +48,7 @@ function deps(overrides: Record<string, unknown> = {}) {
     store: { getModelProfile: vi.fn((id: string) => (id === IMAGE_PROFILE.id ? IMAGE_PROFILE : id === CHAT_PROFILE.id ? CHAT_PROFILE : undefined)), resolveModelProfile: vi.fn(() => IMAGE_PROFILE) },
     credentials: { resolve: vi.fn(() => 'sk-key') },
     images: { generate: vi.fn(async () => ({ bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 1]), mimeType: 'image/png' })) },
-    worldFiles: { saveGeneratedImage: vi.fn(async () => ({ assetId: 'asset-1', name: 'x.png', mimeType: 'image/png', byteLength: 13, url: '/api/worlds/world-1/assets/asset-1' })) },
-    worldArtifacts: { publishGeneratedImage: vi.fn(async () => ({ artifact: { id: 'art-1', title: '生成图片' }, version: {} })) },
+    worldFiles: { saveGeneratedImage: vi.fn(async () => ({ assetId: 'asset-1', name: 'x.png', mimeType: 'image/png', byteLength: 13, url: '/api/worlds/world-1/file?path=x.png' })) },
     interactions: { recordTurn: vi.fn() },
     ...overrides,
   }
@@ -65,24 +64,34 @@ describe('image-aware runtime', () => {
     const result = await runtime.runTurn({ ...request, modelProfileId: CHAT_PROFILE.id })
     expect(result.finalResponse).toBe('chat')
     expect(inner.runTurn).toHaveBeenCalledOnce()
-    expect((d.worldArtifacts.publishGeneratedImage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0)
+    expect(d.worldFiles.saveGeneratedImage).not.toHaveBeenCalled()
   })
 
-  it('runs an image model as a picture: same event channel, attachment and artifact', async () => {
+  it('runs an image model as a picture: same event channel, a visible world file - and no runtime artifact of its own', async () => {
     const { d, events } = deps()
     const runtime = createImageAwareRuntime(d as never)
     const result = await runtime.runTurn(makeRequest(events))
     expect(events.map((event) => event.kind)).toEqual(['turn.started', 'assistant.message', 'turn.completed'])
     const message = events[1]!
     expect(message.content).toContain('图片已经生成')
-    const metadata = message.metadata as { attachments: Array<Record<string, unknown>>; artifactRefs: Array<Record<string, unknown>>; generatedImage?: boolean }
-    expect(metadata.attachments[0]).toMatchObject({ assetId: 'asset-1', url: '/api/worlds/world-1/assets/asset-1', mimeType: 'image/png' })
-    expect(metadata.artifactRefs[0]).toMatchObject({ artifactId: 'art-1', kind: 'image' })
+    const metadata = message.metadata as { attachments: Array<Record<string, unknown>>; artifactRefs?: Array<Record<string, unknown>>; imageModel?: string; generatedImage?: boolean }
+    expect(metadata.attachments[0]).toMatchObject({ assetId: 'asset-1', url: '/api/worlds/world-1/file?path=x.png', mimeType: 'image/png' })
     expect(metadata.generatedImage).toBe(true)
+    expect(metadata.imageModel).toBe('wan2.7-image')
     expect(result.finalResponse).toBe(message.content)
     expect(d.interactions.recordTurn).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', modelId: 'wan2.7-image', agentRunId: 'run-1' }))
-    // 产物幂等键绑定 agentRun：重放同一轮不会存出两张
-    expect(d.worldArtifacts.publishGeneratedImage).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: 'generated-image:run-1' }))
+    // One generation must produce exactly one durable artifact, and it is the
+    // run-completion worker - not this runtime - who registers the world file
+    // it just wrote. The runtime publishes nothing: no artifactRefs on the
+    // message, no extra bytes in a cache copy, so the worker's later
+    // publication cannot double with a manual one.
+    expect(metadata.artifactRefs).toBeUndefined()
+    const saveArgs = (d.worldFiles.saveGeneratedImage as ReturnType<typeof vi.fn>).mock.calls[0]![1] as { bytes: Buffer; mimeType: string; name: string }
+    expect(saveArgs.bytes.byteLength).toBeGreaterThan(0)
+    // The file service appends the extension itself; a name that already
+    // carries one would produce the visible 生成图片-...png-<id8>.png.
+    expect(saveArgs.name).not.toMatch(/\.(png|jpe?g|webp)$/u)
+    expect(saveArgs.name.startsWith('生成图片-')).toBe(true)
   })
 
   it('takes the image path when the model comes from the assignment chain alone', async () => {
@@ -92,6 +101,7 @@ describe('image-aware runtime', () => {
     expect(events.map((event) => event.kind)).toEqual(['turn.started', 'assistant.message', 'turn.completed'])
     expect(d.inner.runTurn).not.toHaveBeenCalled()
     expect(result.finalResponse).toContain('图片已经生成')
+    expect(d.worldFiles.saveGeneratedImage).toHaveBeenCalledOnce()
   })
 
   it('fails the turn through turn.failed and records the attempt when the endpoint errors', async () => {


### PR DESCRIPTION
## 问题

一次图像生成会产生**两张字节完全相同的产物**，且可见文件名出现双扩展名（如 `生成图片-0907-1235-06ed.png-053e6907.png`）：

- 同一回合里 runtime 手动调用 `WorldArtifactService.publishGeneratedImage` 发布一次（把字节先写进隐藏的 `cache/generated-images/<uuid>.png` 再登记为产物）；
- 回合结束后 orchestrator 的 run-completion worker 又通过 `publishAgentRun` 把 run 期间真实写入的 `files/图片/…` 世界文件登记为第二个产物；
- 两条登记路径的幂等键互不相同（`generated-image:<run>` vs `agent-run:v1:<run>:图片/<file>`），去重不了彼此。

实测（本机、gpt-image-2、同一 run）：两个产物 sha256 相同，一个来源 `cache/generated-images/…`，一个来源 `图片/…png-<id8>.png`。`files/图片/` 下存的是双扩展文件名，因为 runtime 传给 `saveGeneratedImage` 的 name 已带扩展名，而文件服务自身又会追加一次扩展名。

## 改动

- **runtime 不再发布产物**：`image-turn-runtime` 只把生成图作为真实世界文件写入 `files/图片/` 并作为聊天附件返回；`WorldArtifactService` 从 `ImageTurnRuntimeDependencies` 移除，`server.ts` 组装同步去掉该参数。
- **单一权威登记路径**：durable Artifact 统一由 run-completion worker（`publishAgentRun`，与每个 AgentRun 相同的权威路径）把 run 写入的世界文件登记为唯一产物——一张图恰好一个产物，不再有隐藏 cache 副本。
- **文件名单扩展名**：runtime 传裸文件名（`生成图片-…`），扩展名由 `saveGeneratedImage` 统一推导追加；聊天附件、`files/图片/` 文件与产物名称一致，不再出现 `…png-<id8>.png`。
- 消息元数据不再带运行期 `artifactRefs`（产物登记交由 worker 后由 completion 贡献补齐），`WorldArtifactService.publishGeneratedImage` 方法保留给需要显式独立副本的调用方。

## 验证

- `image-turn-runtime.test.ts` 更新：图像回合断言不产出 `artifactRefs`、`saveGeneratedImage` 收到的是不带扩展名的裸 name、无任何运行期发布；
- `packages/server` 全量测试：903 passed / 0 failed / 1 skipped；
- 实机验证（本地 gpt-image-2，一个生成请求）：合并前同一请求产生两个同 sha 产物；本分支下只产生 **1 个产物** `生成图片-….png`（单扩展名，来源即 `files/图片/` 下的可见文件）。
