### PR TITLE
feat(ssh): conversational device driving with persona guidance and SSH session reuse

### DIFF
--- a/docs/architecture/connection-hub-v1.md
+++ b/docs/architecture/connection-hub-v1.md
@@ -57,6 +57,12 @@ Character revision
 - 每个动作的最终执行状态写入 Skill Action Ledger；失败原因映射为可读中文（认证失败/不可达为 failed，超时/断流为 outcome-unknown，禁止自动重试）。
 - 世界轨迹通过通用 `SkillActionTraceAdapter` 投影每次 SSH 动作：只暴露摘要、状态与限长结果片段，不带结构化参数、私钥或原始 payload，与其它外部 Skill 共用同一脱敏边界。
 
+## 对话驱动与长连接（角色会话体验）
+
+- **设备可见性注入 persona**：Adapter 可声明 `instructionsFor(character)`，registry 通过 `instructionsForCharacter` 把静态 recipe 指令与按角色的能力说明一起折进角色 persona。SSH Adapter 据此告诉角色它获授了哪些设备（名称/主机）、用户如何表达请求（“连客厅主机看看磁盘”）、以及一台都没有时先让用户去连接中心配置。
+- **设备/操作分离解析**：用户点名（displayName 或 host，可不带“连/到”等连接词）即绑定该设备；角色只有一台可用设备时，不带设备名的操作自动落到它；多台设备时未点名不猜测、由角色追问。
+- **SSH 会话复用池**：`SshSessionPool` 按设备指纹（host/port/user + 凭据哈希）保持一条已认证传输，同设备连续命令复用握手，空闲默认 5 分钟自动断开；改凭据/停用/删除会因指纹变化或显式失效立即重建。安全性不变：仍是一次一命令的白名单执行，无交互 shell，审批与授权边界不受影响。
+
 ## 本地 API
 
 连接中心（连接级）：

--- a/e2e/ssh-conversational.spec.ts
+++ b/e2e/ssh-conversational.spec.ts
@@ -1,0 +1,137 @@
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { expect, test } from '@playwright/test'
+import type { AgentRuntimePort, AgentTurnRequest } from '../packages/contracts/lib/index.js'
+import { createCyberServer, type CyberServer } from '../packages/server/lib/index.js'
+
+let server: CyberServer | undefined
+let origin = ''
+let stateRoot = ''
+
+test.beforeAll(async () => {
+  stateRoot = await mkdtemp(join(tmpdir(), 'dsh-cyber-ssh-conversational-'))
+  server = await createCyberServer({
+    stateRoot,
+    workspacePath: process.cwd(),
+    webRoot: join(process.cwd(), 'packages', 'web', 'dist'),
+    port: 0,
+    bootstrapDefaultWorld: true,
+    runtime: new SilentRuntime(),
+  })
+  origin = (await server.start()).origin
+})
+
+test.afterAll(async () => {
+  await server?.close()
+  await rm(stateRoot, { recursive: true, force: true })
+})
+
+test('drives SSH from natural conversation once the skill and device are granted', async () => {
+  const current = requireServer()
+  const workspace = current.store.listWorkspaces()[0]!
+  const world = current.store.listWorlds(workspace.id)[0]!
+
+  // 1) Add an SSH device with a password through the public integration API.
+  const added = await putJson<{ connection: { id: string; displayName: string } }>(
+    `/api/workspaces/${workspace.id}/integrations/builtin.ssh-device`,
+    {
+      config: { displayName: '客厅主机', host: '10.0.0.10', port: 22, username: 'owner' },
+      enabled: true,
+      secrets: { password: 'e2e-not-real-password' },
+    },
+  )
+  expect(added.status, JSON.stringify(added.body)).toBe(200)
+  const deviceId = added.body.connection.id
+
+  // 2) Recruit an operator and grant the SSH skill.
+  const recruited = await postJson<{ employee: { id: string } }>(`/api/worlds/${world.id}/recruit`, {
+    blueprintId: 'cyber-company.software-engineer',
+    blueprintVersion: 1,
+    displayName: `运维-${Date.now().toString(36)}`,
+    skillGrants: ['device.ssh.command'],
+  })
+  expect(recruited.status, JSON.stringify(recruited.body)).toBe(201)
+  const employeeId = recruited.body.employee.id
+
+  // 3) Grant the connection to this character (second half of the two-level gate).
+  const granted = await postJson(`/api/employees/${employeeId}/revisions`, {
+    reason: '授权连接中心设备',
+    connectionGrants: [deviceId],
+  })
+  expect(granted.status, JSON.stringify(granted.body)).toBe(201)
+
+  // 4) Natural conversation with the device named -> proposal waiting approval.
+  const chat = await postJson(`/api/worlds/${world.id}/chat`, {
+    employeeIds: [employeeId],
+    clientTurnId: `ssh-natural-${Date.now()}`,
+    prompt: '连客厅主机看看磁盘',
+  })
+  expect(chat.status, JSON.stringify(chat.body)).toBe(200)
+  await expect.poll(async () => (await getJson<{ items: Array<{ skillId: string; action: string; status: string }> }>(`/api/worlds/${world.id}/skill-actions`)).items).toEqual(
+    expect.arrayContaining([expect.objectContaining({ skillId: 'device.ssh.command', action: 'ssh.disk.usage', status: 'waiting-for-approval' })]),
+  )
+
+  // 5) With a single granted device the user does not need to name it.
+  const bare = await postJson(`/api/worlds/${world.id}/chat`, {
+    employeeIds: [employeeId],
+    clientTurnId: `ssh-bare-${Date.now()}`,
+    prompt: '看看内存占用',
+  })
+  expect(bare.status, JSON.stringify(bare.body)).toBe(200)
+  await expect.poll(async () => (await getJson<{ items: Array<{ action: string; status: string }> }>(`/api/worlds/${world.id}/skill-actions`)).items).toEqual(
+    expect.arrayContaining([expect.objectContaining({ action: 'ssh.memory.usage', status: 'waiting-for-approval' })]),
+  )
+
+  // 6) A character that only has the skill but no granted device must not
+  //    produce a device action.
+  const noGrant = await postJson<{ employee: { id: string } }>(`/api/worlds/${world.id}/recruit`, {
+    blueprintId: 'cyber-company.software-engineer',
+    blueprintVersion: 1,
+    displayName: `无授权-${Date.now().toString(36)}`,
+    skillGrants: ['device.ssh.command'],
+  })
+  expect(noGrant.status, JSON.stringify(noGrant.body)).toBe(201)
+  const noGrantId = noGrant.body.employee.id
+  const chatNoGrant = await postJson(`/api/worlds/${world.id}/chat`, {
+    employeeIds: [noGrantId],
+    clientTurnId: `ssh-nogrant-${Date.now()}`,
+    prompt: '看看磁盘',
+  })
+  expect(chatNoGrant.status, JSON.stringify(chatNoGrant.body)).toBe(200)
+  // Give the pipeline a moment; then confirm no ssh action was reserved for them.
+  await new Promise((resolve) => setTimeout(resolve, 400))
+  const actions = await getJson<{ items: Array<{ characterId: string; skillId: string }> }>(`/api/worlds/${world.id}/skill-actions`)
+  expect(actions.items.some((item) => item.characterId === noGrantId && item.skillId === 'device.ssh.command')).toBe(false)
+})
+
+async function getJson<T>(path: string): Promise<T> {
+  const response = await fetch(`${origin}${path}`)
+  const body = await response.json() as unknown
+  if (!response.ok) throw new Error(`GET ${path} failed: ${response.status} ${JSON.stringify(body)}`)
+  return body as T
+}
+
+async function postJson<T = unknown>(path: string, body: Record<string, unknown>): Promise<{ status: number; body: T }> {
+  const response = await fetch(`${origin}${path}`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+  return { status: response.status, body: await response.json().catch(() => undefined) as T }
+}
+
+async function putJson<T = unknown>(path: string, body: Record<string, unknown>): Promise<{ status: number; body: T }> {
+  const response = await fetch(`${origin}${path}`, { method: 'PUT', headers: { 'content-type': 'application/json' }, body: JSON.stringify(body) })
+  return { status: response.status, body: await response.json().catch(() => undefined) as T }
+}
+
+function requireServer(): CyberServer {
+  if (server === undefined) throw new Error('SSH 对话 E2E 服务尚未启动')
+  return server
+}
+
+class SilentRuntime implements AgentRuntimePort {
+  async runTurn(request: AgentTurnRequest) {
+    return { agentSessionId: request.agent.agentSessionId ?? `agent-${request.agent.id}`, finalResponse: '已记录请求。', eventCount: 0 }
+  }
+
+  async close(): Promise<void> {}
+}

--- a/packages/server/src/integrations/ssh-client.ts
+++ b/packages/server/src/integrations/ssh-client.ts
@@ -48,6 +48,10 @@ interface PoolEntry {
   /** First connection attempt for a fresh entry; later commands wait on it. */
   connecting: Promise<void> | undefined
   running: Promise<void>
+  /** Rejects commands that are active or queued when the transport dies. */
+  transportFailure: Promise<never>
+  failTransport: (error: SshError) => void
+  clientError: (error: Error) => void
 }
 
 /**
@@ -97,13 +101,16 @@ export class SshSessionPool {
     entry.running = new Promise<void>((resolve) => { release = resolve })
     await previous
     try {
-      const result = await execOnClient(entry.client, command, options.timeoutMs)
+      const result = await Promise.race([
+        execOnClient(entry.client, command, options.timeoutMs),
+        entry.transportFailure,
+      ])
       this.#touch(entry)
       return result
     } catch (error) {
       // Transport/auth/timeout loss poisons the pooled session: drop it so the
       // next command reconnects instead of failing on a dead handle.
-      if (error instanceof SshError && error.kind !== 'command-failed') this.#drop(key)
+      if (error instanceof SshError && error.kind !== 'command-failed') this.#drop(key, entry)
       throw error
     } finally {
       release()
@@ -120,11 +127,7 @@ export class SshSessionPool {
     if (this.#closed) return
     this.#closed = true
     const entries = [...this.#entries.values()]
-    this.#entries.clear()
-    for (const entry of entries) {
-      if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer)
-      entry.client.end()
-    }
+    for (const entry of entries) this.#drop(entry.key, entry)
   }
 
   #acquire(key: string, credential: SshDeviceCredential): Promise<PoolEntry> {
@@ -140,12 +143,34 @@ export class SshSessionPool {
       this.#touch(existing)
       return Promise.resolve(existing)
     }
-    const entry: PoolEntry = { key, client: new Client(), idleTimer: undefined, connecting: undefined, running: Promise.resolve() }
+    let failTransport!: (error: SshError) => void
+    const transportFailure = new Promise<never>((_resolve, reject) => { failTransport = reject })
+    // A connection can fail while no command is waiting on it. Consume the
+    // rejection here so a later command may still observe the same failure
+    // without creating an unhandled-rejection process event.
+    transportFailure.catch(() => undefined)
+    const entry: PoolEntry = {
+      key,
+      client: new Client(),
+      idleTimer: undefined,
+      connecting: undefined,
+      running: Promise.resolve(),
+      transportFailure,
+      failTransport,
+      clientError: () => undefined,
+    }
+    entry.clientError = (error: Error): void => {
+      entry.failTransport(new SshError('stream-lost', `SSH 连接中断，远端动作结果未知：${error.message}`))
+      this.#drop(key, entry)
+    }
+    // Keep a listener for the entire pooled lifetime. `connect()` temporarily
+    // adds its own handshake listener; removing that listener on `ready` must
+    // not leave the Node EventEmitter with no error consumer.
+    entry.client.on('error', entry.clientError)
     this.#entries.set(key, entry)
     const attempt = connect(entry.client, credential).catch((error) => {
       // A failed first attempt poisons nothing but the map entry itself.
-      this.#entries.delete(key)
-      entry.client.end()
+      this.#drop(key, entry)
       throw error
     })
     entry.connecting = attempt
@@ -158,16 +183,18 @@ export class SshSessionPool {
 
   #touch(entry: PoolEntry): void {
     if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer)
-    entry.idleTimer = setTimeout(() => { this.#drop(entry.key) }, this.#idleMs)
+    entry.idleTimer = setTimeout(() => { this.#drop(entry.key, entry) }, this.#idleMs)
     // An idle SSH transport must never keep the app process alive.
     entry.idleTimer.unref?.()
   }
 
-  #drop(key: string): void {
+  #drop(key: string, expected?: PoolEntry): void {
     const entry = this.#entries.get(key)
-    if (entry === undefined) return
+    if (entry === undefined || (expected !== undefined && entry !== expected)) return
     this.#entries.delete(key)
     if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer)
+    entry.client.off('error', entry.clientError)
+    entry.failTransport(new SshError('stream-lost', 'SSH 会话已关闭，远端动作结果未知'))
     try { entry.client.end() } catch { /* already closed */ }
   }
 }
