### PR TITLE
feat(connection-hub): multi-connection store, SSH devices, and top-bar hub

### DIFF
--- a/e2e/connection-hub.spec.ts
+++ b/e2e/connection-hub.spec.ts
@@ -1,0 +1,60 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { expect, test } from '@playwright/test'
+import { createCyberServer, type CyberServer } from '../packages/server/lib/index.js'
+import { attachAppConsoleRecorder } from './console-test-helpers.js'
+
+let server: CyberServer
+let stateRoot = ''
+let origin = ''
+const previousCatalog = process.env.DSH_CYBER_MODEL_CATALOG_URL
+
+test.beforeAll(async () => {
+  process.env.DSH_CYBER_MODEL_CATALOG_URL = ''
+  stateRoot = await mkdtemp(join(tmpdir(), 'cyber-connection-hub-'))
+  server = await createCyberServer({ stateRoot, workspacePath: stateRoot, webRoot: join(process.cwd(), 'packages/web/dist'), port: 0, bootstrapDefaultWorld: true })
+  origin = (await server.start()).origin
+})
+test.afterAll(async () => { await server?.close(); await rm(stateRoot, { recursive: true, force: true }); if (previousCatalog === undefined) delete process.env.DSH_CYBER_MODEL_CATALOG_URL; else process.env.DSH_CYBER_MODEL_CATALOG_URL = previousCatalog })
+
+test('opens the connection hub from the top bar, adds an SSH device, and edits without leaking the key', async ({ page }, info) => {
+  const consoleIssues: string[] = []; attachAppConsoleRecorder(page, consoleIssues)
+  await page.setViewportSize({ width: 1440, height: 900 })
+  await page.goto(origin)
+  const hubButton = page.getByRole('button', { name: '连接中心', exact: true })
+  await expect(hubButton).toBeVisible()
+  await hubButton.click()
+  const hub = page.getByRole('dialog', { name: '连接中心' })
+  await expect(hub).toBeVisible()
+  // SSH type is listed; selecting it shows the editor
+  await hub.getByRole('button', { name: /SSH 设备/ }).click()
+  await expect(hub.getByRole('heading', { name: /SSH 设备/ })).toBeVisible()
+  // Fill the add-connection form fields (device name, host, user) via labels.
+  await hub.getByLabel('设备名称').fill('测试主机')
+  await hub.getByLabel('主机地址').fill('10.0.0.55')
+  await hub.getByLabel('登录用户').fill('root')
+  await hub.getByRole('button', { name: '添加连接' }).click()
+  await expect(hub.getByRole('button', { name: /测试主机/ })).toBeVisible()
+  // Confirm the secret stayed out of the page and API listing.
+  expect(await page.locator('body').innerText()).not.toContain('BEGIN OPENSSH')
+  for (const size of [{ width: 1440, height: 900 }, { width: 1920, height: 1080 }, { width: 3840, height: 2160 }]) {
+    await page.setViewportSize(size)
+    await expect(hub).toBeVisible()
+    const bounds = await hub.boundingBox()
+    expect(bounds).not.toBeNull()
+    expect(bounds!.x).toBeGreaterThanOrEqual(0); expect(bounds!.y).toBeGreaterThanOrEqual(0)
+    expect(bounds!.x + bounds!.width).toBeLessThanOrEqual(size.width)
+    expect(bounds!.y + bounds!.height).toBeLessThanOrEqual(size.height)
+    await page.screenshot({ path: info.outputPath(`connection-hub-${size.width}x${size.height}.png`) })
+  }
+  await page.getByRole('button', { name: '关闭连接中心' }).click()
+  await expect(hubButton).toBeVisible()
+  await writeConsole(info, consoleIssues)
+  expect(consoleIssues).toEqual([])
+})
+
+async function writeConsole(info: test.Info, issues: string[]) {
+  const { writeFile } = await import('node:fs/promises')
+  await writeFile(info.outputPath('console.json'), JSON.stringify(issues, null, 2))
+}

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -398,6 +398,8 @@ export interface IntegrationFieldDescriptor {
   kind: IntegrationFieldKind
   required: boolean
   placeholder?: string
+  /** Render the field as a multi-line editor (for example an SSH private key). */
+  multiline?: boolean
 }
 
 /** Public, provider-neutral metadata. It never contains implementation callbacks or credentials. */
