### PR TITLE
merge-image-artifact-dedup

### DIFF
--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -318,7 +318,7 @@ async function createLeasedCyberServer(options: CyberServerOptions, onStoreOpene
   const loggingRuntime = new TurnInteractionLoggingRuntime({ inner: contextRuntime, service: interactions, resolveRoute(request) { return resolveHarnessRoute(store, request) } })
   // Image-model turns branch before the whole chat stack: the prompt goes to
   // the images endpoint and never becomes a conversational request.
-  const runtime = createImageAwareRuntime({ inner: loggingRuntime, store, credentials, images: new ImageGenerationService(), worldFiles, worldArtifacts, interactions })
+  const runtime = createImageAwareRuntime({ inner: loggingRuntime, store, credentials, images: new ImageGenerationService(), worldFiles, interactions })
   const completionWorker = composeCompletionWorker(store, worldArtifacts)
   const groupTurnPlanner = composeGroupTurnPlanner(store, credentials, options.groupTurnPlanner)
   const orchestrator = new ConversationOrchestrator({

--- a/packages/server/src/services/image-turn-runtime.ts
+++ b/packages/server/src/services/image-turn-runtime.ts
@@ -8,7 +8,6 @@ import { isImageGenerationModel } from './image-generation-service.js'
 import type { ModelCredentialService } from './model-credential-service.js'
 import type { ModelInteractionService } from './model-interaction-service.js'
 import { ServiceError } from './service-error.js'
-import type { WorldArtifactService } from './world-artifact-service.js'
 import type { WorldFileService } from './world-file-service.js'
 
 export interface ImageTurnRuntimeDependencies {
@@ -17,7 +16,6 @@ export interface ImageTurnRuntimeDependencies {
   credentials: ModelCredentialService
   images: ImageGenerationService
   worldFiles: WorldFileService
-  worldArtifacts: WorldArtifactService
   interactions: ModelInteractionService
 }
 
@@ -25,9 +23,13 @@ export interface ImageTurnRuntimeDependencies {
  * A chat turn whose resolved model is an image generator is not a conversation
  * with that model - it is a request for a picture. This port answers exactly
  * that: the user's message becomes the prompt, the generated image becomes an
- * attachment on the assistant message AND a durable Artifact, and the ordinary
- * runtime event sequence (turn.started / assistant.message / turn.completed)
- * keeps every downstream projection - trace, SSE, completion jobs - unchanged.
+ * attachment on the assistant message AND a real world file under
+ * `files/图片/`, and the ordinary runtime event sequence (turn.started /
+ * assistant.message / turn.completed) keeps every downstream projection -
+ * trace, SSE, completion jobs - unchanged. The run-completion worker then
+ * registers that world file as the run's one durable Artifact, through the
+ * same authoritative path as every other AgentRun - this port never publishes
+ * an artifact itself, so one generation cannot produce two.
  *
  * The chat pipeline normally sends system prompt + tools + history; image
  * models reject that shape entirely (the usage log's context-window and
@@ -65,22 +67,13 @@ export function createImageAwareRuntime(deps: ImageTurnRuntimeDependencies): Age
         ...(typeof profile.settings.imageSize === 'string' ? { size: profile.settings.imageSize } : {}),
       })
       const fileName = `生成图片-${shortTime(new Date())}`
+      // The file service derives and appends the extension itself, so the name
+      // must stay bare - otherwise the visible file ends up with two of them
+      // (生成图片-....png-<id8>.png).
       const attachment = await deps.worldFiles.saveGeneratedImage(employee.worldId, {
         bytes: image.bytes,
         mimeType: image.mimeType,
-        name: `${fileName}.${image.mimeType === 'image/jpeg' ? 'jpg' : image.mimeType === 'image/webp' ? 'webp' : 'png'}`,
-      })
-      const publication = await deps.worldArtifacts.publishGeneratedImage({
-        workspaceId: employee.workspaceId,
-        worldId: employee.worldId,
-        bytes: image.bytes,
-        mimeType: image.mimeType,
-        title: fileName,
-        createdById: employee.id,
-        sessionId: request.conversationId,
-        ...(request.workTurnId === undefined ? {} : { workTurnId: request.workTurnId }),
-        ...(request.agentRunId === undefined ? {} : { agentRunId: request.agentRunId }),
-        ...(request.agentRunId === undefined ? {} : { idempotencyKey: `generated-image:${request.agentRunId}` }),
+        name: fileName,
       })
       const caption = '图片已经生成，点击可以放大查看；它也已存入本世界的产物。'
       const metadata: JsonObject = {
@@ -91,7 +84,6 @@ export function createImageAwareRuntime(deps: ImageTurnRuntimeDependencies): Age
           byteLength: attachment.byteLength,
           url: attachment.url,
         }],
-        artifactRefs: [{ artifactId: publication.artifact.id, title: publication.artifact.title, kind: 'image' }],
         imageModel: profile.modelId,
         generatedImage: true,
       }

--- a/packages/server/tests/image-turn-runtime.test.ts
+++ b/packages/server/tests/image-turn-runtime.test.ts
@@ -48,8 +48,7 @@ function deps(overrides: Record<string, unknown> = {}) {
     store: { getModelProfile: vi.fn((id: string) => (id === IMAGE_PROFILE.id ? IMAGE_PROFILE : id === CHAT_PROFILE.id ? CHAT_PROFILE : undefined)), resolveModelProfile: vi.fn(() => IMAGE_PROFILE) },
     credentials: { resolve: vi.fn(() => 'sk-key') },
     images: { generate: vi.fn(async () => ({ bytes: Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 1]), mimeType: 'image/png' })) },
-    worldFiles: { saveGeneratedImage: vi.fn(async () => ({ assetId: 'asset-1', name: 'x.png', mimeType: 'image/png', byteLength: 13, url: '/api/worlds/world-1/assets/asset-1' })) },
-    worldArtifacts: { publishGeneratedImage: vi.fn(async () => ({ artifact: { id: 'art-1', title: '生成图片' }, version: {} })) },
+    worldFiles: { saveGeneratedImage: vi.fn(async () => ({ assetId: 'asset-1', name: 'x.png', mimeType: 'image/png', byteLength: 13, url: '/api/worlds/world-1/file?path=x.png' })) },
     interactions: { recordTurn: vi.fn() },
     ...overrides,
   }