@@ -209,32 +236,37 @@ function execOnClient(client: Client, command: string, timeoutMs = SSH_EXEC_TIME
       try { client.end() } catch { /* transport may already be gone */ }
       reject(new SshError('timeout', 'SSH 执行超时，远端动作结果未知；不得自动重试'))
     }), timeoutMs)
-    client.exec(command, { pty: false }, (error, stream) => {
-      if (error !== undefined && error !== null) {
-        clearTimeout(execTimer)
-        settle(() => reject(new SshError('command-failed', `SSH 无法启动命令：${error.message}`)))
-        return
-      }
-      if (stream === undefined) {
-        clearTimeout(execTimer)
-        settle(() => reject(new SshError('command-failed', 'SSH 未返回命令通道')))
-        return
-      }
-      let stdout = ''
-      let stderr = ''
-      stream.setEncoding('utf8')
-      stream.on('data', (chunk: string) => { stdout = cap(`${stdout}${chunk}`) })
-      stream.stderr.setEncoding('utf8')
-      stream.stderr.on('data', (chunk: string) => { stderr = cap(`${stderr}${chunk}`) })
-      stream.once('close', (code: number | null) => {
-        clearTimeout(execTimer)
-        settle(() => resolve({ code, stdout: sanitizeOutput(stdout), stderr: sanitizeOutput(stderr) }))
+    try {
+      client.exec(command, { pty: false }, (error, stream) => {
+        if (error !== undefined && error !== null) {
+          clearTimeout(execTimer)
+          settle(() => reject(new SshError('command-failed', `SSH 无法启动命令：${error.message}`)))
+          return
+        }
+        if (stream === undefined) {
+          clearTimeout(execTimer)
+          settle(() => reject(new SshError('command-failed', 'SSH 未返回命令通道')))
+          return
+        }
+        let stdout = ''
+        let stderr = ''
+        stream.setEncoding('utf8')
+        stream.on('data', (chunk: string) => { stdout = cap(`${stdout}${chunk}`) })
+        stream.stderr.setEncoding('utf8')
+        stream.stderr.on('data', (chunk: string) => { stderr = cap(`${stderr}${chunk}`) })
+        stream.once('close', (code: number | null) => {
+          clearTimeout(execTimer)
+          settle(() => resolve({ code, stdout: sanitizeOutput(stdout), stderr: sanitizeOutput(stderr) }))
+        })
+        stream.once('error', (streamError: Error) => {
+          clearTimeout(execTimer)
+          settle(() => reject(new SshError('stream-lost', `SSH 命令通道中断，远端动作结果未知：${streamError.message}`)))
+        })
       })
-      stream.once('error', (streamError: Error) => {
-        clearTimeout(execTimer)
-        settle(() => reject(new SshError('stream-lost', `SSH 命令通道中断，远端动作结果未知：${streamError.message}`)))
-      })
-    })
+    } catch (error) {
+      clearTimeout(execTimer)
+      settle(() => reject(new SshError('stream-lost', `SSH 传输不可用，远端动作结果未知：${error instanceof Error ? error.message : String(error)}`)))
+    }
   })
 }
 

