### PR TITLE
fix(connection-hub): keep credential state out of connections.json (no stale credentialConfigured:false)

### DIFF
--- a/packages/server/src/integrations/integration-service.ts
+++ b/packages/server/src/integrations/integration-service.ts
@@ -288,7 +288,11 @@ export class IntegrationService {
 
   async #persist(): Promise<void> {
     const temporary = `${this.#path}.tmp-${randomUUID()}`
-    const items = [...this.#connections.values()].map((item) => ({ ...item, credentialConfigured: false, secretsConfigured: undefined }))
+    // The on-disk file never carries credential state: `credentialConfigured`
+    // and `secretsConfigured` are recomputed from the vault on every load and
+    // list, so writing a stale false (or true) here would only mislead. Keep
+    // the file about configuration only.
+    const items = [...this.#connections.values()].map(({ credentialConfigured: _configured, secretsConfigured: _secrets, ...rest }) => rest)
     try { await writeFile(temporary, JSON.stringify({ version: 1, items }), { encoding: 'utf8', flag: 'wx', mode: 0o600 }); await rename(temporary, this.#path) }
     catch (error) { await rm(temporary, { force: true }).catch(() => undefined); throw error }
   }

--- a/packages/server/tests/ssh-connection-hub.test.ts
+++ b/packages/server/tests/ssh-connection-hub.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm } from 'node:fs/promises'
+import { mkdtemp, rm, readFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createServer } from 'node:net'
@@ -15,6 +15,10 @@ afterEach(async () => { for (const root of roots.splice(0)) await rm(root, { rec
 async function openService(): Promise<IntegrationService> {
   const root = await mkdtemp(join(tmpdir(), 'dsh-ssh-connections-'))
   roots.push(root)
+  return IntegrationService.open(root, createBuiltinIntegrationRegistry())
+}
+
+async function openServiceAt(root: string): Promise<IntegrationService> {
   return IntegrationService.open(root, createBuiltinIntegrationRegistry())
 }
 
@@ -114,6 +118,33 @@ describe('SSH multi-connection hub', () => {
     expect(service.secretsForConnection('workspace-1', keyDevice.id)).toEqual({ privateKey: expect.stringContaining('BEGIN OPENSSH') })
     expect(service.secretsForConnection('workspace-1', passwordDevice.id)).toEqual({ privateKey: 'key-material' })
     service.close()
+  })
+
+  it('keeps the persisted connections.json free of credential state and still reports it live', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-ssh-persist-'))
+    roots.push(root)
+    const service = await openServiceAt(root)
+    const connection = await service.save({
+      workspaceId: 'workspace-1', integrationId: SSH_DEVICE_INTEGRATION_ID,
+      config: { displayName: '文件设备', host: '10.0.0.77', username: 'root' }, enabled: true,
+      secrets: { password: 'persisted-secret-value' },
+    })
+    // Runtime projection is correct…
+    expect(service.getById('workspace-1', connection.id)?.credentialConfigured).toBe(true)
+    expect(service.getById('workspace-1', connection.id)?.secretsConfigured).toEqual({ privateKey: false, password: true })
+    service.close()
+
+    // …but the on-disk file never carries credential flags or plaintext.
+    const file = JSON.parse(await readFile(join(root, 'integrations', 'connections.json'), 'utf8')) as { items: Array<Record<string, unknown>> }
+    expect(file.items[0]).not.toHaveProperty('credentialConfigured')
+    expect(file.items[0]).not.toHaveProperty('secretsConfigured')
+    expect(JSON.stringify(file)).not.toContain('persisted-secret-value')
+
+    // Reopening recomputes the flags from the vault, not from the file.
+    const reopened = await openServiceAt(root)
+    expect(reopened.getById('workspace-1', connection.id)?.credentialConfigured).toBe(true)
+    expect(reopened.getById('workspace-1', connection.id)?.secretsConfigured).toEqual({ privateKey: false, password: true })
+    reopened.close()
   })
 
   it('tests a connection against a reachable SSH banner without sending credentials', async () => {


### PR DESCRIPTION
## 问题

SSH 设备等连接保存凭据后，凭据确实加密写入本机 `credentials/integration-credentials.json`，但 `integrations/connections.json` 中落盘的 `credentialConfigured` 一直是 `false`（`secretsConfigured` 也被置空）。读文件会误以为连接没有配置凭据。

根因：`IntegrationService.#persist()` 写盘时把这两个字段强制归零。它们本来每次启动/每次 list 都由凭据库实时重算（API 与 UI 显示正确），磁盘上写死的 false 只是误导、还可能过期。

## 修复

- `connections.json` 只存配置（config / displayName / enabled / 时间戳），不再写入 `credentialConfigured` / `secretsConfigured`
- 这两个标志继续由凭据库在加载与每次读取时计算（行为不变，API/UI 不受影响）
- 新增持久化测试：保存凭据后断言文件不含这两个字段、不含明文；运行期投影与重启后重开均报告 `credentialConfigured: true`

## 验证

- `tsc -b` 通过；ssh-connection-hub 9 条、ssh-skill-adapter 等测试全绿