### PR TITLE
fix(model-hub): stats sidebar lists configured providers and legacy rows attribute correctly

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,7 @@
 import type { WorldCharacterAuthority } from './world-authority.js'
 import type { UiLocale } from './locales.js'
 
-export const CYBER_SCHEMA_VERSION = 49 as const
+export const CYBER_SCHEMA_VERSION = 50 as const
 
 export * from './runtime-access.js'
 export * from './locales.js'

--- a/packages/contracts/tests/world-knowledge.test.ts
+++ b/packages/contracts/tests/world-knowledge.test.ts
@@ -52,7 +52,7 @@ describe('World knowledge contracts', () => {
       document: { workspaceId: 'workspace-1', chunkCount: 0 },
       chunk: { worldId: 'world-1', documentId: 'document-1' },
     })
-    expect(CYBER_SCHEMA_VERSION).toBe(49)
+    expect(CYBER_SCHEMA_VERSION).toBe(50)
   })
 
   it('exports a source version whose completion watermark counts chunks, not sources', () => {

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -2365,6 +2365,56 @@ const MIGRATIONS: readonly Migration[] = [
         ON model_interaction_logs(workspace_id, provider_id, created_at);
     `,
   },
+  {
+    version: 50,
+    name: 'model-interaction-backfill-employee-attribution',
+    sql: `
+      -- v49 added provider_id but did not backfill. Turns recorded before that
+      -- change carry only the model nickname in ` + '`provider`' + ` and NULL
+      -- provider_id, so they disappear from the per-provider stats view even
+      -- though the employee was routed through a known provider connection at
+      -- the time. Recover attribution deterministically: a legacy row whose
+      -- employee was assigned (model_assignments scope='employee') a profile
+      -- exposing the same model_id, with that assignment effective before the
+      -- row was written, belongs to that profile's provider. Rows without an
+      -- employee, or whose employee has no matching assignment, stay legacy.
+      UPDATE model_interaction_logs
+      SET provider_id = (
+            SELECT p.id FROM model_assignments a
+              JOIN model_profiles mp ON mp.id = a.model_profile_id
+              JOIN model_providers p ON p.id = mp.provider_id
+            WHERE a.workspace_id = model_interaction_logs.workspace_id
+              AND a.scope = 'employee'
+              AND a.scope_id = model_interaction_logs.employee_id
+              AND mp.model_id = model_interaction_logs.model_id
+              AND a.updated_at <= model_interaction_logs.created_at
+            LIMIT 1
+          ),
+          provider_name = (
+            SELECT p.name FROM model_assignments a
+              JOIN model_profiles mp ON mp.id = a.model_profile_id
+              JOIN model_providers p ON p.id = mp.provider_id
+            WHERE a.workspace_id = model_interaction_logs.workspace_id
+              AND a.scope = 'employee'
+              AND a.scope_id = model_interaction_logs.employee_id
+              AND mp.model_id = model_interaction_logs.model_id
+              AND a.updated_at <= model_interaction_logs.created_at
+            LIMIT 1
+          )
+      WHERE provider_id IS NULL
+        AND employee_id IS NOT NULL
+        AND EXISTS (
+          SELECT 1 FROM model_assignments a
+            JOIN model_profiles mp ON mp.id = a.model_profile_id
+            JOIN model_providers p ON p.id = mp.provider_id
+          WHERE a.workspace_id = model_interaction_logs.workspace_id
+            AND a.scope = 'employee'
+            AND a.scope_id = model_interaction_logs.employee_id
+            AND mp.model_id = model_interaction_logs.model_id
+            AND a.updated_at <= model_interaction_logs.created_at
+        );
+    `,
+  },
 ]
 
 /**

--- a/packages/persistence/src/model-stats-repository.ts
+++ b/packages/persistence/src/model-stats-repository.ts
@@ -22,8 +22,18 @@ export class ModelStatsRepository {
     let where = base
     if (params.groupBy === 'provider') {
       const key = params.providerId!
-      if (key.startsWith('provider:')) { where += ' AND provider_id = ?'; values.push(key.slice(9)) }
-      else { where += ' AND provider_id IS NULL AND provider = ?'; values.push(key.startsWith('legacy:') ? key.slice(7) : key) }
+      if (key.startsWith('provider:')) {
+        // Rows recorded after migration 49 carry provider_id; earlier rows only
+        // kept the provider display name. A configured provider therefore owns
+        // its attributed rows AND the legacy rows logged under that name.
+        const providerId = key.slice(9)
+        const provider = this.db.prepare('SELECT name FROM model_providers WHERE workspace_id = ? AND id = ?').get(workspaceId, providerId) as { name: string } | undefined
+        where += provider
+          ? ' AND (provider_id = ? OR (provider_id IS NULL AND provider = ?))'
+          : ' AND provider_id = ?'
+        values.push(providerId)
+        if (provider) values.push(provider.name)
+      } else { where += ' AND provider_id IS NULL AND provider = ?'; values.push(key.startsWith('legacy:') ? key.slice(7) : key) }
     }
     const total = this.db.prepare(`SELECT ${METRICS} FROM model_interaction_logs WHERE ${where}`).get(...values) as Aggregate
     const group = params.groupBy === 'all' ? 'employee_id, world_id' : 'model_id'

--- a/packages/persistence/tests/model-stats-migration.test.ts
+++ b/packages/persistence/tests/model-stats-migration.test.ts
@@ -18,7 +18,7 @@ it('migrates v48 logs without inventing provider IDs/cache and restores new fiel
       ALTER TABLE model_interaction_logs DROP COLUMN provider_id;
       ALTER TABLE model_interaction_logs DROP COLUMN provider_name;
       ALTER TABLE model_interaction_logs DROP COLUMN tokens_cached;
-      DELETE FROM schema_migrations WHERE version = 49; PRAGMA user_version = 48;`)
+      DELETE FROM schema_migrations WHERE version IN (49, 50); PRAGMA user_version = 48;`)
     legacy.close()
     store = await SqliteStore.open(file)
     expect(store.doctor().ok).toBe(true)

--- a/packages/web/src/features/model-hub/ModelStatsPanel.tsx
+++ b/packages/web/src/features/model-hub/ModelStatsPanel.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 import { ArrowsClockwise } from '@phosphor-icons/react'
-import type { ModelStatsItem, ModelStatsProvider, ModelStatsResponse } from '@dsh-cyber/contracts'
+import type { ModelStatsItem, ModelStatsResponse } from '@dsh-cyber/contracts'
 import { useI18n } from '../../i18n/runtime.js'
 import { formatDuration, formatNumber } from '../../i18n/format.js'
 import { fetchModelStats, type HubProvider } from './api.js'
@@ -14,7 +14,6 @@ export function ModelStatsPanel({ workspaceId, providers }: { workspaceId: strin
   const [providerId, setProviderId] = useState<string>()
   const [refresh, setRefresh] = useState(0)
   const [resource, setResource] = useState<Resource>()
-  const [menu, setMenu] = useState<{ workspaceId: string; items: ModelStatsProvider[] }>()
   const key = JSON.stringify([workspaceId, range, providerId, refresh])
   const failureMessage = t('modelHub.statsLoadFailed', '模型统计数据加载失败。')
 
@@ -32,9 +31,7 @@ export function ModelStatsPanel({ workspaceId, providers }: { workspaceId: strin
       ...(providerId === undefined ? {} : { providerId }),
       from: from.toISOString(), to: to.toISOString(),
     }, controller.signal).then((data) => {
-      if (!current) return
-      setResource({ key, status: 'ready', data })
-      setMenu({ workspaceId, items: data.providers ?? [] })
+      if (current) setResource({ key, status: 'ready', data })
     }).catch((error: unknown) => {
       if (current) setResource({ key, status: 'error', error: error instanceof Error ? error.message : failureMessage })
     })
@@ -44,11 +41,11 @@ export function ModelStatsPanel({ workspaceId, providers }: { workspaceId: strin
   const active = resource?.key === key ? resource : undefined
   const busy = active === undefined || active.status === 'loading'
   const data = active?.status === 'ready' ? active.data : undefined
-  const choices = new Map<string, ModelStatsProvider>()
-  for (const provider of providers) if (provider.workspaceId === workspaceId) choices.set(`provider:${provider.id}`, { id: `provider:${provider.id}`, name: provider.name, legacy: false })
-  if (menu?.workspaceId === workspaceId) for (const item of menu.items) choices.set(item.id, item)
-  const names = new Map<string, number>()
-  for (const item of choices.values()) names.set(item.name, (names.get(item.name) ?? 0) + 1)
+  // Sidebar shows every provider actually added in this workspace — nothing
+  // derived from log-only names or removed providers.
+  const choices = providers
+    .filter((provider) => provider.workspaceId === workspaceId)
+    .map((provider) => ({ id: `provider:${provider.id}`, name: provider.name }))
   const summary = data?.summary
   return <div className="model-hub__body model-hub__stats">
     <div className="model-hub__toolbar">
@@ -61,8 +58,8 @@ export function ModelStatsPanel({ workspaceId, providers }: { workspaceId: strin
     <div className="model-hub__stats-layout">
       <aside className="model-hub__stats-sidebar" aria-label={t('modelHub.statsProviderFilter', '统计服务商')}>
         <button type="button" aria-pressed={providerId === undefined} className={providerId === undefined ? 'is-active' : ''} onClick={() => setProviderId(undefined)}>{t('modelHub.statsGroupAll', '全部')}</button>
-        {[...choices.values()].map((item) => <button key={item.id} type="button" aria-pressed={providerId === item.id} className={providerId === item.id ? 'is-active' : ''} title={item.id} onClick={() => setProviderId(item.id)}>
-          <span>{item.name}{(names.get(item.name) ?? 0) > 1 ? ` · ${item.id.slice(-8)}` : ''}{item.legacy ? <small>{t('modelHub.statsLegacy', '历史来源（未归属）')}</small> : null}</span>
+        {choices.map((item) => <button key={item.id} type="button" aria-pressed={providerId === item.id} className={providerId === item.id ? 'is-active' : ''} title={item.id} onClick={() => setProviderId(item.id)}>
+          <span>{item.name}</span>
         </button>)}
       </aside>
       <div className="model-hub__stats-main" aria-busy={busy}>


### PR DESCRIPTION
## 问题

1. 模型统计左侧栏混入了日志推导的服务商条目，用户期望只显示「全部 + 已添加的服务商」。
2. 点击服务商时右侧无数据：迁移 v49 给交互日志加了 provider_id 但从未回填，旧日志 provider_id 为 NULL，按 provider_id 过滤返回空。
3. 酒馆老板（月影酒馆）用 sandaoliu 的 deepseek-v4-flash 有 3 次成功交互，但按服务商统计看不到——旧日志只带模型昵称、没有连接归属。

## 改动

- `ModelStatsPanel.tsx`：左侧栏改为只渲染当前工作区已添加的服务商 + 「全部」，移除从响应 providers/legacy 合并的条目。
- `model-stats-repository.ts`：按服务商统计时，除 `provider_id = ?` 外还接受 `provider_id IS NULL AND provider = 服务商名` 的旧行（配置服务商拥有其归属行与以该名称记录的旧行）。
- 迁移 v50（`migrations.ts`，schema 50）：回填员工可归属的 legacy 日志——对 `provider_id IS NULL` 且有 employee 的行，若 `model_assignments`（scope=employee）分配的 profile 的 model_id 一致且分配时间早于日志写入，则写入该 profile 所属服务商的 provider_id/provider_name；无员工或匹配不上的行保持 legacy，不臆造归属。

## 验证

- sandaoliu 9 月统计现为 sensenova-6.8-flash-lite=11 + deepseek-v4-flash=3；酒馆老板角色行 4 次请求、世界「月影酒馆」。
- 单测/回归/迁移测试 20 个通过；E2E model-stats（1440x900/1920x1080/3840x2160/390x844 四视口、console 干净）通过；全量 tsc 通过。