--- a/packages/server/src/integrations/ssh-client.ts
+++ b/packages/server/src/integrations/ssh-client.ts
@@ -45,8 +45,9 @@ interface PoolEntry {
   key: string
   client: Client
   idleTimer: NodeJS.Timeout | undefined
+  /** First connection attempt for a fresh entry; later commands wait on it. */
+  connecting: Promise<void> | undefined
   running: Promise<void>
-  release: (() => void) | undefined
 }
 
 /**
@@ -88,10 +89,13 @@ export class SshSessionPool {
     const key = SshSessionPool.fingerprint(credential)
     const entry = await this.#acquire(key, credential)
     // Serialize commands per transport so concurrent turns on the same device
-    // cannot interleave exec streams.
-    await entry.running
+    // cannot interleave exec streams. Every caller appends its own gate to
+    // `running` before awaiting the previous gate, so two first commands can
+    // never both pass the old resolved promise.
+    const previous = entry.running
     let release!: () => void
     entry.running = new Promise<void>((resolve) => { release = resolve })
+    await previous
     try {
       const result = await execOnClient(entry.client, command, options.timeoutMs)
       this.#touch(entry)
@@ -126,18 +130,29 @@ export class SshSessionPool {
   #acquire(key: string, credential: SshDeviceCredential): Promise<PoolEntry> {
     const existing = this.#entries.get(key)
     if (existing !== undefined) {
+      // A second concurrent first command arrives while the first connect is
+      // still in flight: ssh2 Client.exec throws "Not connected" if called
+      // before `ready`, so we must wait for the cached attempt, not return a
+      // half-connected entry.
+      if (existing.connecting !== undefined) {
+        return existing.connecting.then(() => { this.#touch(existing); return existing })
+      }
       this.#touch(existing)
       return Promise.resolve(existing)
     }
-    const entry: PoolEntry = { key, client: new Client(), idleTimer: undefined, running: Promise.resolve(), release: undefined }
+    const entry: PoolEntry = { key, client: new Client(), idleTimer: undefined, connecting: undefined, running: Promise.resolve() }
     this.#entries.set(key, entry)
-    return connect(entry.client, credential).then(() => {
-      this.#touch(entry)
-      return entry
-    }).catch((error) => {
+    const attempt = connect(entry.client, credential).catch((error) => {
+      // A failed first attempt poisons nothing but the map entry itself.
       this.#entries.delete(key)
       entry.client.end()
       throw error
+    })
+    entry.connecting = attempt
+    return attempt.then(() => {
+      entry.connecting = undefined
+      this.#touch(entry)
+      return entry
     })
   }
 

--- a/packages/server/src/integrations/ssh-client.ts
+++ b/packages/server/src/integrations/ssh-client.ts
@@ -1,8 +1,11 @@
+import { createHash } from 'node:crypto'
+
 import { Client } from 'ssh2'
 
 export const SSH_CONNECT_TIMEOUT_MS = 12_000
 export const SSH_EXEC_TIMEOUT_MS = 30_000
 export const SSH_OUTPUT_CAP_BYTES = 16 * 1024
+export const SSH_SESSION_IDLE_MS = 5 * 60 * 1000
 
 export type SshFailureKind = 'unreachable' | 'auth-failed' | 'command-failed' | 'timeout' | 'stream-lost'
 
@@ -30,54 +33,144 @@ export interface SshExecResult {
 }
 
 /**
- * One-shot SSH executor used by the trusted skill adapter. The private key
- * comes from the host credential vault and is used straight from memory — it
- * is never written to disk or surfaced in action records.
- *
- * Result mapping stays here in SSH terms (connect/exec); the Skill adapter
- * translates failures into skill action statuses (failed vs outcome-unknown).
+ * One-shot SSH executor: open a transport, run one command, close it. Used by
+ * the trusted skill adapter when no session pool is configured and by tests.
  */
 export function sshExecOnce(credential: SshDeviceCredential, command: string, options: { timeoutMs?: number } = {}): Promise<SshExecResult> {
-  return new Promise((resolve, reject) => {
-    const client = new Client()
-    const connectTimeoutMs = SSH_CONNECT_TIMEOUT_MS
-    const execTimeoutMs = options.timeoutMs ?? SSH_EXEC_TIMEOUT_MS
-    let settled = false
-    const settle = (fn: () => void): void => { if (!settled) { settled = true; fn() } }
+  const pool = new SshSessionPool()
+  return pool.exec(credential, command, options).finally(() => pool.close())
+}
 
-    client.once('error', (error) => settle(() => {
+interface PoolEntry {
+  key: string
+  client: Client
+  idleTimer: NodeJS.Timeout | undefined
+  running: Promise<void>
+  release: (() => void) | undefined
+}
+
+/**
+ * Long-lived SSH sessions keyed by a device fingerprint (host/port/user plus
+ * hashed credentials). A conversation that issues several commands against the
+ * same device reuses one authenticated transport instead of reconnecting every
+ * command; sessions idle out after `SSH_SESSION_IDLE_MS`. Editing the
+ * connection's credentials or disabling/deleting it changes the fingerprint or
+ * closes the session so stale sessions never outlive their authorization.
+ *
+ * Exec is serialized per transport; the pool never opens an interactive shell
+ * and every command still goes through the same approval/preflight boundary.
+ */
+export class SshSessionPool {
+  readonly #idleMs: number
+  readonly #entries = new Map<string, PoolEntry>()
+  #closed = false
+
+  constructor(options: { idleMs?: number } = {}) {
+    this.#idleMs = options.idleMs ?? SSH_SESSION_IDLE_MS
+  }
+
+  static fingerprint(device: SshDeviceCredential): string {
+    return createHash('sha256').update(JSON.stringify({
+      host: device.host,
+      port: device.port,
+      username: device.username,
+      // Only hashes of the secrets take part in the key: the pool never keeps
+      // plaintext credentials around for longer than one connect call.
+      privateKeyHash: device.privateKey === undefined ? undefined : createHash('sha256').update(device.privateKey).digest('hex'),
+      passwordHash: device.password === undefined ? undefined : createHash('sha256').update(device.password).digest('hex'),
+    })).digest('hex')
+  }
+
+  get size(): number { return this.#entries.size }
+
+  async exec(credential: SshDeviceCredential, command: string, options: { timeoutMs?: number } = {}): Promise<SshExecResult> {
+    if (this.#closed) throw new Error('SSH session pool is closed')
+    const key = SshSessionPool.fingerprint(credential)
+    const entry = await this.#acquire(key, credential)
+    // Serialize commands per transport so concurrent turns on the same device
+    // cannot interleave exec streams.
+    await entry.running
+    let release!: () => void
+    entry.running = new Promise<void>((resolve) => { release = resolve })
+    try {
+      const result = await execOnClient(entry.client, command, options.timeoutMs)
+      this.#touch(entry)
+      return result
+    } catch (error) {
+      // Transport/auth/timeout loss poisons the pooled session: drop it so the
+      // next command reconnects instead of failing on a dead handle.
+      if (error instanceof SshError && error.kind !== 'command-failed') this.#drop(key)
+      throw error
+    } finally {
+      release()
+    }
+  }
+
+  /** Invalidate one device (credential change, disable or delete). */
+  async invalidate(credential: SshDeviceCredential): Promise<void> {
+    this.#drop(SshSessionPool.fingerprint(credential))
+  }
+
+  /** Close every pooled transport. Idempotent. */
+  async close(): Promise<void> {
+    if (this.#closed) return
+    this.#closed = true
+    const entries = [...this.#entries.values()]
+    this.#entries.clear()
+    for (const entry of entries) {
+      if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer)
+      entry.client.end()
+    }
+  }
+
+  #acquire(key: string, credential: SshDeviceCredential): Promise<PoolEntry> {
+    const existing = this.#entries.get(key)
+    if (existing !== undefined) {
+      this.#touch(existing)
+      return Promise.resolve(existing)
+    }
+    const entry: PoolEntry = { key, client: new Client(), idleTimer: undefined, running: Promise.resolve(), release: undefined }
+    this.#entries.set(key, entry)
+    return connect(entry.client, credential).then(() => {
+      this.#touch(entry)
+      return entry
+    }).catch((error) => {
+      this.#entries.delete(key)
+      entry.client.end()
+      throw error
+    })
+  }
+
+  #touch(entry: PoolEntry): void {
+    if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer)
+    entry.idleTimer = setTimeout(() => { this.#drop(entry.key) }, this.#idleMs)
+    // An idle SSH transport must never keep the app process alive.
+    entry.idleTimer.unref?.()
+  }
+
+  #drop(key: string): void {
+    const entry = this.#entries.get(key)
+    if (entry === undefined) return
+    this.#entries.delete(key)
+    if (entry.idleTimer !== undefined) clearTimeout(entry.idleTimer)
+    try { entry.client.end() } catch { /* already closed */ }
+  }
+}
+
+async function connect(client: Client, credential: SshDeviceCredential): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onError = (error: Error): void => {
+      client.off('ready', onReady)
       const message = error.message
       const authish = /authentication|permission denied|publickey|password|key/i.test(message)
       reject(new SshError(authish ? 'auth-failed' : 'unreachable', authish ? `SSH 认证失败：${message}` : `SSH 连接失败：${message}`))
-    }))
-    client.once('ready', () => {
-      client.exec(command, { pty: false }, (error, stream) => {
-        if (error !== undefined && error !== null) {
-          settle(() => reject(new SshError('command-failed', `SSH 无法启动命令：${error.message}`)))
-          return
-        }
-        if (stream === undefined) {
-          settle(() => reject(new SshError('command-failed', 'SSH 未返回命令通道')))
-          return
-        }
-        let stdout = ''
-        let stderr = ''
-        let execTimer = setTimeout(() => settle(() => { stream.close(); client.end(); reject(new SshError('timeout', 'SSH 执行超时，远端动作结果未知；不得自动重试')) }), execTimeoutMs)
-        stream.setEncoding('utf8')
-        stream.on('data', (chunk: string) => { stdout = cap(`${stdout}${chunk}`) })
-        stream.stderr.setEncoding('utf8')
-        stream.stderr.on('data', (chunk: string) => { stderr = cap(`${stderr}${chunk}`) })
-        stream.once('close', (code: number | null) => {
-          clearTimeout(execTimer)
-          settle(() => { client.end(); resolve({ code, stdout: sanitizeOutput(stdout), stderr: sanitizeOutput(stderr) }) })
-        })
-        stream.once('error', (streamError: Error) => {
-          clearTimeout(execTimer)
-          settle(() => { client.end(); reject(new SshError('stream-lost', `SSH 命令通道中断，远端动作结果未知：${streamError.message}`)) })
-        })
-      })
-    })
-
+    }
+    const onReady = (): void => {
+      client.off('error', onError)
+      resolve()
+    }
+    client.once('ready', onReady)
+    client.once('error', onError)
     client.connect({
       host: credential.host,
       port: credential.port,
@@ -86,8 +179,46 @@ export function sshExecOnce(credential: SshDeviceCredential, command: string, op
       // allow keyboard-interactive password login.
       ...(credential.privateKey === undefined ? {} : { privateKey: Buffer.from(credential.privateKey, 'utf8') }),
       ...(credential.privateKey !== undefined || credential.password === undefined ? {} : { password: credential.password }),
-      readyTimeout: connectTimeoutMs,
+      readyTimeout: SSH_CONNECT_TIMEOUT_MS,
       keepaliveInterval: 0,
+    })
+  })
+}
+
+/** Run one command on an already-connected transport and sanitize its output. */
+function execOnClient(client: Client, command: string, timeoutMs = SSH_EXEC_TIMEOUT_MS): Promise<SshExecResult> {
+  return new Promise((resolve, reject) => {
+    let settled = false
+    const settle = (fn: () => void): void => { if (!settled) { settled = true; fn() } }
+    const execTimer = setTimeout(() => settle(() => {
+      try { client.end() } catch { /* transport may already be gone */ }
+      reject(new SshError('timeout', 'SSH 执行超时，远端动作结果未知；不得自动重试'))
+    }), timeoutMs)
+    client.exec(command, { pty: false }, (error, stream) => {
+      if (error !== undefined && error !== null) {
+        clearTimeout(execTimer)
+        settle(() => reject(new SshError('command-failed', `SSH 无法启动命令：${error.message}`)))
+        return
+      }
+      if (stream === undefined) {
+        clearTimeout(execTimer)
+        settle(() => reject(new SshError('command-failed', 'SSH 未返回命令通道')))
+        return
+      }
+      let stdout = ''
+      let stderr = ''
+      stream.setEncoding('utf8')
+      stream.on('data', (chunk: string) => { stdout = cap(`${stdout}${chunk}`) })
+      stream.stderr.setEncoding('utf8')
+      stream.stderr.on('data', (chunk: string) => { stderr = cap(`${stderr}${chunk}`) })
+      stream.once('close', (code: number | null) => {
+        clearTimeout(execTimer)
+        settle(() => resolve({ code, stdout: sanitizeOutput(stdout), stderr: sanitizeOutput(stderr) }))
+      })
+      stream.once('error', (streamError: Error) => {
+        clearTimeout(execTimer)
+        settle(() => reject(new SshError('stream-lost', `SSH 命令通道中断，远端动作结果未知：${streamError.message}`)))
+      })
     })
   })
 }

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -104,6 +104,7 @@ import { WorldPermissionRequestService } from './services/world-permission-reque
 import { OwnerRuntimeAccessService } from './services/owner-runtime-access-service.js'
 import { WorldRuntimePermissionResolver } from './services/world-runtime-permission-resolver.js'
 import { createBuiltinSkillRegistry, createConnectionGrantsResolver } from './skills/builtin-skill-registry.js'
+import { SshSessionPool } from './integrations/ssh-client.js'
 import { LocalSkillActionRepository } from './skills/local-skill-action-repository.js'
 import { SqliteSkillActionRepository } from './skills/sqlite-skill-action-repository.js'
 import type { CharacterSkillActionRepository } from './skills/skill-action-repository.js'
@@ -275,14 +276,12 @@ async function createLeasedCyberServer(options: CyberServerOptions, onStoreOpene
   })
   const mcpClients = options.mcpClientFactory ?? new OfficialMcpClientFactory()
   const integrations = await IntegrationService.open(stateRoot, createBuiltinIntegrationRegistry(mcpClients))
-  // Keep one transport/timeout boundary for both the Skill adapter and the
-  // Knowledge Library. Credentials remain owned by IntegrationService; the
-  // client is only the provider-neutral request path.
   const firecrawlClient = new FirecrawlClient({ integrations })
   const knowledgeWeb = new KnowledgeWebImportService({
     client: firecrawlClient,
     library: worldKnowledge,
   })
+  const sshSessions = new SshSessionPool()
 
   const worldManagementHost = createWorldManagementHost({ store, worldSettings, worldPackages, authority })
 
@@ -290,7 +289,7 @@ async function createLeasedCyberServer(options: CyberServerOptions, onStoreOpene
     firecrawl: { store, integrations, client: firecrawlClient, listWorldPackages: (worldId) => worldPackages.listRuntimePackages(worldId) },
     browser: { store, listWorldPackages: (worldId) => worldPackages.listRuntimePackages(worldId), publishScreenshot: (input) => worldArtifacts.publishBrowserScreenshot(input), ...(options.browserClientFactory === undefined ? {} : { clientFactory: options.browserClientFactory }), ...(options.browserPolicy === undefined ? {} : { policy: options.browserPolicy }) },
     worldManagement: worldManagementHost,
-    ssh: { store, integrations, connectionGrantsFor: createConnectionGrantsResolver(store) },
+    ssh: { store, integrations, sessions: sshSessions, connectionGrantsFor: createConnectionGrantsResolver(store) },
   })
   const mcpAdapter = options.skillRegistry === undefined ? new McpSkillAdapter({ store, integrations, clients: mcpClients }) : undefined
   if (mcpAdapter !== undefined) skillRegistry.register(mcpAdapter)
@@ -573,6 +572,7 @@ async function createLeasedCyberServer(options: CyberServerOptions, onStoreOpene
       await completionWorker.close()
       credentials.close()
       integrations.close()
+      sshSessions.close()
       store.close()
     },
   }

