### PR TITLE
fix(trace): carry prompt-cache hits into world trace usage

### DIFF
--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -890,6 +890,7 @@ export function normalizeHarnessTraceNotification(
         metadata.tokensPrompt = usage.prompt
         metadata.tokensCompletion = usage.completion
         metadata.tokensTotal = usage.total
+        if (usage.cachedPrompt !== undefined) metadata.tokensCached = usage.cachedPrompt
       }
       return [
         make(reasonKind === 'completed' ? 'turn.completed' : 'turn.failed', {

--- a/packages/server/src/world-trace/agent-run-trace-adapter.ts
+++ b/packages/server/src/world-trace/agent-run-trace-adapter.ts
@@ -62,6 +62,7 @@ export class AgentRunTraceAdapter implements WorldTraceAdapter<'agent-run'> {
           prompt: interaction.tokensPrompt,
           completion: interaction.tokensCompletion,
           total: interaction.tokensTotal,
+          ...(interaction.tokensCached === undefined ? {} : { cachedPrompt: interaction.tokensCached }),
         }
       }
     }

--- a/packages/server/src/world-trace/runtime-event-trace-adapter.ts
+++ b/packages/server/src/world-trace/runtime-event-trace-adapter.ts
@@ -90,7 +90,9 @@ function tokenUsage(event: AgentRuntimeEvent) {
   const prompt = event.metadata.tokensPrompt
   const completion = event.metadata.tokensCompletion
   const total = event.metadata.tokensTotal
-  return typeof prompt === 'number' && typeof completion === 'number' && typeof total === 'number'
-    ? { prompt, completion, total }
-    : undefined
+  if (typeof prompt !== 'number' || typeof completion !== 'number' || typeof total !== 'number') return undefined
+  const cached = event.metadata.tokensCached
+  return typeof cached === 'number'
+    ? { prompt, completion, total, cachedPrompt: cached }
+    : { prompt, completion, total }
 }

--- a/packages/server/tests/world-trace-integration.test.ts
+++ b/packages/server/tests/world-trace-integration.test.ts
@@ -24,7 +24,7 @@ class TraceRuntime implements AgentRuntimePort {
     request.onEvent?.({ kind: 'tool.completed', source: 'trace-test', sourceSessionId, sourceSequence: 4, toolName: 'sk-1234567890123456', callId: 'call-1', failed: false, metadata: {} })
     request.onEvent?.({ kind: 'assistant.message', source: 'trace-test', sourceSessionId, sourceSequence: 5, content: '最终回答', metadata: {} })
     request.onEvent?.({ kind: 'turn.completed', source: 'trace-test', sourceSessionId, sourceSequence: 6, metadata: {} })
-    return { agentSessionId: sourceSessionId, finalResponse: '最终回答', eventCount: 6, tokenUsage: { prompt: 120, completion: 30, total: 150 } }
+    return { agentSessionId: sourceSessionId, finalResponse: '最终回答', eventCount: 6, tokenUsage: { prompt: 120, completion: 30, total: 150, cachedPrompt: 40 } }
   }
   async close(): Promise<void> {}
 }
