### PR TITLE
feat(model-stats): abbreviate large token figures with K/M/B units

### DIFF
--- a/packages/web/src/features/model-hub/ModelStatsPanel.tsx
+++ b/packages/web/src/features/model-hub/ModelStatsPanel.tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import { ArrowsClockwise } from '@phosphor-icons/react'
 import type { ModelStatsItem, ModelStatsResponse } from '@dsh-cyber/contracts'
 import { useI18n } from '../../i18n/runtime.js'
-import { formatDuration, formatNumber } from '../../i18n/format.js'
+import { formatCompactNumber, formatDuration, formatNumber } from '../../i18n/format.js'
 import { fetchModelStats, type HubProvider } from './api.js'
 
 type Range = '7d' | '30d' | 'all'
@@ -73,14 +73,22 @@ export function ModelStatsPanel({ workspaceId, providers }: { workspaceId: strin
         {active?.status === 'error' ? <div className="model-hub__error" role="alert">{active.error}</div> : null}
         {summary && data ? <>
           <div className="model-hub__stats-overview">
-            {[
-              [t('modelHub.colTokensSent', '输入'), formatNumber(summary.totalTokensSent)],
-              [t('modelHub.colTokensReceived', '输出'), formatNumber(summary.totalTokensReceived)],
-              [t('modelHub.statsTotalCached', '缓存命中'), summary.tokensCached === undefined ? '—' : formatNumber(summary.tokensCached)],
-              [t('modelHub.statsInteractions', '交互次数'), formatNumber(summary.totalRequests)],
-              [t('modelHub.statsTotalToolCalls', '工具调用'), formatNumber(summary.totalToolCalls)],
-              [t('modelHub.statsSuccessRate', '成功率'), summary.totalRequests === 0 ? '—' : `${summary.successRate.toFixed(1)}%`],
-            ].map(([label, value]) => <div className="model-hub__stat-card" key={label}><strong>{value}</strong><span>{label}</span></div>)}
+            {(() => {
+              const cards: Array<{ key: string; label: string; display: string; exact?: string }> = []
+              const add = (key: string, label: string, display: string, exact?: string) => {
+                const card: { key: string; label: string; display: string; exact?: string } = { key, label, display }
+                if (exact !== undefined) card.exact = exact
+                cards.push(card)
+              }
+              add('sent', t('modelHub.colTokensSent', '输入'), formatCompactNumber(summary.totalTokensSent), formatNumber(summary.totalTokensSent))
+              add('received', t('modelHub.colTokensReceived', '输出'), formatCompactNumber(summary.totalTokensReceived), formatNumber(summary.totalTokensReceived))
+              if (summary.tokensCached !== undefined) add('cached', t('modelHub.statsTotalCached', '缓存命中'), formatCompactNumber(summary.tokensCached), formatNumber(summary.tokensCached))
+              else add('cached', t('modelHub.statsTotalCached', '缓存命中'), '—')
+              add('requests', t('modelHub.statsInteractions', '交互次数'), formatNumber(summary.totalRequests))
+              add('tools', t('modelHub.statsTotalToolCalls', '工具调用'), formatNumber(summary.totalToolCalls))
+              add('rate', t('modelHub.statsSuccessRate', '成功率'), summary.totalRequests === 0 ? '—' : `${summary.successRate.toFixed(1)}%`)
+              return cards.map((card) => <div className="model-hub__stat-card" key={card.key}><strong title={card.exact}>{card.display}</strong><span>{card.label}</span></div>)
+            })()}
           </div>
           {data.items.length === 0 ? <div className="model-hub__empty"><strong>{t('modelHub.statsEmpty', '尚无交互记录')}</strong><span>{t('modelHub.statsEmptyHint', '完成一次对话后这里会出现统计。')}</span></div>
             : <div className="model-hub__stats-table-scroll" tabIndex={0} role="region" aria-label={t('modelHub.statsDetails', '统计明细')}>
@@ -100,7 +108,9 @@ export function ModelStatsPanel({ workspaceId, providers }: { workspaceId: strin
 function StatsRow({ item, system }: { item: ModelStatsItem; system: boolean }) {
   const { t } = useI18n()
   return <tr><td><strong>{system ? t('modelHub.statsSystem', '系统') : item.name ?? item.id}</strong>{item.worldName ? <small>{item.worldName}</small> : null}</td>
-    <td>{formatNumber(item.tokensSent)}</td><td>{formatNumber(item.tokensReceived)}</td><td>{item.hasCacheData ? formatNumber(item.tokensCached ?? 0) : '—'}</td>
+    <td title={formatNumber(item.tokensSent)}>{formatCompactNumber(item.tokensSent)}</td>
+    <td title={formatNumber(item.tokensReceived)}>{formatCompactNumber(item.tokensReceived)}</td>
+    <td title={item.hasCacheData ? formatNumber(item.tokensCached ?? 0) : undefined}>{item.hasCacheData ? formatCompactNumber(item.tokensCached ?? 0) : '—'}</td>
     <td>{formatNumber(item.requests)}</td><td>{formatNumber(item.toolCalls)}</td><td>{item.requests === 0 ? '—' : `${(item.successCount / item.requests * 100).toFixed(1)}%`}</td><td>{item.avgLatencyMs === undefined ? '—' : formatDuration(item.avgLatencyMs)}</td>
   </tr>
 }

--- a/packages/web/src/i18n/format.ts
+++ b/packages/web/src/i18n/format.ts
@@ -4,6 +4,24 @@ export function formatNumber(value: number): string {
   return new Intl.NumberFormat(getUiLocale()).format(value)
 }
 
+/**
+ * Token-style magnitude abbreviation (e.g. 1.2M, 340K, 12.5B). Wide tables
+ * keep whole counts for readability elsewhere; token columns use this so a
+ * row stays narrow. Values below 1_000 keep their exact digits.
+ */
+export function formatCompactNumber(value: number): string {
+  const absolute = Math.abs(value)
+  if (absolute >= 1_000_000_000) return `${trimFraction(value / 1_000_000_000)}B`
+  if (absolute >= 1_000_000) return `${trimFraction(value / 1_000_000)}M`
+  if (absolute >= 1_000) return `${trimFraction(value / 1_000)}K`
+  return String(value)
+}
+
+function trimFraction(value: number): string {
+  const fixed = value.toFixed(1)
+  return fixed.endsWith('.0') ? fixed.slice(0, -2) : fixed
+}
+
 export function formatDateTime(value: string | number | Date, options: Intl.DateTimeFormatOptions = { dateStyle: 'medium', timeStyle: 'short' }): string {
   const date = new Date(value)
   return Number.isNaN(date.getTime()) ? String(value) : new Intl.DateTimeFormat(getUiLocale(), options).format(date)

--- a/packages/web/tests/model-stats-panel.test.tsx
+++ b/packages/web/tests/model-stats-panel.test.tsx
@@ -63,6 +63,16 @@ describe('model stats state-owned requests', () => {
     await act(async () => pending.reject(new Error('旧请求失败')))
     expect(node.querySelector('[role="alert"]')).toBeNull(); expect(inputValue()).toBe('10')
   })
+  it('abbreviates large token columns while keeping exact values in the title', async () => {
+    fetchStats.mockResolvedValueOnce(result(1_250_000))
+    await render()
+    const first = node.querySelector('.model-hub__stat-card strong')!
+    expect(first.textContent).toBe('1.3M')
+    expect(first.getAttribute('title')).toBe('1,250,000')
+    const cells = [...node.querySelectorAll('.model-hub__stats-table tbody tr td')]
+    expect(cells[1]?.textContent).toBe('1.3M')
+    expect(cells[1]?.getAttribute('title')).toBe('1,250,000')
+  })
 })
 
 it('lists only configured workspace providers, including providers with no logs', async () => {


### PR DESCRIPTION
## 问题

模型统计里「输入 / 输出」等 token 列数字过大后太长（如 `1,250,000`、`593,183`），把表格和顶部卡片撑得很宽。

## 改动

- `packages/web/src/i18n/format.ts`：新增 `formatCompactNumber` —— 1,000+ 缩写为 K、1,000,000+ 为 M、1,000,000,000+ 为 B，最多保留 1 位小数（`1.3M`、`340K`、`12.5B`），小于 1,000 保持原样。
- `ModelStatsPanel.tsx`：输入 / 输出 / 缓存命中 的顶部卡片与明细行改用紧凑格式；**精确值通过 hover title 保留**（`title="1,250,000"`）。交互次数、工具调用、成功率不变。

## 验证

- 新增单测：`1,250,000` 显示为 `1.3M` 且 title 保留 `1,250,000`。
- 12 个面板单测 + E2E（四视口、console 干净）通过。