@@ -65,24 +64,34 @@ describe('image-aware runtime', () => {
     const result = await runtime.runTurn({ ...request, modelProfileId: CHAT_PROFILE.id })
     expect(result.finalResponse).toBe('chat')
     expect(inner.runTurn).toHaveBeenCalledOnce()
-    expect((d.worldArtifacts.publishGeneratedImage as ReturnType<typeof vi.fn>).mock.calls).toHaveLength(0)
+    expect(d.worldFiles.saveGeneratedImage).not.toHaveBeenCalled()
   })
 
-  it('runs an image model as a picture: same event channel, attachment and artifact', async () => {
+  it('runs an image model as a picture: same event channel, a visible world file - and no runtime artifact of its own', async () => {
     const { d, events } = deps()
     const runtime = createImageAwareRuntime(d as never)
     const result = await runtime.runTurn(makeRequest(events))
     expect(events.map((event) => event.kind)).toEqual(['turn.started', 'assistant.message', 'turn.completed'])
     const message = events[1]!
     expect(message.content).toContain('图片已经生成')
-    const metadata = message.metadata as { attachments: Array<Record<string, unknown>>; artifactRefs: Array<Record<string, unknown>>; generatedImage?: boolean }
-    expect(metadata.attachments[0]).toMatchObject({ assetId: 'asset-1', url: '/api/worlds/world-1/assets/asset-1', mimeType: 'image/png' })
-    expect(metadata.artifactRefs[0]).toMatchObject({ artifactId: 'art-1', kind: 'image' })
+    const metadata = message.metadata as { attachments: Array<Record<string, unknown>>; artifactRefs?: Array<Record<string, unknown>>; imageModel?: string; generatedImage?: boolean }
+    expect(metadata.attachments[0]).toMatchObject({ assetId: 'asset-1', url: '/api/worlds/world-1/file?path=x.png', mimeType: 'image/png' })
     expect(metadata.generatedImage).toBe(true)
+    expect(metadata.imageModel).toBe('wan2.7-image')
     expect(result.finalResponse).toBe(message.content)
     expect(d.interactions.recordTurn).toHaveBeenCalledWith(expect.objectContaining({ status: 'success', modelId: 'wan2.7-image', agentRunId: 'run-1' }))
-    // 产物幂等键绑定 agentRun：重放同一轮不会存出两张
-    expect(d.worldArtifacts.publishGeneratedImage).toHaveBeenCalledWith(expect.objectContaining({ idempotencyKey: 'generated-image:run-1' }))
+    // One generation must produce exactly one durable artifact, and it is the
+    // run-completion worker - not this runtime - who registers the world file
+    // it just wrote. The runtime publishes nothing: no artifactRefs on the
+    // message, no extra bytes in a cache copy, so the worker's later
+    // publication cannot double with a manual one.
+    expect(metadata.artifactRefs).toBeUndefined()
+    const saveArgs = (d.worldFiles.saveGeneratedImage as ReturnType<typeof vi.fn>).mock.calls[0]![1] as { bytes: Buffer; mimeType: string; name: string }
+    expect(saveArgs.bytes.byteLength).toBeGreaterThan(0)
+    // The file service appends the extension itself; a name that already
+    // carries one would produce the visible 生成图片-...png-<id8>.png.
+    expect(saveArgs.name).not.toMatch(/\.(png|jpe?g|webp)$/u)
+    expect(saveArgs.name.startsWith('生成图片-')).toBe(true)
   })
 
   it('takes the image path when the model comes from the assignment chain alone', async () => {
@@ -92,6 +101,7 @@ describe('image-aware runtime', () => {
     expect(events.map((event) => event.kind)).toEqual(['turn.started', 'assistant.message', 'turn.completed'])
     expect(d.inner.runTurn).not.toHaveBeenCalled()
     expect(result.finalResponse).toContain('图片已经生成')
+    expect(d.worldFiles.saveGeneratedImage).toHaveBeenCalledOnce()
   })
 
   it('fails the turn through turn.failed and records the attempt when the endpoint errors', async () => {


### PR DESCRIPTION
## 变更

线性整合远程 #187 的实际提交：

- 图像回合只写入可见世界文件，不在 runtime 期间重复发布隐藏产物。
- durable Artifact 统一由 run-completion worker 登记，单次生成图只产生一个 Artifact。
- 传入文件服务的名称保持裸文件名，避免重复扩展名。
- 更新图像回合测试，覆盖不重复登记与单扩展名行为。

这是 #187 的无冲突替代合并 PR，原分支因主分支保护策略无法直接合并。

## 验证

- 原 #187 required CI `34089448108` 已通过。
- 本分支基于最新 `origin/main` `24fd3baa6a1d758ea349742bb2f299b38bea030f`。
