### PR TITLE
fix(files): preview generated images larger than 2 MiB

### DIFF
--- a/packages/server/src/services/workspace-file-service.ts
+++ b/packages/server/src/services/workspace-file-service.ts
@@ -3,7 +3,10 @@ import { extname, join, relative, resolve, sep } from 'node:path'
 
 import { ServiceError } from './service-error.js'
 
-const MAX_WORKSPACE_PREVIEW_BYTES = 2 * 1024 * 1024
+const MAX_WORKSPACE_TEXT_PREVIEW_BYTES = 2 * 1024 * 1024
+// Image payloads ride the same endpoint the chat transcript uses for generated
+// pictures: readAttachment-sized images (up to the generation cap) must render.
+const MAX_WORKSPACE_IMAGE_PREVIEW_BYTES = 40 * 1024 * 1024
 
 export interface WorkspaceFileListItem {
   name: string
@@ -78,11 +81,13 @@ export class WorkspaceFileService {
     const file = await this.#resolveEntry(requestedPath)
     const fileInfo = await stat(file.absolutePath)
     if (!fileInfo.isFile()) throw new ServiceError('invalid', 'workspace_file_required', 'Workspace path is not a file')
-    if (fileInfo.size > MAX_WORKSPACE_PREVIEW_BYTES) {
-      throw new ServiceError('too-large', 'workspace_file_too_large', 'Workspace preview is limited to 2 MiB')
-    }
     const preview = workspacePreviewKind(file.relativePath)
     if (preview === undefined) throw new ServiceError('unsupported', 'workspace_file_unsupported', 'File type cannot be previewed')
+    const cap = preview.kind === 'image' ? MAX_WORKSPACE_IMAGE_PREVIEW_BYTES : MAX_WORKSPACE_TEXT_PREVIEW_BYTES
+    if (fileInfo.size > cap) {
+      throw new ServiceError('too-large', 'workspace_file_too_large',
+        preview.kind === 'image' ? 'Workspace image preview is limited to 40 MiB' : 'Workspace preview is limited to 2 MiB')
+    }
     return { body: await readFile(file.absolutePath), contentType: preview.contentType }
   }
 

--- a/packages/server/tests/application-services.test.ts
+++ b/packages/server/tests/application-services.test.ts
@@ -119,7 +119,11 @@ describe('WorkspaceFileService', () => {
     // capped at 2 MiB (protecting the browser from huge text buffers).
     const bigImage = Buffer.alloc(3 * 1024 * 1024 + 1, 7)
     await writeFile(join(root, 'big.png'), bigImage)
-    await expect(files.preview('big.png')).resolves.toMatchObject({ body: bigImage, contentType: 'image/png' })
+    const imagePreview = await files.preview('big.png')
+    expect(imagePreview.contentType).toBe('image/png')
+    expect(imagePreview.body.byteLength).toBe(bigImage.byteLength)
+    expect(imagePreview.body[0]).toBe(7)
+    expect(imagePreview.body.at(-1)).toBe(7)
 
     const bigText = Buffer.alloc(2 * 1024 * 1024 + 1, 0x61)
     await writeFile(join(root, 'big.txt'), bigText)

--- a/packages/server/tests/application-services.test.ts
+++ b/packages/server/tests/application-services.test.ts
@@ -109,6 +109,25 @@ describe('WorkspaceFileService', () => {
     const listing = await files.list('')
     expect(listing.items.map((item) => item.name)).toEqual(['src'])
   })
+
+  it('previews generated-size images beyond 2 MiB while keeping the text cap', async () => {
+    const root = await temporaryRoot()
+    const files = new WorkspaceFileService(root)
+    // Generated images are written up to the image pipeline cap (40 MiB), but
+    // the chat transcript renders them through the workspace file preview
+    // endpoint. A >2 MiB picture must open even though text previews stay
+    // capped at 2 MiB (protecting the browser from huge text buffers).
+    const bigImage = Buffer.alloc(3 * 1024 * 1024 + 1, 7)
+    await writeFile(join(root, 'big.png'), bigImage)
+    await expect(files.preview('big.png')).resolves.toMatchObject({ body: bigImage, contentType: 'image/png' })
+
+    const bigText = Buffer.alloc(2 * 1024 * 1024 + 1, 0x61)
+    await writeFile(join(root, 'big.txt'), bigText)
+    await expect(files.preview('big.txt')).rejects.toMatchObject<ServiceError>({
+      kind: 'too-large',
+      code: 'workspace_file_too_large',
+    })
+  })
 })
 
 async function temporaryRoot(): Promise<string> {


### PR DESCRIPTION
## 问题

对话中 AI 生成的图片若超过 2 MiB，预览打不开：

```
{"error":{"code":"workspace_file_too_large","message":"Workspace preview is limited to 2 MiB",...}}
```

## 根因

- 生成图片 `saveGeneratedImage` 允许最大 **20 MiB**，保存到世界 `files/图片/` 目录（文件浏览器/备份可见，设计正确）。
- 但聊天转录里的 `<img src>` 指向 `/api/worlds/:id/file?path=` 预览端点（`workspace-file-service.ts`），该端点对所有文件**硬限 2 MiB**。
- 保存上限与预览上限不一致 → 2–20 MiB 的生成图无法在对话中打开。

## 修复

按类型区分预览上限（`packages/server/src/services/workspace-file-service.ts`）：

- **图片**：放宽到 40 MiB（对齐图像管线读取上限 `MAX_IMAGE_BODY_BYTES`，覆盖生成图 ≤20 MiB 保存上限）。
- **文本**：保持 2 MiB（防止超大文本缓冲进入浏览器，保留原有保护意图）。

## 验证

- 新增回归测试：>2 MiB PNG 预览成功、>2 MiB 文本仍被拒绝（`packages/server/tests/application-services.test.ts`）。
- 真实数据：2.47 MiB 生成图经 HTTP 预览返回 200 完整字节（此前报错）。