@@ -76,7 +76,7 @@ describe('World Trace HTTP and live recovery', () => {
     expect(JSON.stringify(history)).not.toContain('sk-1234567890123456')
     const liveTurn = live.find((entry) => entry.sourceKind === 'agent-run' && entry.status === 'success')
     const durableTurn = history.items.find((entry) => entry.sourceKind === 'agent-run')
-    expect(durableTurn?.tokenUsage).toEqual({ prompt: 120, completion: 30, total: 150 })
+    expect(durableTurn?.tokenUsage).toEqual({ prompt: 120, completion: 30, total: 150, cachedPrompt: 40 })
     expect(durableTurn?.actorId).toBe(employee.id)
     // A chat run belongs to no task, and its card says so by carrying none.
     expect(durableTurn).not.toHaveProperty('taskId')

--- a/packages/web/src/components/world-trace/WorldTraceItem.tsx
+++ b/packages/web/src/components/world-trace/WorldTraceItem.tsx
@@ -65,7 +65,7 @@ export function WorldTraceItem({ entry, employees, open, onToggle, onOpenArtifac
           </>}
         {contextRunId === undefined || onOpenContext === undefined ? null : <button type="button" className="world-trace-context__open" aria-label={`查看运行 ${contextRunId} 的上下文`} onClick={() => onOpenContext(contextRunId)}>{entry.context === undefined ? '查看上下文记录' : '打开上下文检查器'}</button>}
       </section>}
-      {entry.modelId || entry.provider || entry.tokenUsage ? <section className="world-trace-usage"><strong>模型用量</strong><dl>{entry.provider ? <><dt>服务</dt><dd>{entry.provider}</dd></> : null}{entry.modelId ? <><dt>模型</dt><dd>{entry.modelId}</dd></> : null}{entry.tokenUsage ? <><dt>输入</dt><dd>{formatNumber(entry.tokenUsage.prompt)}</dd><dt>输出</dt><dd>{formatNumber(entry.tokenUsage.completion)}</dd><dt>合计</dt><dd>{formatNumber(entry.tokenUsage.total)} Token</dd></> : null}</dl></section> : null}
+      {entry.modelId || entry.provider || entry.tokenUsage ? <section className="world-trace-usage"><strong>模型用量</strong><dl>{entry.provider ? <><dt>服务</dt><dd>{entry.provider}</dd></> : null}{entry.modelId ? <><dt>模型</dt><dd>{entry.modelId}</dd></> : null}{entry.tokenUsage ? <><dt>输入</dt><dd>{formatNumber(entry.tokenUsage.prompt)}</dd><dt>输出</dt><dd>{formatNumber(entry.tokenUsage.completion)}</dd>{entry.tokenUsage.cachedPrompt === undefined ? null : <><dt>缓存命中</dt><dd>{formatNumber(entry.tokenUsage.cachedPrompt)}</dd></>}<dt>合计</dt><dd>{formatNumber(entry.tokenUsage.total)} Token</dd></> : null}</dl></section> : null}
     </div></details></article>}
   </li>
 }


### PR DESCRIPTION
## 问题

问：模型统计里的「缓存命中」在轨迹里是不是没获取到？答：**缓存命中读取链路是完整的，但轨迹投影把它丢了**——已从上游 usage 读到并存入交互日志，只是没投影到轨迹显示，所以轨迹的「模型用量」永远没有缓存命中。

具体两个断点：

1. `harness-adapter/src/adapter.ts` 的 `turn/end` 归一化只把 prompt/completion/total 复制进事件 metadata，`cachedPrompt` 在读出来后被丢弃，未进 metadata。
2. `world-trace` 两个 adapter（`runtime-event-trace-adapter.ts`、`agent-run-trace-adapter.ts`）都用这三个数字重建 `tokenUsage`，即使日志里已有 `tokens_cached` 也不带进轨迹条目；渲染组件也没有缓存命中一行。

另外：你看到的旧交互缓存命中为空，是因为那些日志（如 sandaoliu 的 deepseek/sensenova 行）都在缓存采集功能（schema v49）**上线前**由旧代码记录，本来就没采集——不是「取不到」，是「那时代码还没采集」。采集功能上线后的真实对话会有缓存数字。

## 改动

- `adapter.ts`：`turn/end` 事件把 `usage.cachedPrompt` 放进 `metadata.tokensCached`。
- `runtime-event-trace-adapter.ts` / `agent-run-trace-adapter.ts`：把缓存数字投影进 `tokenUsage.cachedPrompt`（来自事件 metadata 或交互日志 `tokensCached`）。
- `WorldTraceItem.tsx`：「模型用量」卡片在提供方上报了缓存命中时渲染「缓存命中」一行。
- `world-trace-integration.test.ts`：端到端断言带 `cachedPrompt` 的 run 在轨迹里保留该字段。

## 验证

- 142 个 adapter/轨迹/统计测试通过；`world-trace-integration` 现在验证 `{ prompt, completion, total, cachedPrompt }` 全链路保留。