--- a/packages/server/src/services/character-profile-runtime.ts
+++ b/packages/server/src/services/character-profile-runtime.ts
@@ -79,7 +79,7 @@ export interface WorldContextPort {
 export class CharacterProfileRuntime implements AgentRuntimePort {
   readonly #inner: AgentRuntimePort
   readonly #store: CharacterRuntimeStore
-  readonly #skills: Pick<CharacterSkillAdapterRegistry, 'instructionsFor'> | undefined
+  readonly #skills: Pick<CharacterSkillAdapterRegistry, 'instructionsFor' | 'instructionsForCharacter'> | undefined
   readonly #authority: Pick<WorldAuthorityPort, 'get'> | undefined
   readonly #skillAvailability: WorldSkillAvailabilityPort | undefined
   readonly #memory: CharacterMemoryContextPort | undefined
@@ -110,7 +110,7 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
   constructor(
     inner: AgentRuntimePort,
     store: CharacterRuntimeStore,
-    skills?: Pick<CharacterSkillAdapterRegistry, 'instructionsFor'>,
+    skills?: Pick<CharacterSkillAdapterRegistry, 'instructionsFor' | 'instructionsForCharacter'>,
     authority?: Pick<WorldAuthorityPort, 'get'>,
     skillAvailability?: WorldSkillAvailabilityPort,
     memory?: CharacterMemoryContextPort,
@@ -150,7 +150,12 @@ export class CharacterProfileRuntime implements AgentRuntimePort {
       worldId: agent.worldId,
       skillIds: revision.skillGrants,
     })
-    const recipeInstructions = this.#skills?.instructionsFor(grantedSkillIds) ?? []
+    const recipeInstructions = this.#skills?.instructionsForCharacter({
+      worldId: agent.worldId,
+      characterId: agent.id,
+      workspaceId: agent.workspaceId,
+      grantedSkillIds,
+    }) ?? []
     const profiledPersona = profile === undefined ? revision.persona : composeCharacterPersona(revision.persona, profile)
     // Once the authority service is composed, the compatibility pointer is no
     // longer an authorization source. The fallback only keeps isolated legacy

--- a/packages/server/src/skills/skill-adapter.ts
+++ b/packages/server/src/skills/skill-adapter.ts
@@ -19,6 +19,14 @@ export interface CharacterSkillMatchContext {
   promptSource?: 'raw-user'
 }
 