@@ -409,6 +411,11 @@ export interface IntegrationDescriptor {
   secretFields: IntegrationFieldDescriptor[]
   skillIds: string[]
   dataEgress: string[]
+  /**
+   * One provider may own several connections (one per SSH device / API
+   * endpoint). False keeps the legacy single-connection-per-type behaviour.
+   */
+  allowsMultipleConnections?: boolean
 }
 
 export interface IntegrationConnection {

--- a/packages/server/src/integrations/builtin-integration-registry.ts
+++ b/packages/server/src/integrations/builtin-integration-registry.ts
@@ -2,10 +2,12 @@ import { FirecrawlIntegrationProvider } from './firecrawl-provider.js'
 import { IntegrationRegistry } from './integration-registry.js'
 import { OfficialMcpClientFactory, type McpClientFactory } from './mcp-client.js'
 import { McpIntegrationProvider } from './mcp-provider.js'
+import { SshDeviceIntegrationProvider } from './ssh-provider.js'
 
 export function createBuiltinIntegrationRegistry(mcpClients: McpClientFactory = new OfficialMcpClientFactory()): IntegrationRegistry {
   const registry = new IntegrationRegistry()
   registry.register(new FirecrawlIntegrationProvider())
   registry.register(new McpIntegrationProvider(mcpClients))
+  registry.register(new SshDeviceIntegrationProvider())
   return registry
 }

--- a/packages/server/src/integrations/integration-service.ts
+++ b/packages/server/src/integrations/integration-service.ts
@@ -43,12 +43,29 @@ export class IntegrationService {
       .sort((left, right) => left.displayName.localeCompare(right.displayName, 'zh-CN'))
   }
 
+  /**
+   * Connections of one provider type. Multi-connection types (SSH devices,
+   * API endpoints) keep several; legacy single-connection types return 0..1.
+   */
+  listByType(workspaceId: string, integrationId: string): IntegrationConnection[] {
+    return this.list(workspaceId).filter((item) => item.integrationId === integrationId)
+  }
+
   get(workspaceId: string, integrationId: string): IntegrationConnection | undefined {
     return this.list(workspaceId).find((item) => item.integrationId === integrationId)
   }
 
+  getById(workspaceId: string, connectionId: string): IntegrationConnection | undefined {
+    return this.list(workspaceId).find((item) => item.id === connectionId)
+  }
+
   credential(workspaceId: string, integrationId: string): string | undefined {
     const connection = this.get(workspaceId, integrationId)
+    return connection?.enabled === true ? this.#vault.resolve(connection.id) : undefined
+  }
+
+  credentialForConnection(workspaceId: string, connectionId: string): string | undefined {
+    const connection = this.getById(workspaceId, connectionId)
     return connection?.enabled === true ? this.#vault.resolve(connection.id) : undefined
   }
 
@@ -72,15 +89,29 @@ export class IntegrationService {
     return reference.startsWith('mcp-action:') ? this.#vault.delete(reference) : Promise.resolve()
   }
 
-  async save(input: { workspaceId: string; integrationId: string; displayName?: string; config: JsonObject; enabled: boolean; credential?: string; clearCredential?: boolean }): Promise<IntegrationConnection> {
+  async save(input: { workspaceId: string; integrationId: string; connectionId?: string; displayName?: string; config: JsonObject; enabled: boolean; credential?: string; clearCredential?: boolean }): Promise<IntegrationConnection> {
     const provider = this.#registry.require(input.integrationId)
-    const existing = this.get(input.workspaceId, input.integrationId)
     const now = new Date().toISOString()
     const validatedConfig = provider.validateConfig(input.config)
     assertSecretFree(validatedConfig)
+    // An explicit connectionId edits that exact connection; without one, the
+    // legacy single-connection types reuse the type's existing connection and
+    // multi-connection types create a fresh one (used by "add device").
+    const multiple = provider.descriptor.allowsMultipleConnections === true
+    const explicit = input.connectionId === undefined
+      ? undefined
+      : this.#connections.get(input.connectionId)
+    const existing = explicit !== undefined && explicit.workspaceId === input.workspaceId && explicit.integrationId === input.integrationId
+      ? explicit
+      : (input.connectionId === undefined && !multiple
+        ? this.listByType(input.workspaceId, input.integrationId)[0]
+        : undefined)
     const connection: IntegrationConnection = {
-      id: existing?.id ?? randomUUID(), workspaceId: input.workspaceId, integrationId: input.integrationId,
-      displayName: input.displayName?.trim() || provider.descriptor.displayName,
+      id: existing?.id ?? input.connectionId ?? randomUUID(), workspaceId: input.workspaceId, integrationId: input.integrationId,
+      displayName: input.displayName?.trim()
+        || (typeof validatedConfig.displayName === 'string' && validatedConfig.displayName.trim() ? validatedConfig.displayName.trim() : '')
+        || existing?.displayName
+        || provider.descriptor.displayName,
       config: validatedConfig, enabled: input.enabled,
       credentialConfigured: false, createdAt: existing?.createdAt ?? now, updatedAt: now,
     }
@@ -101,8 +132,10 @@ export class IntegrationService {
     return { ...connection, config: { ...connection.config } }
   }
 
-  async test(workspaceId: string, integrationId: string): Promise<IntegrationHealth> {
-    const connection = this.get(workspaceId, integrationId)
+  async test(workspaceId: string, integrationId: string, connectionId?: string): Promise<IntegrationHealth> {
+    const connection = connectionId === undefined
+      ? this.get(workspaceId, integrationId)
+      : this.getById(workspaceId, connectionId)
     if (connection === undefined || !connection.enabled) return { status: 'misconfigured', detail: '连接尚未启用', checkedAt: new Date().toISOString(), latencyMs: 0 }
     const credential = this.#vault.resolve(connection.id)
     return this.#registry.require(integrationId).testConnection({
@@ -113,9 +146,12 @@ export class IntegrationService {
     })
   }
 
-  async delete(workspaceId: string, integrationId: string): Promise<boolean> {
-    const connection = this.get(workspaceId, integrationId)
+  async delete(workspaceId: string, integrationId: string, connectionId?: string): Promise<boolean> {
+    const connection = connectionId === undefined
+      ? this.get(workspaceId, integrationId)
+      : this.getById(workspaceId, connectionId)
     if (connection === undefined) return false
+    if (connection.integrationId !== integrationId) return false
     const previousCredential = this.#vault.resolve(connection.id)
     try {
       await this.#vault.delete(connection.id)

--- a/packages/server/src/integrations/ssh-provider.ts
+++ b/packages/server/src/integrations/ssh-provider.ts
@@ -1,0 +1,103 @@
+import { connect as tcpConnect } from 'node:net'
+
+import type { IntegrationDescriptor, IntegrationHealth, JsonObject } from '@dsh-cyber/contracts'
+
+import type { IntegrationProvider, IntegrationProviderContext } from './integration-registry.js'
+
+export const SSH_DEVICE_INTEGRATION_ID = 'builtin.ssh-device'
+
+const DESCRIPTOR: IntegrationDescriptor = {
+  id: SSH_DEVICE_INTEGRATION_ID,
+  displayName: 'SSH 设备',
+  summary: '通过 SSH 连接的受信任设备。每台设备一条连接；角色需获授权并逐动作审批后才能执行命令。',
+  configFields: [
+    { id: 'displayName', displayName: '设备名称', description: '方便角色与用户识别的名称。', kind: 'text', required: false, placeholder: '客厅主机' },
+    { id: 'host', displayName: '主机地址', description: '设备的 IP 或主机名；默认仅允许内网与回环地址。', kind: 'text', required: true, placeholder: '192.168.1.10' },
+    { id: 'port', displayName: '端口', description: 'SSH 端口。', kind: 'number', required: false, placeholder: '22' },
+    { id: 'username', displayName: '登录用户', description: '连接设备时使用的系统用户名。', kind: 'text', required: true, placeholder: 'root' },
+    { id: 'allowPublic', displayName: '允许公网设备', description: '默认拒绝公网地址；打开后仍会在每次执行时提示高风险。', kind: 'boolean', required: false },
+  ],
+  secretFields: [
+    { id: 'privateKey', displayName: '登录私钥', description: 'OpenSSH 私钥原文，仅在本机加密凭据库保存，保存后不回显。', kind: 'secret', required: false, multiline: true, placeholder: '-----BEGIN OPENSSH PRIVATE KEY-----' },
+  ],
+  skillIds: ['device.ssh.command'],
+  dataEgress: ['设备名称/主机地址', '角色经审批后执行的命令文本'],
+  allowsMultipleConnections: true,
+}
+
+export class SshDeviceIntegrationProvider implements IntegrationProvider {
+  readonly descriptor = DESCRIPTOR
+
+  validateConfig(config: JsonObject): JsonObject {
+    const host = typeof config.host === 'string' ? config.host.trim() : ''
+    if (!host) throw new Error('SSH 主机地址不能为空')
+    if (host.includes(' ') || host.includes('/')) throw new Error('SSH 主机地址格式无效')
+    const port = config.port === undefined || config.port === '' ? 22 : Number(config.port)
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) throw new Error('SSH 端口无效')
+    const username = typeof config.username === 'string' ? config.username.trim() : ''
+    if (!username) throw new Error('SSH 登录用户不能为空')
+    const displayName = typeof config.displayName === 'string' ? config.displayName.trim().slice(0, 80) : ''
+    const allowPublic = config.allowPublic === true
+    if (!allowPublic && !isPrivateHost(host)) {
+      throw new Error('SSH 只允许连接内网或回环设备；公网设备需要显式开启“允许公网设备”')
+    }
+    return {
+      ...(displayName ? { displayName } : {}),
+      host,
+      port,
+      username,
+      ...(allowPublic ? { allowPublic: true } : {}),
+    }
+  }
+
+  async testConnection(context: IntegrationProviderContext): Promise<IntegrationHealth> {
+    const startedAt = Date.now()
+    const config = this.validateConfig(context.config)
+    const credentialPresent = Boolean(context.credential)
+    const detail = credentialPresent
+      ? 'SSH 端口可达，凭据已保存（完整登录验证在执行命令时进行）'
+      : 'SSH 端口可达，但尚未配置私钥或密码'
+    try {
+      await probeSshBanner(String(config.host), Number(config.port), 5_000)
+      return { status: 'ready', detail, checkedAt: context.now.toISOString(), latencyMs: Date.now() - startedAt }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : '无法连接'
+      return { status: 'unreachable', detail: message, checkedAt: context.now.toISOString(), latencyMs: Date.now() - startedAt }
+    }
+  }
+}
+
+function probeSshBanner(host: string, port: number, timeoutMs: number): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const socket = tcpConnect({ host, port })
+    const onError = (error: Error): void => { cleanup(); reject(new Error(`SSH 端口无法连接：${error.message}`)) }
+    const onTimeout = (): void => { cleanup(); reject(new Error('SSH 连接超时')) }
+    const onData = (chunk: Buffer): void => {
+      cleanup()
+      if (chunk.toString('utf8').startsWith('SSH-')) resolve()
+      else reject(new Error('对端不是 SSH 服务'))
+    }
+    const cleanup = (): void => {
+      socket.destroy()
+      socket.off('error', onError); socket.off('timeout', onTimeout); socket.off('data', onData)
+    }
+    socket.setTimeout(timeoutMs)
+    socket.once('error', onError)
+    socket.once('timeout', onTimeout)
+    socket.once('data', onData)
+  })
+}
+
+export function isPrivateHost(value: string): boolean {
+  const host = value.toLowerCase().replace(/^\[|\]$/g, '')
+  if (host === 'localhost' || host === '::1' || host.endsWith('.local')) return true
+  const ipv4 = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/.exec(host)
+  if (ipv4 === null) return host.startsWith('fc') || host.startsWith('fd') || host.startsWith('fe80:')
+  const octets = ipv4.slice(1).map(Number)
+  if (octets.some((item) => item > 255)) return false
+  const [first, second] = octets
+  return first === 10 || first === 127
+    || (first === 172 && second !== undefined && second >= 16 && second <= 31)
+    || (first === 192 && second === 168)
+    || (first === 169 && second === 254)
+}

--- a/packages/server/src/routes/integration-routes.ts
+++ b/packages/server/src/routes/integration-routes.ts
@@ -2,7 +2,7 @@ import type { JsonObject } from '@dsh-cyber/contracts'
 import type { SqliteStore } from '@dsh-cyber/persistence'
 
 import { HttpError } from '../http/errors.js'
-import { readJson, record, requiredString } from '../http/request.js'
+import { optionalString, readJson, record, requiredString } from '../http/request.js'
 import { writeJson } from '../http/response.js'
 import type { Router } from '../http/router.js'
 import type { IntegrationService } from '../integrations/integration-service.js'
@@ -17,6 +17,30 @@ export function registerIntegrationRoutes(router: Router, dependencies: { store:
     const descriptors = visibleDescriptors(store, integrations, workspaceId)
     const allowed = new Set(descriptors.map((descriptor) => descriptor.id))
     writeJson(response, 200, { descriptors, items: integrations.list(workspaceId).filter((item) => allowed.has(item.integrationId)) })
+  })
+
+  router.put(/^\/api\/workspaces\/([^/]+)\/integrations\/([^/]+)\/connections\/([^/]+)$/, async ({ request, response, params }) => {
+    // Connection-scoped write: edits one exact device/endpoint connection.
+    const workspaceId = requireWorkspace(store, params[0]!); const integrationId = params[1]!; const connectionId = params[2]!
+    assertIntegrationAvailable(store, workspaceId, integrationId)
+    const body = await readJson(request); const config = record(body.config) ?? {}
+    if (body.enabled !== undefined && typeof body.enabled !== 'boolean') throw new HttpError(422, 'integration_enabled_invalid', 'enabled must be boolean')
+    if (body.clearCredential !== undefined && typeof body.clearCredential !== 'boolean') throw new HttpError(422, 'integration_clear_credential_invalid', 'clearCredential must be boolean')
+    const existing = integrations.getById(workspaceId, connectionId)
+    if (existing === undefined || existing.integrationId !== integrationId) throw new HttpError(404, 'integration_connection_not_found', '外部连接不存在')
+    let connection
+    try {
+      connection = await integrations.save({
+        workspaceId, integrationId, connectionId, config: config as JsonObject, enabled: body.enabled !== false,
+        ...(body.displayName === undefined ? {} : { displayName: requiredString(body, 'displayName') }),
+        ...(body.credential === undefined ? {} : { credential: requiredString(body, 'credential') }),
+        ...(body.clearCredential === true ? { clearCredential: true } : {}),
+      })
+    } catch (error) {
+      throw new HttpError(422, 'integration_config_invalid', error instanceof Error ? error.message : 'Integration configuration is invalid')
+    }
+    await onChanged?.(integrationId)
+    writeJson(response, 200, { connection })
   })
 
   router.put(/^\/api\/workspaces\/([^/]+)\/integrations\/([^/]+)$/, async ({ request, response, params }) => {
@@ -40,13 +64,22 @@ export function registerIntegrationRoutes(router: Router, dependencies: { store:
     writeJson(response, 200, { connection })
   })
 
-  router.post(/^\/api\/workspaces\/([^/]+)\/integrations\/([^/]+)\/test$/, async ({ response, params }) => {
+  router.post(/^\/api\/workspaces\/([^/]+)\/integrations\/([^/]+)\/test$/, async ({ response, params, url }) => {
     const workspaceId = requireWorkspace(store, params[0]!)
     const integrationId = params[1]!
     assertIntegrationAvailable(store, workspaceId, integrationId)
-    const health = await integrations.test(workspaceId, integrationId)
+    const connectionId = optionalString(url.searchParams.get('connectionId'))
+    const health = await integrations.test(workspaceId, integrationId, connectionId)
     if (health.status === 'ready') await onChanged?.(integrationId)
     writeJson(response, 200, { health })
+  })
+
+  router.delete(/^\/api\/workspaces\/([^/]+)\/integrations\/([^/]+)\/connections\/([^/]+)$/, async ({ response, params }) => {
+    const workspaceId = requireWorkspace(store, params[0]!); const integrationId = params[1]!; const connectionId = params[2]!
+    assertIntegrationAvailable(store, workspaceId, integrationId)
+    const removed = await integrations.delete(workspaceId, integrationId, connectionId)
+    if (removed) await onChanged?.(integrationId)
+    writeJson(response, 200, { removed })
   })
 
   router.delete(/^\/api\/workspaces\/([^/]+)\/integrations\/([^/]+)$/, async ({ response, params }) => {

--- a/packages/server/tests/ssh-connection-hub.test.ts
+++ b/packages/server/tests/ssh-connection-hub.test.ts
@@ -1,0 +1,104 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { createServer } from 'node:net'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { createBuiltinIntegrationRegistry } from '../src/integrations/builtin-integration-registry.js'
+import { IntegrationService } from '../src/integrations/integration-service.js'
+import { SSH_DEVICE_INTEGRATION_ID, SshDeviceIntegrationProvider, isPrivateHost } from '../src/integrations/ssh-provider.js'
+
+const roots: string[] = []
+afterEach(async () => { for (const root of roots.splice(0)) await rm(root, { recursive: true, force: true }) })
+
+async function openService(): Promise<IntegrationService> {
+  const root = await mkdtemp(join(tmpdir(), 'dsh-ssh-connections-'))
+  roots.push(root)
+  return IntegrationService.open(root, createBuiltinIntegrationRegistry())
+}
+
+describe('SSH multi-connection hub', () => {
+  it('registers an SSH device provider that allows multiple connections', () => {
+    const registry = createBuiltinIntegrationRegistry()
+    const descriptor = registry.list().find((item) => item.id === SSH_DEVICE_INTEGRATION_ID)
+    expect(descriptor).toBeDefined()
+    expect(descriptor!.allowsMultipleConnections).toBe(true)
+    expect(descriptor!.skillIds).toContain('device.ssh.command')
+  })
+
+  it('validates SSH config: host/user required, private-range enforced by default', () => {
+    const provider = new SshDeviceIntegrationProvider()
+    expect(() => provider.validateConfig({ host: '', username: 'root' })).toThrow(/主机地址不能为空/)
+    expect(() => provider.validateConfig({ host: '8.8.8.8', username: 'root' })).toThrow(/只允许连接内网或回环/)
+    expect(provider.validateConfig({ host: '10.0.0.8', username: 'root', port: 22 })).toEqual({ host: '10.0.0.8', port: 22, username: 'root' })
+    expect(provider.validateConfig({ host: 'example.com', username: 'root', allowPublic: true })).toMatchObject({ host: 'example.com', username: 'root', allowPublic: true })
+  })
+
+  it('classifies hosts as private or public consistently', () => {
+    for (const host of ['10.1.2.3', '127.0.0.1', 'localhost', '192.168.1.5', '172.16.0.2', '169.254.1.1', '[fd12::1]']) {
+      expect(isPrivateHost(host)).toBe(true)
+    }
+    for (const host of ['8.8.8.8', 'example.com', '1.1.1.1']) {
+      expect(isPrivateHost(host)).toBe(false)
+    }
+  })
+
+  it('keeps several SSH devices of one type with independent credentials', async () => {
+    const service = await openService()
+    const first = await service.save({
+      workspaceId: 'workspace-1', integrationId: SSH_DEVICE_INTEGRATION_ID,
+      config: { displayName: '客厅主机', host: '10.0.0.10', username: 'owner' }, enabled: true, credential: 'key-a',
+    })
+    const second = await service.save({
+      workspaceId: 'workspace-1', integrationId: SSH_DEVICE_INTEGRATION_ID,
+      config: { displayName: '工作区服务器', host: '192.168.1.20', username: 'deploy' }, enabled: true, credential: 'key-b',
+    })
+    expect(service.listByType('workspace-1', SSH_DEVICE_INTEGRATION_ID)).toHaveLength(2)
+    expect(service.getById('workspace-1', first.id)).toMatchObject({ displayName: '客厅主机', enabled: true })
+    expect(service.credentialForConnection('workspace-1', first.id)).toBe('key-a')
+    expect(service.credentialForConnection('workspace-1', second.id)).toBe('key-b')
+    // Editing one connection never touches the sibling's credential.
+    await service.save({
+      workspaceId: 'workspace-1', integrationId: SSH_DEVICE_INTEGRATION_ID, connectionId: first.id,
+      config: { displayName: '客厅主机(改)', host: '10.0.0.10', username: 'owner' }, enabled: true, credential: 'key-a-v2',
+    })
+    expect(service.getById('workspace-1', first.id)?.displayName).toBe('客厅主机(改)')
+    expect(service.credentialForConnection('workspace-1', first.id)).toBe('key-a-v2')
+    expect(service.credentialForConnection('workspace-1', second.id)).toBe('key-b')
+    expect(await service.delete('workspace-1', SSH_DEVICE_INTEGRATION_ID, first.id)).toBe(true)
+    expect(service.listByType('workspace-1', SSH_DEVICE_INTEGRATION_ID)).toHaveLength(1)
+    expect(service.credentialForConnection('workspace-1', second.id)).toBe('key-b')
+    service.close()
+  })
+
+  it('tests a connection against a reachable SSH banner without sending credentials', async () => {
+    const server = createServer((socket) => { socket.write('SSH-2.0-OpenSSH_test\r\n') })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as { port: number }).port
+    const service = await openService()
+    const connection = await service.save({
+      workspaceId: 'workspace-1', integrationId: SSH_DEVICE_INTEGRATION_ID,
+      config: { displayName: '本机测试', host: '127.0.0.1', port, username: 'tester' }, enabled: true, credential: 'private-key-material',
+    })
+    const health = await service.test('workspace-1', SSH_DEVICE_INTEGRATION_ID, connection.id)
+    expect(health.status).toBe('ready')
+    expect(JSON.stringify(service.list('workspace-1'))).not.toContain('private-key-material')
+    service.close()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+
+  it('reports an unreachable or non-SSH endpoint as unreachable', async () => {
+    const server = createServer((socket) => { socket.write('HTTP/1.1 200 OK\r\n') })
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve))
+    const port = (server.address() as { port: number }).port
+    const service = await openService()
+    const connection = await service.save({
+      workspaceId: 'workspace-1', integrationId: SSH_DEVICE_INTEGRATION_ID,
+      config: { displayName: '非 SSH 端口', host: '127.0.0.1', port, username: 'tester' }, enabled: true,
+    })
+    expect((await service.test('workspace-1', SSH_DEVICE_INTEGRATION_ID, connection.id)).status).toBe('unreachable')
+    service.close()
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  })
+})

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -75,6 +75,7 @@ import { ChatWorkbench, isChatMessage } from './components/ChatWorkbench.js'
 import type { ConversationPermissionMode } from './components/ConversationPermissionControl.js'
 import { CreativeWorkshopLauncher } from './components/CreativeWorkshopLauncher.js'
 import { ModelHubLauncher } from './features/model-hub/ModelHubLauncher.js'
+import { ConnectionHubLauncher } from './features/connection-hub/ConnectionHubLauncher.js'
 import { NavigationPane } from './components/NavigationPane.js'
 import { ResizableShell } from './components/ResizableShell.js'
 import { WorldThemeSwitcher } from './components/WorldThemeSwitcher.js'
@@ -2361,6 +2362,7 @@ export default function App() {
           <CreativeWorkshopLauncher workspaceId={workspace.id} onCreated={(project) => { void openWorkshopWorld(project.worldId).catch((cause) => setError(cause instanceof Error ? cause.message : '创意工坊世界已创建，但打开失败，请从世界列表重新进入。')) }} onOpenWorld={(worldId) => { void openWorkshopWorld(worldId).catch((cause) => setError(cause instanceof Error ? cause.message : '世界打开失败')) }} />
           <button type="button" onClick={() => void openPackageMarket('theme')}><Storefront size={16} />{t('app.market', '市场')}</button>
           <ModelHubLauncher workspaceId={workspace.id} worlds={worlds} employees={employees} onClosed={() => void refreshModelProfiles()} />
+          <ConnectionHubLauncher workspace={workspace} />
           <button type="button" onClick={() => { clearError(); setSettingsSection('maintenance'); setSettingsOpen(true) }}><Pulse size={16} /><span>{t('app.systemStatus', '系统状态')}</span><i className="health-indicator" />{t('app.healthy', '良好')}</button>
           <button type="button" onClick={() => { clearError(); setSettingsSection('appearance'); setSettingsOpen(true) }}><GearSix size={17} />{t('app.settings', '设置')}</button>
         </nav>

--- a/packages/web/src/components/SettingsDialog.tsx
+++ b/packages/web/src/components/SettingsDialog.tsx
@@ -47,11 +47,13 @@ import type {
 import { api } from '../api.js'
 import { setUiLocale, UI_LOCALES, useI18n } from '../i18n/runtime.js'
 import { formatDateTime, formatDuration as localeFormatDuration, formatNumber } from '../i18n/format.js'
+import { IntegrationSettingsPanel } from '../features/connection-hub/IntegrationSettingsPanel.js'
 import type { ApplicationAccessSummary } from './ApplicationLockGate.js'
 import { useDialogFocusTrap } from './useDialogFocusTrap.js'
 import './SettingsDialog.css'
 
 const ModelHubDialog = lazy(async () => ({ default: (await import('../features/model-hub/ModelHubDialog.js')).ModelHubDialog }))
+const ConnectionHubDialog = lazy(async () => ({ default: (await import('../features/connection-hub/ConnectionHubDialog.js')).ConnectionHubDialog }))
 
 interface ApplicationAccessMutation extends ApplicationAccessSummary { recoveryCode?: string }
 
@@ -255,7 +257,7 @@ export function SettingsDialog({
               <p className="settings-hub-gate__note">{t('modelHub.gateNote', '本设置页不再单独管理模型；旧的模型配置已在首次启动时自动迁移为服务商。')}</p>
             </div>
           ) : null}
-          {section === 'integrations' ? <IntegrationSettings workspaceId={workspace.id} /> : null}
+          {section === 'integrations' ? <IntegrationSettingsPanel workspaceId={workspace.id} standalone /> : null}
           {section === 'privacy' ? <PrivacySettings /> : null}
           {section === 'logs' ? (
             <ModelInteractionLogSettings
@@ -278,95 +280,6 @@ export function SettingsDialog({
       </section>
     </div>
   )
-}
-
-function IntegrationSettings({ workspaceId }: { workspaceId: string }) {
-  const [descriptors, setDescriptors] = useState<IntegrationDescriptor[]>([])
-  const [connections, setConnections] = useState<IntegrationConnection[]>([])
-  const [selectedId, setSelectedId] = useState<string>()
-  const [config, setConfig] = useState<JsonObject>({})
-  const [credential, setCredential] = useState('')
-  const [enabled, setEnabled] = useState(true)
-  const [health, setHealth] = useState<IntegrationHealth>()
-  const [busy, setBusy] = useState(false)
-  const [error, setError] = useState<string>()
-
-  const load = async () => {
-    const result = await api<{ descriptors: IntegrationDescriptor[]; items: IntegrationConnection[] }>(`/api/workspaces/${encodeURIComponent(workspaceId)}/integrations`)
-    setDescriptors(result.descriptors)
-    setConnections(result.items)
-    setSelectedId((current) => current ?? result.descriptors[0]?.id)
-  }
-
-  useEffect(() => {
-    void load().catch((cause: unknown) => setError(cause instanceof Error ? cause.message : '外部连接加载失败'))
-    // load only changes local connection state for the selected workspace.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [workspaceId])
-
-  const descriptor = descriptors.find((item) => item.id === selectedId)
-  const connection = connections.find((item) => item.integrationId === selectedId)
-  useEffect(() => {
-    setConfig(Object.fromEntries((descriptor?.configFields ?? []).map((field) => [
-      field.id,
-      connection?.config[field.id] ?? (field.kind === 'boolean' ? false : field.kind === 'number' ? 0 : field.placeholder ?? ''),
-    ])) as JsonObject)
-    setEnabled(connection?.enabled ?? true)
-    setCredential('')
-    setHealth(undefined)
-  }, [connection?.id, descriptor?.id])
-
-  const save = async () => {
-    if (descriptor === undefined) return
-    setBusy(true); setError(undefined); setHealth(undefined)
-    try {
-      await api(`/api/workspaces/${encodeURIComponent(workspaceId)}/integrations/${encodeURIComponent(descriptor.id)}`, {
-        method: 'PUT',
-        body: JSON.stringify({ config, enabled, ...(credential.trim() ? { credential: credential.trim() } : {}) }),
-      })
-      await load()
-      setCredential('')
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : '连接保存失败')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const test = async () => {
-    if (descriptor === undefined) return
-    setBusy(true); setError(undefined)
-    try {
-      const result = await api<{ health: IntegrationHealth }>(`/api/workspaces/${encodeURIComponent(workspaceId)}/integrations/${encodeURIComponent(descriptor.id)}/test`, { method: 'POST', body: '{}' })
-      setHealth(result.health)
-    } catch (cause) {
-      setError(cause instanceof Error ? cause.message : '连接测试失败')
-    } finally {
-      setBusy(false)
-    }
-  }
-
-  const requiredConfigMissing = descriptor?.configFields.some((field) => field.required && String(config[field.id] ?? '').trim() === '') ?? true
-
-  return <div className="settings-section settings-section--integrations">
-    <div className="settings-section__heading"><h3>外部连接</h3><p>统一管理受信任服务。安装 Skill 只声明能力，角色获得授权后仍需经过审批策略才能发送数据。</p></div>
-    <div className="integration-provider-list" role="list">
-      {descriptors.map((item) => <button key={item.id} type="button" className={item.id === selectedId ? 'is-active' : ''} onClick={() => setSelectedId(item.id)}><strong>{item.displayName}</strong><small>{item.summary}</small></button>)}
-    </div>
-    {descriptor === undefined ? <div className="dialog-empty">当前没有可配置的外部连接。</div> : <section className="integration-editor">
-      <header><div><h4>{descriptor.displayName}</h4><p>{descriptor.summary}</p></div><label><input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />启用连接</label></header>
-      {descriptor.configFields.map((field) => field.kind === 'boolean' ? (
-        <label className="dialog-field dialog-field--checkbox" key={field.id}><input type="checkbox" checked={config[field.id] === true} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.checked }))} /><span>{field.displayName}</span><small>{field.description}</small></label>
-      ) : (
-        <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type={field.kind === 'number' ? 'number' : 'text'} value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: field.kind === 'number' ? Number(event.target.value) : event.target.value }))} /><small>{field.description}</small></label>
-      ))}
-      {descriptor.secretFields.map((field) => <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type="password" autoComplete="new-password" value={credential} placeholder={connection?.credentialConfigured ? '已加密保存；留空保持不变' : field.required ? '请输入连接凭据' : '可选'} onChange={(event) => setCredential(event.target.value)} /><small>{field.description}</small></label>)}
-      <div className="integration-egress"><strong>会发送到外部服务</strong><span>{descriptor.dataEgress.join('、') || '无'}</span></div>
-      {error ? <p className="model-form-message model-form-message--error" role="alert">{error}</p> : null}
-      {health ? <p className={health.status === 'ready' ? 'model-form-message model-form-message--success' : 'model-form-message model-form-message--error'} role="status">{health.detail} · {health.latencyMs} ms</p> : null}
-      <footer><button className="secondary-button" type="button" disabled={busy || connection === undefined} onClick={() => void test()}>测试连接</button><button className="primary-button" type="button" disabled={busy || requiredConfigMissing} onClick={() => void save()}>{busy ? '处理中…' : '保存连接'}</button></footer>
-    </section>}
-  </div>
 }
 
 function PrivacySettings() {

--- a/packages/web/src/features/connection-hub/ConnectionHubDialog.tsx
+++ b/packages/web/src/features/connection-hub/ConnectionHubDialog.tsx
@@ -1,0 +1,36 @@
+import { lazy, Suspense, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { X } from '@phosphor-icons/react'
+import type { Workspace } from '@dsh-cyber/contracts'
+
+import { useI18n } from '../../i18n/runtime.js'
+import { useDialogFocusTrap } from '../../components/useDialogFocusTrap.js'
+
+const IntegrationSettingsPanel = lazy(async () => ({ default: (await import('./IntegrationSettingsPanel.js')).IntegrationSettingsPanel }))
+
+/**
+ * Top-level "connection hub" dialog, sibling to the model hub. Owns the
+ * encrypted connection store (SSH devices, API endpoints, Firecrawl/MCP) and
+ * is where characters get connection-level grants in later milestones.
+ */
+export function ConnectionHubDialog({ workspace, onClose }: { workspace: Workspace; onClose(): void }) {
+  const { t } = useI18n()
+  const [open, setOpen] = useState(true)
+  const panelRef = useRef<HTMLElement>(null)
+  useDialogFocusTrap(panelRef, () => { setOpen(false); onClose() })
+  if (!open) return null
+  return createPortal(<div className="modal-backdrop" role="presentation" onMouseDown={(event) => { if (event.target === event.currentTarget) { setOpen(false); onClose() } }}>
+    <section ref={panelRef} className="connection-hub" role="dialog" aria-modal="true" aria-labelledby="connection-hub-title">
+      <header className="connection-hub__header">
+        <div>
+          <h2 id="connection-hub-title"><span className="connection-hub__glyph">⌁</span> {t('connectionHub.title', '连接中心')}</h2>
+          <p>{t('connectionHub.subtitle', '统一管理受信任的连接：SSH 设备、API 端点等。凭据只在本机加密保存；角色仍需授权并逐动作审批。')}</p>
+        </div>
+        <button type="button" className="icon-button" aria-label={t('connectionHub.close', '关闭连接中心')} data-dialog-initial-focus onClick={() => { setOpen(false); onClose() }}><X size={18} /></button>
+      </header>
+      <Suspense fallback={<div className="connection-hub__loading">{t('connectionHub.loading', '加载连接中心…')}</div>}>
+        <IntegrationSettingsPanel workspaceId={workspace.id} />
+      </Suspense>
+    </section>
+  </div>, document.body)
+}

--- a/packages/web/src/features/connection-hub/ConnectionHubLauncher.tsx
+++ b/packages/web/src/features/connection-hub/ConnectionHubLauncher.tsx
@@ -1,0 +1,21 @@
+import { lazy, Suspense, useState } from 'react'
+import type { Workspace } from '@dsh-cyber/contracts'
+import { PlugsConnected } from '@phosphor-icons/react'
+
+import { useI18n } from '../../i18n/runtime.js'
+
+const ConnectionHubDialog = lazy(async () => ({ default: (await import('./ConnectionHubDialog.js')).ConnectionHubDialog }))
+
+/**
+ * Top-bar entry for the connection hub, placed right after the model hub. The
+ * dialog is lazy: connection management belongs out of the first paint.
+ */
+export function ConnectionHubLauncher({ workspace, onClosed }: { workspace: Workspace; onClosed?(): void }) {
+  const { t } = useI18n()
+  const [open, setOpen] = useState(false)
+  const close = (): void => { setOpen(false); onClosed?.() }
+  return <>
+    <button type="button" aria-haspopup="dialog" onClick={() => setOpen(true)}><PlugsConnected size={16} />{t('app.connectionHub', '连接中心')}</button>
+    {open ? <Suspense fallback={null}><ConnectionHubDialog workspace={workspace} onClose={close} /></Suspense> : null}
+  </>
+}

--- a/packages/web/src/features/connection-hub/IntegrationSettingsPanel.tsx
+++ b/packages/web/src/features/connection-hub/IntegrationSettingsPanel.tsx
@@ -1,0 +1,213 @@
+import { useEffect, useMemo, useState, type ReactNode } from 'react'
+import { Trash } from '@phosphor-icons/react'
+import type {
+  IntegrationConnection,
+  IntegrationDescriptor,
+  IntegrationHealth,
+  JsonObject,
+} from '@dsh-cyber/contracts'
+import { api } from '../../api.js'
+
+export interface IntegrationSettingsPanelProps {
+  workspaceId: string
+  /** When true the outer chrome (provider rail + section paddings) is rendered too. */
+  standalone?: boolean
+}
+
+/**
+ * Connection-center management shared by the settings section and the top-bar
+ * hub dialog.
+ *
+ * Single-connection types keep their legacy one-form-per-type flow. Types that
+ * declare `allowsMultipleConnections` (SSH devices) render a connection list
+ * with an "add" action; the editor always targets the selected connection.
+ */
+export function IntegrationSettingsPanel({ workspaceId, standalone = false }: IntegrationSettingsPanelProps) {
+  const [descriptors, setDescriptors] = useState<IntegrationDescriptor[]>([])
+  const [connections, setConnections] = useState<IntegrationConnection[]>([])
+  const [selectedTypeId, setSelectedTypeId] = useState<string>()
+  const [selectedConnectionId, setSelectedConnectionId] = useState<string>()
+  const [config, setConfig] = useState<JsonObject>({})
+  const [credential, setCredential] = useState('')
+  const [enabled, setEnabled] = useState(true)
+  const [health, setHealth] = useState<IntegrationHealth>()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string>()
+
+  const load = async () => {
+    const result = await api<{ descriptors: IntegrationDescriptor[]; items: IntegrationConnection[] }>(`/api/workspaces/${encodeURIComponent(workspaceId)}/integrations`)
+    setDescriptors(result.descriptors)
+    setConnections(result.items)
+    setSelectedTypeId((current) => current ?? result.descriptors[0]?.id)
+  }
+
+  useEffect(() => {
+    void load().catch((cause: unknown) => setError(cause instanceof Error ? cause.message : '外部连接加载失败'))
+    // load only changes local connection state for the selected workspace.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [workspaceId])
+
+  const descriptor = descriptors.find((item) => item.id === selectedTypeId)
+  const multiple = descriptor?.allowsMultipleConnections === true
+  const typeConnections = useMemo(
+    () => connections.filter((item) => item.integrationId === descriptor?.id),
+    [connections, descriptor?.id],
+  )
+  // Single-connection types edit their one connection; multi-connection types
+  // edit the selected device, or a fresh form when none is chosen yet.
+  const connection = multiple
+    ? typeConnections.find((item) => item.id === selectedConnectionId)
+    : typeConnections[0]
+
+  useEffect(() => {
+    setConfig(Object.fromEntries((descriptor?.configFields ?? []).map((field) => [
+      field.id,
+      connection?.config[field.id] ?? (field.kind === 'boolean' ? false : field.kind === 'number' ? '' : field.placeholder ?? ''),
+    ])) as JsonObject)
+    setEnabled(connection?.enabled ?? true)
+    setCredential('')
+    setHealth(undefined)
+    setError(undefined)
+  }, [connection?.id, descriptor?.id])
+
+  const targetId = descriptor?.id
+  const targetConnectionId = connection?.id
+
+  const save = async () => {
+    if (descriptor === undefined) return
+    setBusy(true); setError(undefined); setHealth(undefined)
+    try {
+      const path = targetConnectionId === undefined
+        ? `/api/workspaces/${encodeURIComponent(workspaceId)}/integrations/${encodeURIComponent(descriptor.id)}`
+        : `/api/workspaces/${encodeURIComponent(workspaceId)}/integrations/${encodeURIComponent(descriptor.id)}/connections/${encodeURIComponent(targetConnectionId)}`
+      await api(path, {
+        method: 'PUT',
+        body: JSON.stringify({
+          config,
+          enabled,
+          displayName: typeof config.displayName === 'string' ? config.displayName : descriptor.displayName,
+          ...(credential.trim() ? { credential: credential.trim() } : {}),
+          ...(connection?.credentialConfigured === true && !credential.trim() ? {} : {}),
+        }),
+      })
+      await load()
+      setCredential('')
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '连接保存失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const addConnection = async () => {
+    if (descriptor === undefined) return
+    setBusy(true); setError(undefined)
+    try {
+      // Multi-connection types create a fresh row on every PUT without a
+      // connectionId; begin editing a blank form then save persists it.
+      setSelectedConnectionId(undefined)
+      setConfig(Object.fromEntries((descriptor.configFields ?? []).map((field) => [
+        field.id,
+        field.kind === 'boolean' ? false : field.kind === 'number' ? '' : field.placeholder ?? '',
+      ])) as JsonObject)
+      setEnabled(true)
+      setCredential('')
+      setHealth(undefined)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const removeConnection = async () => {
+    if (descriptor === undefined || connection === undefined) return
+    if (!window.confirm('确定删除这个连接吗？删除后无法恢复。')) return
+    setBusy(true); setError(undefined)
+    try {
+      await api(`/api/workspaces/${encodeURIComponent(workspaceId)}/integrations/${encodeURIComponent(descriptor.id)}/connections/${encodeURIComponent(connection.id)}`, { method: 'DELETE' })
+      setSelectedConnectionId(undefined)
+      await load()
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '连接删除失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const test = async () => {
+    if (descriptor === undefined) return
+    setBusy(true); setError(undefined)
+    try {
+      const query = targetConnectionId === undefined ? '' : `?connectionId=${encodeURIComponent(targetConnectionId)}`
+      const result = await api<{ health: IntegrationHealth }>(`/api/workspaces/${encodeURIComponent(workspaceId)}/integrations/${encodeURIComponent(descriptor.id)}/test${query}`, { method: 'POST', body: '{}' })
+      setHealth(result.health)
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : '连接测试失败')
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const secretConfigured = connection?.credentialConfigured === true
+  const requiredConfigMissing = descriptor?.configFields.some((field) => field.required && String(config[field.id] ?? '').trim() === '') ?? true
+  const secretMissing = (descriptor?.secretFields ?? []).some((field) => field.required && !secretConfigured && credential.trim() === '')
+
+  const renderBody = () => (descriptor === undefined
+    ? <div className="dialog-empty">当前没有可配置的外部连接。</div>
+    : <>
+        {multiple ? <div className="integration-connection-list">
+          <button type="button" className={connection === undefined ? 'is-active' : ''} onClick={() => { setSelectedConnectionId(undefined); setHealth(undefined) }}>
+            <strong>{connection === undefined ? '新连接' : '未选择'}</strong><small>添加一台新设备或端点</small>
+          </button>
+          {typeConnections.map((item) => <button key={item.id} type="button" className={item.id === selectedConnectionId ? 'is-active' : ''} onClick={() => setSelectedConnectionId(item.id)}>
+            <strong>{item.displayName}</strong><small>{`${String(item.config.host ?? item.config.endpoint ?? '')}${item.enabled ? '' : ' · 已停用'}`}</small>
+          </button>)}
+        </div> : null}
+        <section className="integration-editor">
+          <header>
+            <div><h4>{connection?.displayName ?? descriptor.displayName}</h4><p>{descriptor.summary}</p></div>
+            <label><input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />启用连接</label>
+          </header>
+          {descriptor.configFields.map((field) => field.kind === 'boolean' ? (
+            <label className="dialog-field dialog-field--checkbox" key={field.id}><input type="checkbox" checked={config[field.id] === true} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.checked }))} /><span>{field.displayName}</span><small>{field.description}</small></label>
+          ) : field.id === 'displayName' ? (
+            <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type="text" value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.value }))} /><small>{field.description}</small></label>
+          ) : (
+            <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type={field.kind === 'number' ? 'number' : 'text'} value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: field.kind === 'number' ? Number(event.target.value) : event.target.value }))} /><small>{field.description}</small></label>
+          ))}
+          {descriptor.secretFields.map((field) => <label className="dialog-field" key={field.id}><span>{field.displayName}</span>
+            {field.multiline === true
+              ? <textarea rows={6} value={credential} placeholder={secretConfigured ? '已加密保存；留空保持不变' : (field.required ? '请输入连接凭据' : '可选')} onChange={(event) => setCredential(event.target.value)} autoComplete="new-password" spellCheck={false} />
+              : <input type="password" autoComplete="new-password" value={credential} placeholder={secretConfigured ? '已加密保存；留空保持不变' : (field.required ? '请输入连接凭据' : '可选')} onChange={(event) => setCredential(event.target.value)} />}
+            <small>{field.description}</small></label>)}
+          <div className="integration-egress"><strong>会发送到外部服务</strong><span>{descriptor.dataEgress.join('、') || '无'}</span></div>
+          {error ? <p className="model-form-message model-form-message--error" role="alert">{error}</p> : null}
+          {health ? <p className={health.status === 'ready' ? 'model-form-message model-form-message--success' : 'model-form-message model-form-message--error'} role="status">{health.detail} · {health.latencyMs} ms</p> : null}
+          <footer>
+            {multiple && connection !== undefined ? <button className="text-button is-danger" type="button" disabled={busy} onClick={() => void removeConnection()}><Trash size={15} />删除连接</button> : null}
+            <span className="integration-editor__actions">
+              <button className="secondary-button" type="button" disabled={busy || connection === undefined} onClick={() => void test()}>测试连接</button>
+              <button className="primary-button" type="button" disabled={busy || requiredConfigMissing || secretMissing} onClick={() => void save()}>{busy ? '处理中…' : targetConnectionId === undefined && multiple ? '添加连接' : '保存连接'}</button>
+            </span>
+          </footer>
+        </section>
+      </>)
+
+  const chrome = (content: ReactNode) => standalone
+    ? <div className="settings-section settings-section--integrations">
+        <div className="settings-section__heading"><h3>连接中心</h3><p>统一管理受信任的连接。安装 Skill 只声明能力，角色获得授权后仍需经过审批策略才能执行命令或发送数据。</p></div>
+        <div className="integration-hub-layout">
+          <div className="integration-provider-list" role="list">
+            {descriptors.map((item) => <button key={item.id} type="button" className={item.id === selectedTypeId ? 'is-active' : ''} onClick={() => { setSelectedTypeId(item.id); setSelectedConnectionId(undefined) }}><strong>{item.displayName}</strong><small>{item.summary}</small></button>)}
+          </div>
+          {content}
+        </div>
+      </div>
+    : <div className="integration-hub-layout">
+        <div className="integration-provider-list" role="list">
+          {descriptors.map((item) => <button key={item.id} type="button" className={item.id === selectedTypeId ? 'is-active' : ''} onClick={() => { setSelectedTypeId(item.id); setSelectedConnectionId(undefined) }}><strong>{item.displayName}</strong><small>{item.summary}</small></button>)}
+        </div>
+        {content}
+      </div>
+
+  return chrome(renderBody())
+}

--- a/packages/web/src/i18n/connection-hub-messages.ts
+++ b/packages/web/src/i18n/connection-hub-messages.ts
@@ -1,0 +1,18 @@
+import type { UiLocale } from '@dsh-cyber/contracts'
+
+import { registerMessages } from './runtime.js'
+
+const LOCALES = ['zh-CN', 'zh-TW', 'en-US', 'ja-JP', 'ko-KR', 'es-ES', 'fr-FR', 'de-DE', 'pt-BR', 'ru-RU', 'ar-SA', 'hi-IN'] as const satisfies readonly UiLocale[]
+type V = readonly [string, string, string, string, string, string, string, string, string, string, string, string]
+
+const messages = {
+  'app.connectionHub': ['连接中心', '連接中心', 'Connection hub', '接続センター', '연결 허브', 'Centro de conexiones', 'Centre de connexions', 'Verbindungszentrum', 'Central de conexões', 'Центр подключений', 'مركز الاتصالات', 'कनेक्शन केंद्र'],
+  'connectionHub.title': ['连接中心', '連接中心', 'Connection Hub', '接続センター', '연결 허브', 'Centro de conexiones', 'Centre de connexions', 'Verbindungszentrum', 'Central de conexões', 'Центр подключений', 'مركز الاتصالات', 'कनेक्शन केंद्र'],
+  'connectionHub.subtitle': ['统一管理受信任的连接：SSH 设备、API 端点等。凭据只在本机加密保存；角色仍需授权并逐动作审批。', '統一管理受信任的連線：SSH 裝置、API 端點等。憑證只在本機加密保存；角色仍需授權並逐動作審批。', 'Manage trusted connections: SSH devices, API endpoints and more. Credentials stay encrypted on this machine; characters still need grants and per-action approval.', 'SSH 機器や API エンドポイントなどの信頼済み接続を一元管理します。資格情報はこのマシンに暗号化して保存され、キャラクターには許可とアクションごとの承認が必要です。', '신뢰하는 연결(SSH 장치, API 엔드포인트 등)을 관리합니다. 자격 증명은 이 기기에 암호화되어 저장되며, 캐릭터는 권한과 개별 승인이 필요합니다.', 'Administre conexiones de confianza: dispositivos SSH, endpoints de API y más. Las credenciales quedan cifradas en este equipo; los personajes aún necesitan permisos y aprobación por acción.', 'Gérez les connexions de confiance : appareils SSH, points de terminaison API… Les identifiants restent chiffrés sur cette machine ; les personnages ont toujours besoin d’autorisations et d’une validation action par action.', 'Verwalten Sie vertrauenswürdige Verbindungen: SSH-Geräte, API-Endpunkte u. v. m. Zugangsdaten bleiben auf diesem Rechner verschlüsselt; Charaktere benötigen weiterhin Freigaben und Genehmigung pro Aktion.', 'Gerencie conexões confiáveis: dispositivos SSH, endpoints de API e mais. As credenciais ficam criptografadas nesta máquina; personagens ainda precisam de permissões e aprovação por ação.', 'Управление доверенными подключениями: SSH-устройства, API-эндпоинты и др. Учётные данные шифруются на этой машине; персонажи по-прежнему требуют прав и одобрения каждого действия.', 'إدارة الاتصالات الموثوقة: أجهزة SSH ونقاط نهاية API وغيرها. تُشفر البيانات سرًا على هذا الجهاز؛ ما زالت الشخصيات بحاجة إلى تفويض وموافقة لكل إجراء.', 'विश्वसनीय कनेक्शन प्रबंधित करें: SSH डिवाइस, API एंडपॉइंट आदि। क्रेडेंशियल इसी मशीन पर एन्क्रिप्ट रहते हैं; पात्रों को अनुदान और प्रति-क्रिया अनुमोदन चाहिए।'],
+  'connectionHub.close': ['关闭连接中心', '關閉連接中心', 'Close connection hub', '接続センターを閉じる', '연결 허브 닫기', 'Cerrar el centro', 'Fermer le centre', 'Verbindungszentrum schließen', 'Fechar a central', 'Закрыть центр', 'إغلاق المركز', 'केंद्र बंद करें'],
+  'connectionHub.loading': ['加载连接中心…', '載入連接中心…', 'Loading connection hub…', '接続センターを読み込み中…', '연결 허브 불러오는 중…', 'Cargando el centro…', 'Chargement du centre…', 'Verbindungszentrum wird geladen…', 'Carregando a central…', 'Загрузка центра…', 'جارٍ تحميل المركز…', 'केंद्र लोड हो रहा है…'],
+} satisfies Record<string, V>
+
+export const ALL_CONNECTION_HUB_CATALOGS = Object.fromEntries(LOCALES.map((locale, index) => [locale, Object.fromEntries(Object.entries(messages).map(([key, values]) => [key, values[index]!]))])) as Record<UiLocale, Record<keyof typeof messages, string>>
+
+for (const locale of LOCALES) registerMessages(locale, ALL_CONNECTION_HUB_CATALOGS[locale])

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -30,6 +30,7 @@ await Promise.all([
   import('./i18n/skin-generator-messages.js'),
   import('./i18n/plugin-generator-messages.js'),
   import('./i18n/model-hub-messages.js'),
+  import('./i18n/connection-hub-messages.js'),
 ])
 
 const root = document.getElementById('root')

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -3078,6 +3078,26 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .integration-egress strong { font-size: 13px; }
 .integration-egress span { color: var(--text-soft); font-size: 12px; }
 .integration-editor > footer { display: flex; justify-content: flex-end; gap: 10px; }
+.integration-editor > footer .integration-editor__actions { display: flex; gap: 10px; }
+.integration-editor > footer .text-button.is-danger { margin-right: auto; color: var(--danger); }
+.integration-editor textarea { width: 100%; padding: 9px 11px; color: var(--text); background: var(--surface-0); border: 1px solid var(--border); border-radius: 8px; font: 500 12px/1.5 var(--font-mono); resize: vertical; }
+.integration-connection-list { display: grid; gap: 6px; max-height: 220px; overflow-y: auto; }
+.integration-connection-list button { display: grid; gap: 2px; padding: 10px 12px; border: 1px solid var(--border); color: var(--text); background: var(--surface-1); text-align: left; cursor: pointer; }
+.integration-connection-list button.is-active { border-color: var(--accent); background: color-mix(in srgb, var(--accent) 10%, var(--surface-1)); }
+.integration-connection-list strong { font-size: 13px; }
+.integration-connection-list small { color: var(--text-muted); font-size: 12px; }
+.integration-hub-layout { display: grid; grid-template-columns: 230px minmax(0, 1fr); gap: 16px; align-items: start; }
+
+/* 连接中心（顶栏弹窗，与模型中心平级） */
+.connection-hub { width: min(1180px, 96vw); height: min(820px, 92vh); display: flex; flex-direction: column; overflow: hidden; border: 1px solid var(--border-strong); border-radius: var(--radius-dialog, 14px); background: var(--surface-0); color: var(--text); box-shadow: 0 28px 80px rgb(0 0 0 / 62%), 0 2px 8px rgb(0 0 0 / 34%); }
+.connection-hub__header { min-height: 72px; flex: none; display: flex; align-items: center; justify-content: space-between; gap: 20px; padding: 14px 24px; border-bottom: 1px solid var(--border); background: var(--surface-1); }
+.connection-hub__header > div { min-width: 0; display: grid; gap: 3px; }
+.connection-hub__header h2 { display: flex; gap: 8px; align-items: center; margin: 0; font-size: 20px; line-height: 1.2; letter-spacing: -.01em; }
+.connection-hub__header p { margin: 0; color: var(--text-muted); font-size: 13px; line-height: 1.5; }
+.connection-hub__header .icon-button { width: 40px; height: 40px; flex: none; }
+.connection-hub__glyph { color: var(--accent); font-size: 22px; font-weight: 700; }
+.connection-hub__loading { display: grid; flex: 1; place-items: center; color: var(--text-muted); font-size: 13px; }
+.connection-hub > .integration-hub-layout, .connection-hub > .integration-settings-panel { flex: 1; min-height: 0; overflow-y: auto; padding: 18px 22px 24px; }
 .privacy-lock-card { display: grid; gap: 18px; padding: 20px; border: 1px solid var(--border); background: var(--surface-1); }
 .privacy-lock-card > header { display: grid; grid-template-columns: 42px minmax(0, 1fr); gap: 12px; align-items: center; }
 .privacy-lock-card > header > span { width: 42px; height: 42px; display: grid; place-items: center; border: 1px solid var(--border-strong); color: var(--accent); background: var(--surface-0); }


### PR DESCRIPTION
## 背景

为「连接中心」方向落地 M1。产品形态（与你确认）：连接中心是与**模型中心平级**的顶栏栏目，排在其后；现有 Settings 的「外部连接」合并进连接中心；角色授权为「技能 + 连接」两级（本 PR 为连接级基础，SSH 执行与角色勾选在后续里程碑）。

## 改动

### 契约（contracts）
- `IntegrationDescriptor.allowsMultipleConnections`：一个 provider 类型可有多条连接（每台 SSH 设备/每个 API 端点一条）；缺省 false 保持单连接旧行为。
- `IntegrationFieldDescriptor.multiline`：密钥等多行字段（SSH 私钥）以 textarea 渲染。

### 服务端
- `IntegrationService`：新增 `listByType` / `getById` / `credentialForConnection`，`save/test/delete` 支持按 `connection.id`；单连接类型保留旧 upsert 语义，多连接类型在无 connectionId 时新建行。
- 路由：新增 connection-scoped `PUT/DELETE /integrations/:id/connections/:cid` 与 `test?connectionId=`，保留旧 type-level 路径兼容。
- 新增 `SshDeviceIntegrationProvider`：host/port/username 配置 + 私钥 secret；默认仅私网/回环（`allowPublic` 显式开启可连公网并标高风险）；`testConnection` 做 TCP + SSH banner 探测，不发凭据。注册进内置 registry。
- **注**：M1 为连接管理与可达性测试；完整登录/命令执行（ssh2）与角色两级授权在 M2 里程碑。

### Web
- 顶栏在「模型中心」之后新增「连接中心」入口（`ConnectionHubLauncher`）。
- `ConnectionHubDialog` 弹窗复用抽取出的 `IntegrationSettingsPanel`；该面板同时被 Settings → 外部连接 使用（合并入口）。
- 多连接类型渲染连接列表 + 添加/编辑/删除/测试；secret 多行 textarea；连接名称即设备名。
- 12 语言文案。

## 验证

- 单测：多连接 CRUD（两条设备凭据互相独立、编辑不串扰、删除只删目标）、SSH config 私网默认/公网 opt-in、banner 可达/非 SSH 不可达。
- E2E：从顶栏打开连接中心 → 添加 SSH 设备 → 三视口截图、console 干净。
- `npx tsc -b` + 603 个 web/服务端测试通过。
