### PR TITLE
fix(model-stats): migration 51 attributes legacy rows logged under the connection name

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,7 @@
 import type { WorldCharacterAuthority } from './world-authority.js'
 import type { UiLocale } from './locales.js'
 
-export const CYBER_SCHEMA_VERSION = 50 as const
+export const CYBER_SCHEMA_VERSION = 51 as const
 
 export * from './runtime-access.js'
 export * from './locales.js'

--- a/packages/contracts/tests/world-knowledge.test.ts
+++ b/packages/contracts/tests/world-knowledge.test.ts
@@ -52,7 +52,7 @@ describe('World knowledge contracts', () => {
       document: { workspaceId: 'workspace-1', chunkCount: 0 },
       chunk: { worldId: 'world-1', documentId: 'document-1' },
     })
-    expect(CYBER_SCHEMA_VERSION).toBe(50)
+    expect(CYBER_SCHEMA_VERSION).toBe(51)
   })
 
   it('exports a source version whose completion watermark counts chunks, not sources', () => {

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -2407,6 +2407,51 @@ const MIGRATIONS: readonly Migration[] = [
       WHERE provider_id IS NULL AND id IN (SELECT log_id FROM candidates);
     `,
   },
+  {
+    version: 51,
+    name: 'model-interaction-backfill-provider-name-attribution',
+    sql: `
+      -- v50 recovered employee-routed legacy rows whose provider column held a
+      -- model nickname. Earlier logs often stored the CONNECTION NAME itself
+      -- (e.g. provider='sandaoliu', provider_id NULL), which no employee-route
+      -- rule can reach - the employee may not even be linked to a profile yet,
+      -- or the row came from a discovery probe. Those rows are unambiguous:
+      -- attribute when the legacy provider label equals exactly one configured
+      -- provider in the workspace, that name is not reused as any profile's
+      -- display name (so a model nickname cannot masquerade as a connection),
+      -- the provider was created before the request, it owns a profile for the
+      -- logged model, and no OTHER provider shares that model id today.
+      WITH routed AS (
+        SELECT l.id, l.workspace_id, l.provider, l.model_id, l.created_at, l.duration_ms,
+          COALESCE(julianday(ar.started_at), julianday(wt.started_at),
+            julianday(l.created_at) - l.duration_ms / 86400000.0) AS routed_at
+        FROM model_interaction_logs l
+        LEFT JOIN agent_runs ar ON ar.id = l.agent_run_id AND ar.workspace_id = l.workspace_id
+        LEFT JOIN work_turns wt ON wt.id = l.work_turn_id AND wt.workspace_id = l.workspace_id
+        WHERE l.provider_id IS NULL
+      ), candidates AS (
+        SELECT r.id AS log_id, p.id AS provider_id, p.name AS provider_name
+        FROM routed r
+        JOIN model_providers p ON p.workspace_id = r.workspace_id AND p.name = r.provider
+        WHERE (SELECT COUNT(*) FROM model_providers p2
+               WHERE p2.workspace_id = r.workspace_id AND p2.name = p.name) = 1
+          AND NOT EXISTS (SELECT 1 FROM model_profiles np
+               WHERE np.workspace_id = r.workspace_id AND np.display_name = p.name)
+          AND EXISTS (SELECT 1 FROM model_profiles mp
+               WHERE mp.workspace_id = r.workspace_id AND mp.provider_id = p.id
+                 AND mp.model_id = r.model_id AND julianday(mp.created_at) <= r.routed_at)
+          AND julianday(p.created_at) <= r.routed_at
+          AND NOT EXISTS (SELECT 1 FROM model_profiles other
+               WHERE other.workspace_id = r.workspace_id AND other.model_id = r.model_id
+                 AND other.provider_id IS NOT NULL AND other.provider_id IS NOT p.id)
+      )
+      UPDATE model_interaction_logs
+      SET (provider_id, provider_name) = (
+        SELECT provider_id, provider_name FROM candidates WHERE log_id = model_interaction_logs.id
+      )
+      WHERE provider_id IS NULL AND id IN (SELECT log_id FROM candidates);
+    `,
+  },
 ]
 
 /**

--- a/packages/persistence/tests/model-provider-attribution.test.ts
+++ b/packages/persistence/tests/model-provider-attribution.test.ts
@@ -31,7 +31,7 @@ async function fixture() {
     async migrate() {
       await store.close()
       const db = new DatabaseSync(file)
-      db.exec('DELETE FROM schema_migrations WHERE version = 50; PRAGMA user_version = 49;')
+      db.exec('DELETE FROM schema_migrations WHERE version IN (50, 51); PRAGMA user_version = 49;')
       db.close()
       store = await SqliteStore.open(file, { clock: () => time })
     },
@@ -110,4 +110,36 @@ it('does not import a provider from another workspace through a legacy assignmen
   f.store.database.prepare('UPDATE model_assignments SET model_profile_id = ? WHERE workspace_id = ? AND scope_id = ?').run(profile.id, f.workspaceId, f.employee.id)
   f.time(loggedAt); const row = f.record('shared')
   await f.migrate(); expect(f.store.getModelInteraction(row.id)?.providerId).toBeUndefined()
+})
+
+it('v51 attributes legacy rows logged under the connection name itself', async () => {
+  const f = await fixture()
+  // provider 'conn' is the connection name; the row predates profile routing
+  // and stores provider='conn' (no employee profile assignment needed, even a
+  // discovery probe is attributable). v50's employee-route rule cannot reach
+  // it; v51's name-layer rule must.
+  f.provider('conn')
+  f.profile('pconn', 'conn', 'conn-display')
+  f.time(loggedAt)
+  const turn = f.record('conn', { noEmployee: true })
+  const probe = f.store.recordModelInteraction({ workspaceId: f.workspaceId, source: 'discovery', modelId: 'shared-model', provider: 'conn', status: 'success', durationMs: 40, promptMessageCount: 0, promptCharCount: 0 })
+  await f.migrate()
+  expect(f.store.getModelInteraction(turn.id)).toEqual({ ...turn, providerId: 'conn', providerName: 'conn' })
+  expect(f.store.getModelInteraction(probe.id)).toEqual({ ...probe, providerId: 'conn', providerName: 'conn' })
+  expect(f.store.aggregateModelStats(f.workspaceId, { groupBy: 'provider', providerId: 'provider:conn', ...range }).summary.totalRequests).toBe(2)
+  await f.reopen(); expect(f.store.doctor().ok).toBe(true)
+})
+
+it('v51 does not claim a legacy label that is any profile display name', async () => {
+  const f = await fixture()
+  // Another provider's profile reuses the exact name 'conn' as its nickname,
+  // so a legacy row carrying 'conn' might be that nickname, not this
+  // connection - leave it unclaimed rather than guess.
+  f.provider('conn')
+  f.provider('b'); f.profile('pb', 'b', 'conn')
+  f.time(loggedAt); const row = f.record('conn', { noEmployee: true })
+  await f.migrate()
+  expect(f.store.getModelInteraction(row.id)?.providerId).toBeUndefined()
+  expect(f.store.aggregateModelStats(f.workspaceId, { groupBy: 'provider', providerId: 'provider:conn', ...range }).summary.totalRequests).toBe(0)
+  expect(f.store.aggregateModelStats(f.workspaceId, { groupBy: 'provider', providerId: 'legacy:conn', ...range }).summary.totalRequests).toBe(1)
 })

--- a/packages/persistence/tests/model-stats-migration.test.ts
+++ b/packages/persistence/tests/model-stats-migration.test.ts
@@ -18,7 +18,7 @@ it('migrates v48 logs without inventing provider IDs/cache and restores new fiel
       ALTER TABLE model_interaction_logs DROP COLUMN provider_id;
       ALTER TABLE model_interaction_logs DROP COLUMN provider_name;
       ALTER TABLE model_interaction_logs DROP COLUMN tokens_cached;
-      DELETE FROM schema_migrations WHERE version IN (49, 50); PRAGMA user_version = 48;`)
+      DELETE FROM schema_migrations WHERE version IN (49, 50, 51); PRAGMA user_version = 48;`)
     legacy.close()
     store = await SqliteStore.open(file)
     expect(store.doctor().ok).toBe(true)


### PR DESCRIPTION
## 问题

主仓库 PR #196 合并后（maintainer 收紧了归属逻辑），**sandaoliu 服务商下原本显示的 2 个模型只剩 1 个**：只有 deepseek-v4-flash（3 次）出现，sensenova-6.8-flash-lite 的 44 次消失。

## 根因

- maintainer 移除了查询时按名字兜底的逻辑，只认 `provider_id`。
- 同时把迁移 v50 收紧为只处理「员工路由 + 模型昵称匹配」的行。
- 但大量更早的日志（profile 路由机制出现前）**把连接名本身存进 provider 列**（如 `provider='sandaoliu'`、`provider_id NULL`）——这类行不依赖任何员工分配，v50 的员工路由规则永远够不到 → 整个模型从统计里消失。

## 修复

新增**迁移 v51（名字层归属）**，把满足以下条件的 legacy 行回填到对应服务商：

1. legacy `provider` 标签等于工作区内**唯一一个**配置服务商的名字；
2. 该服务商名没有被任何模型 profile 用作 display_name（防止模型昵称冒充连接名）；
3. 服务商创建时间早于该请求；
4. 该服务商确实拥有一个匹配 `model_id` 的 profile；
5. 没有**其他**服务商今天也共享该 `model_id`（防共享模型误归属）。

只回填、不改统计查询层——归属后 `provider_id` 非空即正常显示。schema 版本 50 → 51。

## 验证

- 真实库迁移后：**sandaoliu = sensenova-6.8-flash-lite 44 + deepseek-v4-flash 3（共 47 次）**，两个模型都出现。
- 新增 2 个名字层回归测试（连接名归属 + 昵称撞名不误认）。
- 26 个归属/迁移/回归测试 + E2E 通过。