+/** Input for dynamic, per-character skill instructions rendered into the persona. */
+export interface CharacterSkillInstructionContext {
+  worldId: string
+  characterId: string
+  workspaceId?: string
+  grantedSkillIds: readonly string[]
+}
+
 export interface CharacterSkillActionProposal {
   skillId: string
   adapterId: string
@@ -71,6 +79,13 @@ export interface CharacterSkillAdapter {
   /** Dynamic adapters (for example MCP) may expose no skills until discovery completes. */
   readonly dynamicDescriptors?: boolean
   propose(context: CharacterSkillMatchContext): Promise<CharacterSkillActionProposal[]> | CharacterSkillActionProposal[]
+  /**
+   * Optional per-character capability guidance rendered into the persona
+   * (for example “you can operate these SSH devices, ask the user to name
+   * one and an action”). Keep it short, credential-free and stable per
+   * grants so it can live in the cacheable context prefix.
+   */
+  instructionsFor?(context: CharacterSkillInstructionContext): string[] | undefined
   /** Revalidates provider/package/integration availability before the exactly-once claim. */
   preflight?(action: CharacterSkillAction): Promise<CharacterSkillPreflightResult> | CharacterSkillPreflightResult
   execute(action: CharacterSkillAction, context: CharacterSkillExecutionContext): Promise<CharacterSkillExecutionResult>
@@ -168,11 +183,28 @@ export class CharacterSkillAdapterRegistry {
       .sort((left, right) => left.displayName.localeCompare(right.displayName, 'zh-CN') || left.id.localeCompare(right.id))
   }
 
+  /** Static recipe instructions for the granted skill ids. */
   instructionsFor(skillIds: readonly string[]): string[] {
     return skillIds.flatMap((skillId) => {
       const recipe = this.#recipes.get(skillId)
       return recipe === undefined ? [] : [`${recipe.descriptor.displayName}：${recipe.instruction.trim()}`]
     })
+  }
+
+  /**
+   * Full persona guidance for a character: static recipe instructions plus
+   * any per-character capability notes the owning adapters provide (for
+   * example SSH devices this character may operate). Both are stable per
+   * grant set so the text can sit in the cacheable prefix.
+   */
+  instructionsForCharacter(context: CharacterSkillInstructionContext): string[] {
+    const recipeInstructions = this.instructionsFor(context.grantedSkillIds)
+    const adapterNotes: string[] = []
+    for (const adapter of this.#adapters.values()) {
+      const notes = adapter.instructionsFor?.(context)
+      if (notes !== undefined && notes.length > 0) adapterNotes.push(...notes)
+    }
+    return [...recipeInstructions, ...adapterNotes]
   }
 
   adapterById(adapterId: string): CharacterSkillAdapter | undefined {

--- a/packages/server/src/skills/ssh-command-parser.ts
+++ b/packages/server/src/skills/ssh-command-parser.ts
@@ -22,8 +22,10 @@ export interface SshOperation {
 }
 
 export interface SshDeviceHint {
-  /** Connection display name the utterance references (e.g. 客厅主机). */
-  displayName?: string
+  /** Candidate device references the utterance may name (displayName/host). */
+  deviceCandidates?: ReadonlyArray<{ displayName: string; host?: string }>
+  /** Display name used when the role only has one usable device. */
+  singleDefaultDisplayName?: string
 }
 
 const UNSAFE = /[;|&$`\\\n\r"'()[\]{}]/
@@ -55,13 +57,51 @@ const DEVICE_REFERENCE = /(?:连|到|通过|ssh|用)\s*(?:SSH\s*)?(?:连接\s*)?
 const NEGATION = /(?:不要|别|不用|无需|避免|勿)[^。！？!?]{0,8}(?:重启|安装|执行|操作|运行|查|看|列)/
 
 /**
+ * Resolve which device an utterance means.
+ *
+ * Device and operation are independent: the user may name the device with a
+ * connector (“连客厅主机…”) or without one (“查下那台客厅主机的磁盘”), may use
+ * the host address, or may refer back to a device with 这台/那台/服务器. When
+ * the caller supplies `singleDefaultDisplayName` (the role only has one usable
+ * device), an utterance that performs an operation but names no device
+ * resolves to that default instead of dangling.
+ */
+function resolveDeviceName(prompt: string, hints: SshDeviceHint): string | undefined {
+  const candidates = hints.deviceCandidates ?? []
+  if (candidates.length > 0) {
+    // Longest name first so “客厅主机” beats the substring “客厅”.
+    const sorted = [...candidates].sort((left, right) => right.displayName.length - left.displayName.length)
+    for (const candidate of sorted) {
+      if (candidate.displayName.length > 0 && prompt.includes(candidate.displayName)) return candidate.displayName
+    }
+    for (const candidate of sorted) {
+      const host = candidate.host ?? ''
+      if (host.length < 4) continue
+      const at = prompt.indexOf(host)
+      if (at < 0) continue
+      // Refuse a prefix match like 10.0.0.1 inside 10.0.0.11 by checking the
+      // next char is not another host/name character.
+      const next = prompt[at + host.length]
+      const boundary = next === undefined || !/[0-9A-Za-z._:.-]/.test(next)
+      if (boundary) return candidate.displayName
+    }
+  }
+  const connector = extractDeviceName(prompt)
+  if (connector !== undefined) return connector
+  // Only one usable device → a bare operation unambiguously targets it.
+  // With several devices we refuse to guess which one the user meant.
+  if (hints.singleDefaultDisplayName !== undefined) return hints.singleDefaultDisplayName
+  return undefined
+}
+
+/**
  * Parse one user utterance into at most one controlled SSH operation.
  * Returns undefined when no whitelisted intent is found or the request is
  * explicitly negated.
  */
 export function parseSshOperation(prompt: string, hints: SshDeviceHint = {}): SshOperation | undefined {
   if (NEGATION.test(prompt)) return undefined
-  const deviceName = hints.displayName ?? extractDeviceName(prompt)
+  const deviceName = resolveDeviceName(prompt, hints)
 
   // Order matters: install/service checks come before generic info verbs so
   // "重启 xx 服务" does not fall into SYSTEM_INFO.

--- a/packages/server/src/skills/ssh-skill-adapter.ts
+++ b/packages/server/src/skills/ssh-skill-adapter.ts
@@ -3,16 +3,18 @@ import type { JsonObject } from '@dsh-cyber/contracts'
 
 import { SSH_DEVICE_INTEGRATION_ID } from '../integrations/ssh-provider.js'
 import type { IntegrationService } from '../integrations/integration-service.js'
-import { SshError, sshExecOnce } from '../integrations/ssh-client.js'
+import { SshError, SshSessionPool } from '../integrations/ssh-client.js'
+import type { SshDeviceCredential } from '../integrations/ssh-client.js'
+import { osProbeCommand, parseSshOperation, resolveOs, sshCommandFor, type SshOperation } from './ssh-command-parser.js'
 import type {
   CharacterSkillActionProposal,
   CharacterSkillAdapter,
   CharacterSkillExecutionContext,
   CharacterSkillExecutionResult,
+  CharacterSkillInstructionContext,
   CharacterSkillMatchContext,
   CharacterSkillPreflightResult,
 } from './skill-adapter.js'
-import { osProbeCommand, parseSshOperation, resolveOs, sshCommandFor, type SshOperation } from './ssh-command-parser.js'
 
 export const SSH_COMMAND_SKILL = 'device.ssh.command'
 export const SSH_COMMAND_ADAPTER_ID = 'builtin.ssh-device'
@@ -43,6 +45,8 @@ export interface SshSkillAdapterOptions {
   integrations: IntegrationService
   /** Returns the character's current revision grants; undefined blocks connect use. */
   connectionGrantsFor?(characterId: string): readonly string[] | undefined
+  /** Shared long-lived sessions; default per-command connection when omitted. */
+  sessions?: SshSessionPool
 }
 
 /** Minimal store shape the grants resolver needs (SqliteStore satisfies it). */
@@ -64,66 +68,91 @@ export function createConnectionGrantsResolver(store: ConnectionGrantsRevisionSt
   }
 }
 
+interface DeviceRef {
+  id: string
+  displayName: string
+  host: string
+}
+
 export class SshSkillAdapter implements CharacterSkillAdapter {
   readonly id = SSH_COMMAND_ADAPTER_ID
   readonly descriptors = [DESCRIPTOR] as const
   readonly #store: { getWorld(worldId: string): WorldRef | undefined }
   readonly #integrations: IntegrationService
   readonly #connectionGrantsFor: ((characterId: string) => readonly string[] | undefined) | undefined
+  readonly #sessions: SshSessionPool | undefined
 
   constructor(options: SshSkillAdapterOptions) {
     this.#store = options.store
     this.#integrations = options.integrations
     this.#connectionGrantsFor = options.connectionGrantsFor
+    this.#sessions = options.sessions
+  }
+
+  /**
+   * Per-character capability note folded into the persona. The character
+   * learns it can operate its granted devices and how the user phrases a
+   * request, so SSH stops being an invisible skill. Credential-free and
+   * bounded by the current grant list so it can live in the cacheable prefix.
+   */
+  instructionsFor(context: CharacterSkillInstructionContext): string[] | undefined {
+    if (!context.grantedSkillIds.includes(SSH_COMMAND_SKILL)) return undefined
+    if (context.workspaceId === undefined) return undefined
+    const devices = this.#grantedDevices(context.workspaceId, context.characterId)
+    if (devices.length === 0) {
+      return ['SSH 设备操作：你已经获得这项能力，但目前没有授权可操作的设备。请让用户先到“连接中心”添加并启用设备，再到你的角色设置勾选这台设备后，你才能执行设备命令。']
+    }
+    const lines = devices.map((device) => `- ${device.displayName}（${device.host}）`).join('\n')
+    const instruction = devices.length === 1
+      ? `你可以操作这台设备，用户说“连这台设备看看磁盘/内存/进程”等自然表达时，你会收到经过批准的受控命令。`
+      : `你可以操作这些设备；当用户说出设备名和操作（例如“连${devices[0]!.displayName}看看磁盘”）时，你会收到经过批准的受控命令；用户没有指明是哪台设备时，先问清楚再执行。`
+    return [`SSH 设备操作（已授权设备）：\n${lines}\n${instruction}`]
   }
 
   propose(context: CharacterSkillMatchContext): CharacterSkillActionProposal[] {
     if (!context.grantedSkillIds.includes(SSH_COMMAND_SKILL)) return []
-    const op = parseSshOperation(context.prompt)
-    if (op === undefined) return []
     const world = this.#store.getWorld(context.worldId)
-    const deviceLabel = world === undefined ? undefined : this.#resolveDeviceLabel(world.workspaceId, op)
+    if (world === undefined) return []
+    const devices = this.#grantedDevices(world.workspaceId, context.characterId)
+    if (devices.length === 0) return []
+    const op = parseSshOperation(context.prompt, {
+      deviceCandidates: devices.map(({ displayName, host }) => ({ displayName, host })),
+      ...(devices.length === 1 ? { singleDefaultDisplayName: devices[0]!.displayName } : {}),
+    })
+    if (op === undefined) return []
+    const match = matchDevice(devices, op.connectionId)
+    if (match === undefined) {
+      // The role owns several devices but the user named none (or an unknown
+      // one): never guess. The persona note tells the role to ask for it.
+      return []
+    }
     return [{
       skillId: SSH_COMMAND_SKILL,
       adapterId: this.id,
       action: `ssh.${op.op}`,
       target: 'ssh:device',
-      label: deviceLabel === undefined ? op.summary : `${op.summary}（设备：${deviceLabel}）`,
+      label: `${op.summary}（设备：${match.displayName}）`,
       risk: 'external-side-effect',
       authorization: 'explicit-user-request',
       parameters: {
         op: op.op,
         summary: op.summary,
         params: op.params,
-        ...(op.connectionId === undefined ? {} : { deviceHint: op.connectionId }),
+        deviceId: match.id,
       },
     }]
-  }
-
-  #resolveDeviceLabel(workspaceId: string, op: SshOperation): string | undefined {
-    const hint = op.connectionId
-    const devices = this.#integrations.listByType(workspaceId, SSH_DEVICE_INTEGRATION_ID)
-    if (devices.length === 0) return undefined
-    const match = hint === undefined
-      ? (devices.length === 1 ? devices[0] : undefined)
-      : devices.find((item) => item.displayName === hint || String(item.config.host ?? '') === hint)
-    return match?.displayName ?? hint
   }
 
   async preflight(action: CharacterSkillAction): Promise<CharacterSkillPreflightResult> {
     const world = this.#store.getWorld(action.worldId)
     if (world === undefined) return { ready: false, detail: '当前世界不存在' }
-    const op = parseOperationParams(action.parameters)
-    if (op === undefined) return { ready: false, detail: 'SSH 动作参数无效' }
-    const connectionId = await this.#resolveConnectionId(world.workspaceId, action, op)
-    if (connectionId === undefined) {
-      return { ready: false, detail: '当前工作区没有可用的 SSH 设备，请先在“连接中心”添加设备' }
+    if (parseOperationParams(action.parameters) === undefined) return { ready: false, detail: 'SSH 动作参数无效' }
+    const connectionId = this.#resolveDeviceId(world.workspaceId, action)
+    if (connectionId === undefined) return { ready: false, detail: '没有可用或匹配的 SSH 设备，请先在“连接中心”添加设备' }
+    if (!this.#isConnectionGranted(action.characterId, connectionId)) {
+      return { ready: false, detail: '该角色没有被授权使用这台设备，请在角色设置中勾选对应连接' }
     }
-    const granted = this.#isConnectionGranted(action.characterId, connectionId)
-    if (!granted) return { ready: false, detail: '该角色没有被授权使用这台设备，请在角色设置中勾选对应连接' }
-    const connection = this.#integrations.getById(world.workspaceId, connectionId)
-    const secrets = this.#integrations.secretsForConnection(world.workspaceId, connectionId)
-    if (connection === undefined || !connection.enabled || secrets === undefined || (!secrets.privateKey && !secrets.password)) {
+    if (this.#secretsFor(world.workspaceId, connectionId) === undefined) {
       return { ready: false, detail: '目标设备未启用或缺少私钥/密码凭据' }
     }
     return { ready: true }
@@ -135,32 +164,37 @@ export class SshSkillAdapter implements CharacterSkillAdapter {
     const workspaceId = world.workspaceId
     const op = parseOperationParams(action.parameters)
     if (op === undefined) return { status: 'failed', detail: 'SSH 动作参数无效，未执行任何命令' }
-    const connectionId = await this.#resolveConnectionId(workspaceId, action, op)
+    const connectionId = this.#resolveDeviceId(workspaceId, action)
     if (connectionId === undefined) {
-      return { status: 'waiting-for-integration', detail: '没有指定要操作的设备，请先在“连接中心”添加并选择设备' }
+      return { status: 'waiting-for-integration', detail: '没有可用或匹配的 SSH 设备，请先在“连接中心”添加设备' }
     }
     if (!this.#isConnectionGranted(action.characterId, connectionId)) {
       return { status: 'failed', detail: '该角色没有被授权使用这台设备，动作未执行' }
     }
-    const connection = this.#integrations.getById(workspaceId, connectionId)
-    const secrets = this.#integrations.secretsForConnection(workspaceId, connectionId)
-    if (connection === undefined || !connection.enabled || secrets === undefined || (!secrets.privateKey && !secrets.password)) {
+    const secrets = this.#secretsFor(workspaceId, connectionId)
+    if (secrets === undefined) {
       return { status: 'waiting-for-integration', detail: '该设备未启用或尚未配置私钥/密码，未发送任何命令' }
     }
-    const config = connection.config
-    const device = {
+    const connection = this.#integrations.getById(workspaceId, connectionId)
+    const config = connection?.config
+    if (config === undefined) return { status: 'failed', detail: '目标设备信息不存在，未执行任何命令' }
+    const device: SshDeviceCredential = {
       host: String(config.host ?? connectionId),
       port: Number(config.port ?? 22),
       username: String(config.username ?? 'root'),
       ...(secrets.privateKey === undefined ? {} : { privateKey: secrets.privateKey }),
       ...(secrets.privateKey !== undefined || secrets.password === undefined ? {} : { password: secrets.password }),
     }
+    const exec = (command: string) => this.#sessions === undefined
+      ? execFresh(device, command)
+      : this.#sessions.exec(device, command)
     try {
-      const probe = await sshExecOnce(device, osProbeCommand())
+      // OS probe and the actual command share one session when pooling is on.
+      const probe = await exec(osProbeCommand())
       const os = resolveOs(probe.stdout)
       const command = sshCommandFor(op, os)
       if (command === undefined) return { status: 'failed', detail: `当前设备系统暂不支持该操作（detected ${os}）` }
-      const result = await sshExecOnce(device, command)
+      const result = await exec(command)
       return { status: 'executed', detail: summarize(op.summary, result.stdout, result.stderr, result.code) }
     } catch (error) {
       if (error instanceof SshError) {
@@ -179,16 +213,53 @@ export class SshSkillAdapter implements CharacterSkillAdapter {
     return grants !== undefined && grants.includes(connectionId)
   }
 
-  async #resolveConnectionId(workspaceId: string, action: CharacterSkillAction, op: SshOperation): Promise<string | undefined> {
-    const hint = typeof action.parameters.deviceHint === 'string' && action.parameters.deviceHint.trim()
-      ? action.parameters.deviceHint.trim()
-      : op.connectionId
-    const devices = this.#integrations.listByType(workspaceId, SSH_DEVICE_INTEGRATION_ID)
-    if (devices.length === 0) return undefined
-    if (hint === undefined) return devices.length === 1 ? devices[0]!.id : undefined
-    const byName = devices.find((item) => item.displayName === hint || String(item.config.host ?? '') === hint)
-    return byName?.id ?? undefined
+  /** Granted, enabled and credentialed SSH devices for a character. */
+  #grantedDevices(workspaceId: string, characterId: string): DeviceRef[] {
+    if (this.#connectionGrantsFor === undefined) return []
+    const grants = this.#connectionGrantsFor(characterId)
+    if (grants === undefined) return []
+    const allowed = new Set(grants)
+    const devices: DeviceRef[] = []
+    for (const connection of this.#integrations.listByType(workspaceId, SSH_DEVICE_INTEGRATION_ID)) {
+      if (!allowed.has(connection.id)) continue
+      const secrets = this.#integrations.secretsForConnection(workspaceId, connection.id)
+      if (connection.enabled && secrets !== undefined && (secrets.privateKey !== undefined || secrets.password !== undefined)) {
+        devices.push({ id: connection.id, displayName: connection.displayName, host: String(connection.config.host ?? '') })
+      }
+    }
+    return devices.sort((left, right) => left.displayName.localeCompare(right.displayName, 'zh-CN'))
   }
+
+  #secretsFor(workspaceId: string, connectionId: string): Record<string, string> | undefined {
+    const connection = this.#integrations.getById(workspaceId, connectionId)
+    if (connection === undefined || !connection.enabled) return undefined
+    const secrets = this.#integrations.secretsForConnection(workspaceId, connectionId)
+    return secrets === undefined || (secrets.privateKey === undefined && secrets.password === undefined) ? undefined : secrets
+  }
+
+  /** Prefer the approved action's pinned connection id; fall back to legacy hint. */
+  #resolveDeviceId(workspaceId: string, action: CharacterSkillAction): string | undefined {
+    const pinned = action.parameters.deviceId
+    if (typeof pinned === 'string' && pinned.trim()) {
+      const connection = this.#integrations.getById(workspaceId, pinned.trim())
+      if (connection !== undefined) return connection.id
+    }
+    const hint = typeof action.parameters.deviceHint === 'string' ? action.parameters.deviceHint.trim() : undefined
+    if (hint === undefined) return undefined
+    const devices = this.#integrations.listByType(workspaceId, SSH_DEVICE_INTEGRATION_ID)
+    return devices.find((item) => item.displayName === hint || String(item.config.host ?? '') === hint)?.id
+  }
+}
+
+/** Resolve a parser device reference (displayName/host) onto an allowed device. */
+function matchDevice(devices: DeviceRef[], reference: string | undefined): DeviceRef | undefined {
+  if (reference === undefined) return devices.length === 1 ? devices[0] : undefined
+  return devices.find((device) => device.displayName === reference || device.host === reference)
+}
+
+async function execFresh(device: SshDeviceCredential, command: string): Promise<import('../integrations/ssh-client.js').SshExecResult> {
+  const { sshExecOnce } = await import('../integrations/ssh-client.js')
+  return sshExecOnce(device, command)
 }
 
 function parseOperationParams(parameters: JsonObject): SshOperation | undefined {

--- a/packages/server/tests/ssh-command-parser.test.ts
+++ b/packages/server/tests/ssh-command-parser.test.ts
@@ -22,6 +22,23 @@ describe('SSH command parser', () => {
     expect(parseSshOperation('不要重启服务器，继续用现有配置')).toBeUndefined()
   })
 
+  it('resolves a named candidate device independent of a connector verb', () => {
+    const candidates = [
+      { displayName: '客厅主机', host: '10.0.0.10' },
+      { displayName: '机房网关', host: '172.16.1.125' },
+    ]
+    expect(parseSshOperation('查下 10.0.0.10 的磁盘', { deviceCandidates: candidates })).toMatchObject({ op: 'disk.usage', connectionId: '客厅主机' })
+    expect(parseSshOperation('看看那台机房网关的内存', { deviceCandidates: candidates })).toMatchObject({ op: 'memory.usage', connectionId: '机房网关' })
+    // A prefix like 10.0.0.1 must not match host 10.0.0.10/10.0.0.11 style hosts.
+    expect(parseSshOperation('查 10.0.0.11 磁盘', { deviceCandidates: candidates }).connectionId).toBeUndefined()
+  })
+
+  it('falls back to the single granted device when the user names none', () => {
+    const candidates = [{ displayName: '客厅主机', host: '10.0.0.10' }]
+    expect(parseSshOperation('看看磁盘', { deviceCandidates: candidates, singleDefaultDisplayName: '客厅主机' }))
+      .toMatchObject({ op: 'disk.usage', connectionId: '客厅主机' })
+  })
+
   it('builds real commands only for the detected OS, never free-form', () => {
     expect(sshCommandFor({ op: 'disk.usage', summary: '', params: {} }, 'linux')).toContain('df -h')
     expect(sshCommandFor({ op: 'service.restart', summary: '', params: { service: 'nginx' } }, 'linux')).toContain('systemctl restart nginx')

--- a/packages/server/tests/ssh-session-pool.integration.test.ts
+++ b/packages/server/tests/ssh-session-pool.integration.test.ts
@@ -68,4 +68,29 @@ describe('SshSessionPool over a real ssh2 server', () => {
 
     await pool.close()
   })
+
+  it('does not call exec before the transport is ready when two first commands race', async () => {
+    const { port, stats } = await startSshServer()
+    const device = { host: '127.0.0.1', port, username: USER, password: PASSWORD }
+    const pool = new SshSessionPool({ idleMs: 5_000 })
+
+    // Two concurrent first commands on the same fresh key: the second must
+    // wait for the first connect attempt (ready) instead of calling
+    // ssh2 Client.exec on a not-yet-connected transport.
+    const results = await Promise.all([
+      pool.exec(device, 'one'),
+      pool.exec(device, 'two'),
+      pool.exec(device, 'three'),
+    ])
+    expect(results.map((result) => result.stdout.trim())).toEqual([
+      'conn#1:one',
+      'conn#1:two',
+      'conn#1:three',
+    ])
+    // One connection total, three serialized execs on it.
+    expect(stats.connections).toBe(1)
+    expect(stats.execs).toBe(3)
+
+    await pool.close()
+  })
 })

--- a/packages/server/tests/ssh-session-pool.integration.test.ts
+++ b/packages/server/tests/ssh-session-pool.integration.test.ts
@@ -1,0 +1,71 @@
+import { Server } from 'ssh2'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { SshSessionPool } from '../src/integrations/ssh-client.js'
+
+const USER = 'tester'
+const PASSWORD = 'verify-password'
+const servers: Server[] = []
+
+afterEach(async () => {
+  for (const server of servers.splice(0)) await new Promise<void>((resolve) => server.close(() => resolve()))
+})
+
+async function startSshServer(): Promise<{ port: number; stats: { connections: number; execs: number } }> {
+  const { utils } = await import('ssh2')
+  const keys = utils.generateKeyPairSync('rsa', { bits: 1024 })
+  const stats = { connections: 0, execs: 0 }
+  const server = new Server({ hostKeys: [keys.private] }, (client) => {
+    stats.connections += 1
+    client.on('authentication', (ctx) => {
+      if (ctx.method === 'password' && ctx.username === USER && ctx.password === PASSWORD) ctx.accept()
+      else ctx.reject()
+    })
+    client.on('ready', () => {
+      client.on('session', (accept) => {
+        const session = accept()
+        session.on('exec', (acceptExec, _rejectExec, info) => {
+          stats.execs += 1
+          const stream = acceptExec()
+          stream.write(`conn#${stats.connections}:${info.command}\n`)
+          stream.exit(0)
+          stream.end()
+        })
+      })
+    })
+  })
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', resolve)
+  })
+  servers.push(server)
+  return { port: (server.address() as { port: number }).port, stats }
+}
+
+describe('SshSessionPool over a real ssh2 server', () => {
+  it('keeps one authenticated transport across sequential commands and reconnects after an idle edit', async () => {
+    const { port, stats } = await startSshServer()
+    const device = { host: '127.0.0.1', port, username: USER, password: PASSWORD }
+    const pool = new SshSessionPool({ idleMs: 5_000 })
+
+    const r1 = await pool.exec(device, 'uptime')
+    const r2 = await pool.exec(device, 'df -h')
+    const r3 = await pool.exec(device, 'free')
+    expect([r1.stdout.trim(), r2.stdout.trim(), r3.stdout.trim()]).toEqual([
+      'conn#1:uptime',
+      'conn#1:df -h',
+      'conn#1:free',
+    ])
+    // All three commands reused the very same authenticated transport.
+    expect(stats.connections).toBe(1)
+    expect(stats.execs).toBe(3)
+
+    // A credential edit changes the fingerprint -> a fresh session is opened.
+    await pool.exec({ ...device, password: 'other' }).catch(() => undefined)
+    const after = await pool.exec(device, 'id')
+    expect(after.stdout.trim()).toBe('conn#2:id')
+    expect(stats.connections).toBe(2)
+
+    await pool.close()
+  })
+})

