### PR TITLE
fix(connection-hub): boolean config option renders as a normal checkbox row

### DIFF
--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -2167,6 +2167,13 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .dialog-field span { color: var(--text-soft); font-size: 13px; font-weight: 600; }
 .dialog-field input, .dialog-field textarea, .dialog-field select { width: 100%; border: 1px solid var(--border-strong); border-radius: var(--radius-control, 8px); padding: 10px 14px; color: var(--text-strong); background: color-mix(in srgb, var(--surface-1) 85%, transparent); font-size: 13.5px; line-height: 1.6; outline: none; box-shadow: inset 0 1px 3px rgba(0, 0, 0, 0.25); transition: all var(--duration-fast) var(--ease-smooth); }
 .dialog-field input:focus, .dialog-field textarea:focus, .dialog-field select:focus { border-color: var(--accent); background: var(--surface-1); box-shadow: 0 0 0 2px var(--accent-soft), inset 0 1px 3px rgba(0, 0, 0, 0.2); }
+/* Boolean option rows: checkbox on the same line as the label, description below. */
+.dialog-field--checkbox { grid-template-columns: 22px minmax(0, 1fr); gap: 8px; align-items: start; cursor: pointer; }
+.dialog-field--checkbox > input[type='checkbox'] { grid-column: 1; width: 18px; height: 18px; margin: 1px 0 0; padding: 0; border-radius: 4px; accent-color: var(--accent); box-shadow: none; }
+.dialog-field--checkbox > span { grid-column: 2; align-self: start; }
+.dialog-field--checkbox > small { grid-column: 1 / -1; color: var(--text-muted); font-size: 12px; font-weight: 400; line-height: 1.55; }
+.dialog-field--checkbox > span, .dialog-field--checkbox > small { cursor: pointer; }
+.dialog-field--checkbox > input[type='checkbox']:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 .dialog-field-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
 .dialog-empty { padding: 24px; color: var(--text-muted); font-size: 13px; text-align: center; }
 


### PR DESCRIPTION
## 问题

连接中心“SSH 设备 → 添加/编辑设备”里的「允许公网设备」勾选框使用了 `dialog-field--checkbox`，但该变体在整个样式表里没有任何定义，于是落进了通用 `.dialog-field input` 的文本框规则（width:100% + 输入框内边距/边框/背景），被拉成整行宽的输入框样式，标签文字被挤到下一行。

## 修复

为 `.dialog-field--checkbox` 补齐与其它勾选行一致的样式：

- 18px 复选框放在左侧 22px 固定列，不再被拉伸
- 「允许公网设备」标签与勾选框同一行
- 说明文字整行换行在下方
- 保留 focus-visible 焦点环

## 验证

- 几何：复选框 18×18（此前 838px 宽）、标签同行、说明在下方
- 交互冒烟：勾选 → 填公网 IP 保存成功（未勾选时公网地址会被服务端拒绝）
- web 单测全绿；无其它影响面（纯 CSS 追加）