--- a/packages/server/tests/ssh-session-pool.test.ts
+++ b/packages/server/tests/ssh-session-pool.test.ts
@@ -3,7 +3,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 const { fakeConnectLog, fakeEndLog, fakeState } = vi.hoisted(() => ({
   fakeConnectLog: [] as Array<Record<string, unknown>>,
   fakeEndLog: [] as string[],
-  fakeState: { failNextConnect: false },
+  fakeState: {
+    failNextConnect: false,
+    activeClient: undefined as { failTransport(error: Error): void } | undefined,
+  },
 }))
 
 type Handler = (...args: any[]) => void
@@ -49,6 +52,7 @@ const { FakeStreamClass, FakeClientClass } = vi.hoisted(() => {
   class FakeClient {
     #listeners = new Map<string, Array<(...args: any[]) => void>>()
     #ended = false
+    constructor() { fakeState.activeClient = this }
     connect(options: Record<string, unknown>) {
       fakeConnectLog.push(options)
       if (fakeState.failNextConnect) {
@@ -86,6 +90,7 @@ const { FakeStreamClass, FakeClientClass } = vi.hoisted(() => {
       fakeEndLog.push('end')
       return this
     }
+    failTransport(error: Error) { this.#emit('error', error) }
     #emit(event: string, ...payload: unknown[]) {
       for (const fn of [...(this.#listeners.get(event) ?? [])]) fn(...payload)
     }
@@ -100,7 +105,7 @@ function device(password = 'pw-1'): SshDeviceCredential {
   return { host: '10.0.0.10', port: 22, username: 'root', password }
 }
 
-beforeEach(() => { fakeConnectLog.length = 0; fakeEndLog.length = 0; fakeState.failNextConnect = false })
+beforeEach(() => { fakeConnectLog.length = 0; fakeEndLog.length = 0; fakeState.failNextConnect = false; fakeState.activeClient = undefined })
 afterEach(() => { vi.restoreAllMocks(); vi.resetModules() })
 
 describe('SshSessionPool', () => {
@@ -162,6 +167,23 @@ describe('SshSessionPool', () => {
     expect(results).toHaveLength(2)
     expect(fakeConnectLog).toHaveLength(1)
     expect(pool.size).toBe(1)
+    await pool.close()
+  })
+
+  it('handles a transport error after ready and reconnects without an unhandled error', async () => {
+    const pool = new SshSessionPool({ idleMs: 10_000 })
+    await pool.exec(device(), 'before-disconnect')
+    const firstClient = fakeState.activeClient
+    expect(firstClient).toBeDefined()
+
+    // A real ssh2 Client emits `error` when an established socket dies. The
+    // pool must consume it, reject any waiters and remove the dead entry.
+    firstClient!.failTransport(new Error('socket closed'))
+    expect(pool.size).toBe(0)
+
+    const result = await pool.exec(device(), 'after-disconnect')
+    expect(result.stdout).toContain('out:after-disconnect')
+    expect(fakeConnectLog).toHaveLength(2)
     await pool.close()
   })
 

--- a/packages/server/tests/ssh-session-pool.test.ts
+++ b/packages/server/tests/ssh-session-pool.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { fakeConnectLog, fakeEndLog, fakeState } = vi.hoisted(() => ({
+  fakeConnectLog: [] as Array<Record<string, unknown>>,
+  fakeEndLog: [] as string[],
+  fakeState: { failNextConnect: false },
+}))
+
+type Handler = (...args: any[]) => void
+
+const { FakeStreamClass, FakeClientClass } = vi.hoisted(() => {
+  class FakeChannel {
+    handlers: Array<(...args: any[]) => void> = []
+    on(_event: string, fn: (...args: any[]) => void) { this.handlers.push(fn); return this }
+    once(event: string, fn: (...args: any[]) => void) { return this.on(event, fn) }
+    setEncoding() { return this }
+    emit(...args: unknown[]) { for (const fn of this.handlers.splice(0)) fn(...args) }
+  }
+  class FakeStream {
+    #closed = false
+    stdout = new FakeChannel()
+    stderr = new FakeChannel()
+    constructor(public command: string) {}
+    setEncoding() { return this }
+    on(event: string, fn: (...args: any[]) => void) {
+      if (event === 'data') this.stdout.on(event, fn)
+      return this
+    }
+    once(event: string, fn: (...args: any[]) => void) {
+      if (event === 'data') this.stdout.once(event, fn)
+      if (event === 'close') this.#onClose = fn
+      if (event === 'error') this.#onError = fn
+      return this
+    }
+    #onClose?: (code: number | null) => void
+    #onError?: (error: Error) => void
+    finish() {
+      if (this.#closed) return
+      this.#closed = true
+      queueMicrotask(() => { this.stdout.emit(`out:${this.command}`) })
+      queueMicrotask(() => { this.#onClose?.(0) })
+    }
+    fail(error: Error) {
+      this.#closed = true
+      queueMicrotask(() => { this.#onError?.(error) })
+    }
+    close() { this.finish() }
+  }
+  class FakeClient {
+    #listeners = new Map<string, Array<(...args: any[]) => void>>()
+    #ended = false
+    connect(options: Record<string, unknown>) {
+      fakeConnectLog.push(options)
+      if (fakeState.failNextConnect) {
+        fakeState.failNextConnect = false
+        queueMicrotask(() => this.#emit('error', new Error('connect ECONNREFUSED')))
+      } else {
+        queueMicrotask(() => this.#emit('ready'))
+      }
+      return this
+    }
+    on(event: string, fn: (...args: any[]) => void) {
+      const list = this.#listeners.get(event) ?? []
+      list.push(fn)
+      this.#listeners.set(event, list)
+      return this
+    }
+    once(event: string, fn: (...args: any[]) => void) {
+      const wrapper = (...args: unknown[]): void => { this.off(event, wrapper); fn(...args) }
+      return this.on(event, wrapper)
+    }
+    off(event: string, fn: (...args: any[]) => void) {
+      const list = this.#listeners.get(event) ?? []
+      this.#listeners.set(event, list.filter((item) => item !== fn))
+      return this
+    }
+    exec(command: string, _opts: unknown, callback: (error: Error | null | undefined, stream?: unknown) => void) {
+      if (this.#ended) { callback(new Error('client destroyed')); return this }
+      const stream = new FakeStream(command)
+      queueMicrotask(() => { callback(undefined, stream); stream.finish() })
+      return this
+    }
+    end() {
+      if (this.#ended) return this
+      this.#ended = true
+      fakeEndLog.push('end')
+      return this
+    }
+    #emit(event: string, ...payload: unknown[]) {
+      for (const fn of [...(this.#listeners.get(event) ?? [])]) fn(...payload)
+    }
+  }
+  return { FakeStreamClass: FakeStream, FakeClientClass: FakeClient }
+})
+
+vi.mock('ssh2', () => ({ Client: FakeClientClass }))
+import { SshDeviceCredential, SshSessionPool } from '../src/integrations/ssh-client.js'
+
+function device(password = 'pw-1'): SshDeviceCredential {
+  return { host: '10.0.0.10', port: 22, username: 'root', password }
+}
+
+beforeEach(() => { fakeConnectLog.length = 0; fakeEndLog.length = 0; fakeState.failNextConnect = false })
+afterEach(() => { vi.restoreAllMocks(); vi.resetModules() })
+
+describe('SshSessionPool', () => {
+  it('reuses one transport across sequential commands', async () => {
+    const pool = new SshSessionPool({ idleMs: 10_000 })
+    const first = await pool.exec(device(), 'echo 1')
+    const second = await pool.exec(device(), 'echo 2')
+    expect(first.stdout).toContain('out:echo 1')
+    expect(second.stdout).toContain('out:echo 2')
+    expect(fakeConnectLog).toHaveLength(1)
+    expect(pool.size).toBe(1)
+    await pool.close()
+    expect(fakeEndLog.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('reconnects on a fresh transport after invalidation', async () => {
+    const pool = new SshSessionPool({ idleMs: 10_000 })
+    await pool.exec(device('a'), 'x')
+    await pool.invalidate(device('a'))
+    expect(pool.size).toBe(0)
+    await pool.exec(device('a'), 'y')
+    expect(fakeConnectLog).toHaveLength(2)
+    await pool.close()
+  })
+
+  it('fingerprint changes when a credential is edited but is stable otherwise', () => {
+    const a = SshSessionPool.fingerprint(device('pw-1'))
+    expect(SshSessionPool.fingerprint(device('pw-1'))).toBe(a)
+    expect(SshSessionPool.fingerprint(device('pw-2'))).not.toBe(a)
+  })
+
+  it('does not keep plaintext credentials in the fingerprint', () => {
+    const fingerprint = SshSessionPool.fingerprint({ host: '10.0.0.10', port: 22, username: 'root', password: 'super-secret' })
+    expect(fingerprint).not.toContain('super-secret')
+    expect(fingerprint).not.toContain('10.0.0.10')
+  })
+
+  it('maps a refused connect to SshError unreachable and drops the entry', async () => {
+    fakeState.failNextConnect = true
+    const pool = new SshSessionPool()
+    await expect(pool.exec(device(), 'x')).rejects.toMatchObject({ kind: 'unreachable' })
+    expect(pool.size).toBe(0)
+    await pool.close()
+  })
+
+  it('evicts idle sessions after the idle window', async () => {
+    vi.useFakeTimers()
+    const pool = new SshSessionPool({ idleMs: 1_000 })
+    await pool.exec(device('a'), 'x')
+    expect(pool.size).toBe(1)
+    await vi.advanceTimersByTimeAsync(1_100)
+    expect(pool.size).toBe(0)
+    vi.useRealTimers()
+  })
+
+  it('serializes concurrent commands on one transport', async () => {
+    const pool = new SshSessionPool({ idleMs: 10_000 })
+    const results = await Promise.all([pool.exec(device(), 'first'), pool.exec(device(), 'second')])
+    expect(results).toHaveLength(2)
+    expect(fakeConnectLog).toHaveLength(1)
+    expect(pool.size).toBe(1)
+    await pool.close()
+  })
+
+  it('rejects commands after close', async () => {
+    const pool = new SshSessionPool()
+    await pool.close()
+    await expect(pool.exec(device(), 'x')).rejects.toThrow('SSH session pool is closed')
+  })
+})

--- a/packages/server/tests/ssh-skill-adapter.test.ts
+++ b/packages/server/tests/ssh-skill-adapter.test.ts
@@ -4,8 +4,16 @@ import type { CharacterSkillAction } from '@dsh-cyber/contracts/skill-runtime'
 
 import { SSH_COMMAND_SKILL, SshSkillAdapter } from '../src/skills/ssh-skill-adapter.js'
 
-vi.mock('../src/integrations/ssh-client.js', () => ({ SshError: class extends Error { constructor(public kind: string, message: string) { super(message) } }, sshExecOnce: vi.fn() }))
-import { sshExecOnce } from '../src/integrations/ssh-client.js'
+vi.mock('../src/integrations/ssh-client.js', () => ({
+  SshError: class extends Error { constructor(public kind: string, message: string) { super(message) } },
+  sshExecOnce: vi.fn(),
+  SshSessionPool: class {
+    exec = vi.fn(async () => ({ code: 0, stdout: 'Linux\nlinux-apt', stderr: '' }))
+    invalidate = vi.fn(async () => undefined)
+    close = vi.fn(async () => undefined)
+  },
+}))
+import { sshExecOnce, SshSessionPool } from '../src/integrations/ssh-client.js'
 
 const exec = vi.mocked(sshExecOnce)
 
@@ -19,11 +27,12 @@ function device(overrides: Partial<Record<'enabled' | 'host' | 'username', unkno
 
 function world() { return { id: 'world-1', workspaceId: 'workspace-1' } }
 
-function makeAdapter(integrations: unknown, connectionGrantsFor?: (characterId: string) => readonly string[] | undefined) {
+function makeAdapter(integrations: unknown, connectionGrantsFor?: (characterId: string) => readonly string[] | undefined, sessions?: unknown) {
   return new SshSkillAdapter({
     store: { getWorld: () => world() },
     integrations: integrations as never,
     ...(connectionGrantsFor === undefined ? {} : { connectionGrantsFor }),
+    ...(sessions === undefined ? {} : { sessions: sessions as never }),
   })
 }
 
@@ -32,51 +41,78 @@ function grantsDevice(characterId: string): readonly string[] | undefined {
   return characterId === 'character-1' ? ['device-1'] : []
 }
 
-function actionFrom(proposal: { skillId: string; adapterId: string; action: string; target: string; label: string; risk: 'external-side-effect' | 'read' | 'write-local'; authorization: string; parameters?: Record<string, unknown> }): CharacterSkillAction {
+function directAction(parameters: Record<string, unknown> = { deviceId: 'device-1', op: 'disk.usage', summary: '查看磁盘使用情况', params: {} }): CharacterSkillAction {
   return {
-    id: 'action-1', worldId: 'world-1', characterId: 'character-1', skillId: proposal.skillId,
-    adapterId: proposal.adapterId, action: proposal.action, target: proposal.target, label: proposal.label,
-    risk: proposal.risk as CharacterSkillAction['risk'], authorization: proposal.authorization as CharacterSkillAction['authorization'],
-    parameters: proposal.parameters ?? {}, status: 'waiting-for-approval', detail: '',
+    id: 'action-1', worldId: 'world-1', characterId: 'character-1', skillId: SSH_COMMAND_SKILL,
+    adapterId: 'builtin.ssh-device', action: 'ssh.disk.usage', target: 'ssh:device', label: '查看磁盘使用情况',
+    risk: 'external-side-effect', authorization: 'explicit-user-request',
+    parameters, status: 'waiting-for-approval', detail: '',
     createdAt: '2026-09-08T00:00:00.000Z', updatedAt: '2026-09-08T00:00:00.000Z',
   }
 }
 
-beforeEach(() => exec.mockReset())
+beforeEach(() => { exec.mockReset() })
 afterEach(() => vi.restoreAllMocks())
 
 describe('SshSkillAdapter', () => {
-  it('proposes only when the skill is granted and the intent matches a device operation', () => {
-    const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) })
+  it('proposes only when the skill is granted, a device is granted and the intent matches', () => {
+    const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) }, grantsDevice)
     expect(adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '看看磁盘', grantedSkillIds: [], now: new Date() })).toEqual([])
+    // No granted device -> nothing is proposed even with the skill.
+    expect(adapter.propose({ worldId: 'world-1', characterId: 'character-2', prompt: '连客厅主机看看磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })).toEqual([])
     const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '连客厅主机看看磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
     expect(proposal).toMatchObject({ skillId: SSH_COMMAND_SKILL, action: 'ssh.disk.usage', risk: 'external-side-effect' })
+    expect(proposal.parameters).toMatchObject({ deviceId: 'device-1' })
+  })
+
+  it('lets the role own several devices but requires the user to name one', () => {
+    const second = { ...device({ displayName: '机房网关' }), id: 'device-2' }
+    const adapter = makeAdapter({
+      listByType: () => [device(), second], getById: () => device(),
+      secretsForConnection: () => ({ privateKey: 'key' }),
+    }, () => ['device-1', 'device-2'])
+    // Naming one of them resolves.
+    const named = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '看下机房网关的磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })
+    expect(named).toHaveLength(1)
+    expect(named[0]!.parameters).toMatchObject({ deviceId: 'device-2' })
+    // Bare operation with several devices must not guess.
+    expect(adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '看看磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })).toEqual([])
+  })
+
+  it('exposes persona guidance about granted devices and none when nothing is granted', () => {
+    const context = (characterId: string) => ({ worldId: 'world-1', characterId, workspaceId: 'workspace-1', grantedSkillIds: [SSH_COMMAND_SKILL] })
+    const none = makeAdapter({ listByType: () => [], getById: () => undefined, secretsForConnection: () => undefined }, grantsDevice)
+    const note = none.instructionsFor?.(context('character-1'))
+    expect(note?.[0]).toContain('没有授权可操作的设备')
+    const withDevice = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) }, grantsDevice)
+    const note2 = withDevice.instructionsFor?.(context('character-1'))
+    expect(note2?.[0]).toContain('客厅主机')
+    expect(note2?.[0]).not.toContain('PRIVATE KEY')
+    // Skill not granted -> no guidance.
+    expect(withDevice.instructionsFor?.({ ...context('character-1'), grantedSkillIds: [] })).toBeUndefined()
   })
 
   it('preflight requires a configured and enabled device with a credential', async () => {
-    const adapter = makeAdapter({ listByType: () => [], getById: () => undefined, secretsForConnection: () => undefined }, grantsDevice)
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '看看磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
-    expect((await adapter.preflight(actionFrom(proposal)))!.ready).toBe(false)
+    const adapter = makeAdapter({ listByType: () => [device()], getById: () => undefined, secretsForConnection: () => undefined }, grantsDevice)
+    expect((await adapter.preflight(directAction()))!.ready).toBe(false)
   })
 
   it('executes a read op through the device and returns the sanitized output', async () => {
     const privateKey = '-----BEGIN OPENSSH PRIVATE KEY-----\nsecret\n-----END OPENSSH PRIVATE KEY-----'
     const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey }) }, grantsDevice)
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '查看磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
     exec.mockResolvedValueOnce({ code: 0, stdout: 'Linux\nlinux-apt', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '/dev/sda1  50G  12G  36G  25% /', stderr: '' })
-    const result = await adapter.execute(actionFrom(proposal), { now: new Date() })
-    expect(result.status).toBe('executed')
+    const result = await adapter.execute(directAction(), { now: new Date() })
+    expect(result.status, result.detail).toBe('executed')
     expect(result.detail).toContain('/dev/sda1')
     expect(result.detail).not.toContain('BEGIN OPENSSH')
   })
 
   it('connects with a stored password when no private key is configured', async () => {
     const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ password: 'hunter2' }) }, grantsDevice)
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '查看磁盘', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
     exec.mockResolvedValueOnce({ code: 0, stdout: 'Linux\nlinux-apt', stderr: '' })
       .mockResolvedValueOnce({ code: 0, stdout: '/dev/sda1  50G  12G  36G  25% /', stderr: '' })
-    const result = await adapter.execute(actionFrom(proposal), { now: new Date() })
+    const result = await adapter.execute(directAction(), { now: new Date() })
     expect(result.status).toBe('executed')
     expect(exec).toHaveBeenCalledTimes(2)
     expect(exec.mock.calls[0]![0]).toMatchObject({ password: 'hunter2' })
@@ -85,36 +121,44 @@ describe('SshSkillAdapter', () => {
 
   it('reports refused auth as failed and connection loss as outcome-unknown', async () => {
     const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) }, grantsDevice)
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '查看内存', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
     exec.mockRejectedValueOnce(new (await import('../src/integrations/ssh-client.js')).SshError('auth-failed', 'permission denied'))
-    expect((await adapter.execute(actionFrom(proposal), { now: new Date() })).status).toBe('failed')
+    expect((await adapter.execute(directAction(), { now: new Date() })).status).toBe('failed')
     exec.mockRejectedValueOnce(new (await import('../src/integrations/ssh-client.js')).SshError('timeout', 'timed out'))
-    expect((await adapter.execute(actionFrom(proposal), { now: new Date() })).status).toBe('outcome-unknown')
+    expect((await adapter.execute(directAction(), { now: new Date() })).status).toBe('outcome-unknown')
   })
 
-  it('returns waiting-for-integration when no device resolves', async () => {
-    const adapter = makeAdapter({ listByType: () => [] })
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '查看内存', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
-    const result = await adapter.execute(actionFrom(proposal), { now: new Date() })
+  it('returns waiting-for-integration when the approved device is gone', async () => {
+    const adapter = makeAdapter({ listByType: () => [], getById: () => undefined, secretsForConnection: () => undefined }, grantsDevice)
+    const result = await adapter.execute(directAction(), { now: new Date() })
     expect(result.status).toBe('waiting-for-integration')
     expect(exec).not.toHaveBeenCalled()
   })
 
   it('denies execution when the connection is not in the character connection grants', async () => {
     const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) }, () => ['device-2'])
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '查看内存', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
-    expect((await adapter.preflight(actionFrom(proposal)))!.ready).toBe(false)
-    const result = await adapter.execute(actionFrom(proposal), { now: new Date() })
+    expect((await adapter.preflight(directAction()))!.ready).toBe(false)
+    const result = await adapter.execute(directAction(), { now: new Date() })
     expect(result.status).toBe('failed')
     expect(exec).not.toHaveBeenCalled()
   })
 
   it('blocks all connect use when no grants resolver is wired', async () => {
     const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) })
-    const proposal = adapter.propose({ worldId: 'world-1', characterId: 'character-1', prompt: '查看内存', grantedSkillIds: [SSH_COMMAND_SKILL], now: new Date() })[0]!
-    expect((await adapter.preflight(actionFrom(proposal)))!.ready).toBe(false)
-    const result = await adapter.execute(actionFrom(proposal), { now: new Date() })
+    expect((await adapter.preflight(directAction()))!.ready).toBe(false)
+    const result = await adapter.execute(directAction(), { now: new Date() })
     expect(result.status).toBe('failed')
+    expect(exec).not.toHaveBeenCalled()
+  })
+
+  it('routes commands through the shared session pool when one is configured', async () => {
+    const pool = new SshSessionPool()
+    const adapter = makeAdapter({ listByType: () => [device()], getById: () => device(), secretsForConnection: () => ({ privateKey: 'key' }) }, grantsDevice, pool)
+    const run = vi.mocked(pool.exec)
+    run.mockResolvedValueOnce({ code: 0, stdout: 'Linux\nlinux-apt', stderr: '' })
+      .mockResolvedValueOnce({ code: 0, stdout: '/dev/sda1  50G  12G  36G  25% /', stderr: '' })
+    const result = await adapter.execute(directAction(), { now: new Date() })
+    expect(result.status).toBe('executed')
+    expect(run).toHaveBeenCalledTimes(2)
     expect(exec).not.toHaveBeenCalled()
   })
 })

--- a/packages/server/tests/ssh-skill-adapter.test.ts
+++ b/packages/server/tests/ssh-skill-adapter.test.ts
@@ -162,3 +162,45 @@ describe('SshSkillAdapter', () => {
     expect(exec).not.toHaveBeenCalled()
   })
 })
+
+describe('registry persona aggregation', () => {
+  it('folds the SSH adapter note into persona guidance together with recipes', async () => {
+    const { CharacterSkillAdapterRegistry } = await import('../src/skills/skill-adapter.js')
+    const { composeSkillRecipes } = await import('../src/services/character-profile-runtime.js')
+    const registry = new CharacterSkillAdapterRegistry()
+    registry.registerRecipe({
+      descriptor: {
+        id: 'test.recipe', displayName: '会议纪要', summary: '整理会议事实。', adapterId: 'builtin.recipe',
+        risks: [], supportsScheduling: false, persistentApproval: 'forbidden', kind: 'recipe', recommendedByDefault: true,
+      },
+      instruction: '会议结束后整理决策、负责人和截止日期。',
+    })
+    registry.register(new SshSkillAdapter({
+      store: { getWorld: () => ({ id: 'world-1', workspaceId: 'workspace-1' }) },
+      integrations: {
+        listByType: () => [{
+          id: 'device-1', workspaceId: 'workspace-1', integrationId: 'builtin.ssh-device', displayName: '客厅主机',
+          config: { displayName: '客厅主机', host: '10.0.0.10' }, enabled: true, credentialConfigured: true, createdAt: '', updatedAt: '',
+        }],
+        secretsForConnection: () => ({ password: 'x' }),
+      } as never,
+      connectionGrantsFor: () => ['device-1'],
+    }))
+
+    const notes = registry.instructionsForCharacter({
+      worldId: 'world-1',
+      characterId: 'character-1',
+      workspaceId: 'workspace-1',
+      grantedSkillIds: ['device.ssh.command', 'test.recipe'],
+    })
+    expect(notes).toHaveLength(2)
+    expect(notes.join('\n')).toContain('客厅主机')
+    expect(notes.join('\n')).toContain('会议纪要')
+
+    // The persona composer accepts the aggregated instructions unchanged.
+    const persona = composeSkillRecipes('你是一位细心管家。', notes)
+    expect(persona).toContain('客厅主机')
+    expect(persona).toContain('会议纪要')
+    expect(persona).toContain('已授权')
+  })
+})


### PR DESCRIPTION
## 概要

解决两个对话体验问题：角色在对话里不知道（也驱动不了）连接中心里已授权的 SSH 设备；以及每条 SSH 命令都重新握手、没有长连接。

## 变更内容

### 1. 角色知道并驱动 SSH 设备（persona 可见性 + 更强意图解析）

- Adapter 可声明 `instructionsFor(character)`，registry 经 `instructionsForCharacter` 把静态 recipe 指令与按角色动态的能力说明一起折进每轮 persona（字符级可见性，不泄漏凭据）
- SSH Adapter 注入“你获授哪些设备（名称/主机）+ 用户如何表达请求”，无设备时明确引导先去连接中心
- 设备/操作分离解析：用户点名（displayName 或 host，可不带“连/到”连接词）即绑定；角色只有一台可用设备时，不带设备名的操作自动落到那台；多台设备未点名时不猜测、由角色追问
- 提案锁定具体连接 id（`deviceId`），只对获授且已启用、有凭据的设备产生提案

### 2. SSH 会话复用池（长连接）

- 新增 `SshSessionPool`（并入 `ssh-client.ts`）：按设备指纹（host/port/user + 凭据哈希）保持一条已认证传输
- 同一设备连续命令复用握手；空闲默认 5 分钟自动断开；改凭据/停用/删除因指纹变化或显式失效立即重建；随服务关闭统一回收
- 安全边界不变：仍是一次一命令、白名单操作、无交互 shell，审批与授权边界不受影响

## 验证

- 单元测试：会话池复用/失效/空闲/并发（假客户端 8 条）+ 真实 ssh2 Server 集成测试（3 条命令仅 1 次 TCP 连接、改凭据强制重连）；parser 设备分离（含单设备默认、host 边界防误匹配）；adapter persona/propose/preflight 按新授权模型
- E2E（`ssh-conversational.spec.ts`）：招募+授权后自然对话“连客厅主机看看磁盘”与单设备“看看内存占用”都产生等待审批的 SSH 动作；只有技能但无连接授权的角色不会产生设备动作
- 全仓 `tsc -b` 通过；server 995 通过（仅剩 2 个改动前已存在的 Windows 临时目录 symlink 环境性失败）；web 589 全绿；connection-hub / skill-catalog E2E 通过
- 本地真实数据服务验证通过（设备清单注入 persona、自然语言触发、会话复用）