### PR TITLE
feat(trace): show raw command and result in one expandable evidence box

### DIFF
--- a/e2e/trace-evidence.spec.ts
+++ b/e2e/trace-evidence.spec.ts
@@ -19,7 +19,12 @@ class EvidenceRuntime {
       for (const event of normalizeHarnessTraceNotification(notification, subjects)) request.onEvent?.(event)
     }
     notify('tool/call', { name: 'read', callId: 'fixture-read', arguments: JSON.stringify({ file_path: 'packages/server/src/services/character-profile-runtime.ts' }) })
-    notify('tool/result', { message: { source: { callId: 'fixture-read' }, content: [{ type: 'tool-result', toolCallId: 'fixture-read', content: [{ type: 'text', text: 'export const directoryEnabled = true;\naccess_token="LOCAL-FIXTURE-SECRET"' }] }] } })
+    const resultLines = [
+      'export const directoryEnabled = true;',
+      'access_token="LOCAL-FIXTURE-SECRET"',
+      ...Array.from({ length: 6 }, (_, index) => `body-${index + 1}`),
+    ]
+    notify('tool/result', { message: { source: { callId: 'fixture-read' }, content: [{ type: 'tool-result', toolCallId: 'fixture-read', content: [{ type: 'text', text: resultLines.join('\n') }] }] } })
     return { agentSessionId: 'evidence-runtime', finalResponse: '已完成轨迹样例。', eventCount: 2 }
   }
   async close() {}
@@ -31,7 +36,7 @@ test.beforeAll(async () => {
 })
 test.afterAll(async () => { await server.close(); await rm(stateRoot, { recursive: true, force: true }) })
 
-test('expands and copies sanitized real-event evidence, survives reload, and fits three viewports', async ({ page }, info) => {
+test('expands and reads raw event evidence, survives reload, and fits three viewports', async ({ page }, info) => {
   const consoleIssues: string[] = []
   page.on('console', (message) => { if (message.type() === 'error' || message.type() === 'warning') consoleIssues.push(message.text()) })
   page.on('pageerror', (error) => consoleIssues.push(error.message))
@@ -53,21 +58,27 @@ test('expands and copies sanitized real-event evidence, survives reload, and fit
   }
   await openTraceTab()
   let entry = await openTraceEntry(dock, '完成处理')
-  const target = 'packages/server/src/services/character-profile-runtime.ts'
-  await expect(entry.locator('.world-trace-tool__target')).toHaveText(target)
-  await expect(entry.getByText('查看参数', { exact: true })).toHaveCount(0)
-  await entry.locator('.world-trace-tool__evidence > summary').click()
-  await expect(entry.locator('pre')).toContainText('directoryEnabled = true')
-  await expect(entry.locator('pre')).not.toContainText('LOCAL-FIXTURE-SECRET')
-  await page.context().grantPermissions(['clipboard-read', 'clipboard-write'], { origin })
-  await entry.getByRole('button', { name: '复制结果', exact: true }).click()
-  await expect(entry.getByRole('status')).toHaveText('已复制')
-  const copied = await page.evaluate(() => navigator.clipboard.readText())
-  expect(copied).toContain('directoryEnabled')
-  expect(copied).not.toContain('LOCAL-FIXTURE-SECRET')
+  // The redundant target command line is gone; one merged evidence box holds
+  // the raw command and the raw result together.
+  await expect(entry.locator('.world-trace-tool__target')).toHaveCount(0)
+  let box = entry.locator('.world-trace-tool__evidence')
+  await expect(box).toHaveCount(1)
+  // Collapsed: a five-line preview, raw and unmasked, with an expand affordance.
+  await expect(box).toHaveClass(/is-clickable/)
+  const preview = box.locator('pre')
+  await expect(preview).toContainText('character-profile-runtime.ts')
+  await expect(preview).toContainText('LOCAL-FIXTURE-SECRET')
+  await expect(preview).not.toContainText('body-6')
+  // The copy affordances are gone: select text in the box instead.
+  await expect(entry.getByRole('button', { name: /复制/ })).toHaveCount(0)
+  // Clicking the box expands the full raw command and result.
+  await preview.click()
+  await expect(box).toHaveText(/命令/)
+  await expect(box).toHaveText(/结果/)
+  await expect(box.locator('.world-trace-tool__part pre').last()).toContainText('body-6')
   for (const size of [{ width: 1440, height: 900 }, { width: 1920, height: 1080 }, { width: 3840, height: 2160 }]) {
     await page.setViewportSize(size)
-    await expect(entry.locator('pre')).toBeVisible()
+    await expect(box).toBeVisible()
     const overflow = await entry.locator('.world-trace-tool__body').evaluate((element) => element.scrollWidth > element.clientWidth + 1)
     expect(overflow).toBe(false)
     await page.screenshot({ path: info.outputPath(`trace-${size.width}x${size.height}.png`) })
@@ -75,9 +86,12 @@ test('expands and copies sanitized real-event evidence, survives reload, and fit
   await page.reload()
   await openTraceTab()
   entry = await openTraceEntry(dock, '完成处理')
-  await entry.locator('.world-trace-tool__evidence > summary').click()
-  await expect(entry.locator('pre')).toContainText('directoryEnabled')
-  await expect(entry.locator('pre')).not.toContainText('LOCAL-FIXTURE-SECRET')
+  // Persisted evidence reloads collapsed again; expand to the full raw text.
+  box = entry.locator('.world-trace-tool__evidence')
+  await expect(box).toHaveClass(/is-clickable/)
+  await expect(box.locator('pre')).toContainText('LOCAL-FIXTURE-SECRET')
+  await box.locator('pre').click()
+  await expect(box.locator('.world-trace-tool__part pre').last()).toContainText('body-6')
   await writeFile(info.outputPath('console.json'), JSON.stringify(consoleIssues, null, 2))
   expect(consoleIssues).toEqual([])
 })

--- a/packages/contracts/src/tool-trace.ts
+++ b/packages/contracts/src/tool-trace.ts
@@ -1,6 +1,10 @@
-/** Display-safe tool evidence. Paths are identifiers, not credentials. */
-export const TOOL_TRACE_INPUT_LIMIT = 2_000
-export const TOOL_TRACE_OUTPUT_LIMIT = 4_000
+/**
+ * Raw tool evidence shown verbatim in the trace panel. The trace adapter
+ * clips parameters and results to these bounds; `redactToolTraceText` below
+ * only still guards narrative summary fields.
+ */
+export const TOOL_TRACE_INPUT_LIMIT = 32_000
+export const TOOL_TRACE_OUTPUT_LIMIT = 32_000
 const HIDDEN = '[已隐藏敏感信息]'
 
 /** Redact before clipping, so a truncated credential can never escape detection. */

--- a/packages/contracts/src/world-trace.ts
+++ b/packages/contracts/src/world-trace.ts
@@ -40,6 +40,7 @@ export interface WorldTraceToolStep {
   callId: string
   name?: string
   label: string
+  /** Narrative summary line; unlike `input`/`output` it stays host-sanitized. */
   description?: string
   status: 'running' | 'success' | 'failed'
   createdAt?: IsoTimestamp
@@ -47,17 +48,21 @@ export interface WorldTraceToolStep {
   /** Wall-clock span of the call, once both ends are known. */
   durationMs?: number
   /**
-   * The redacted call target — the command or file the tool worked on.
+   * The raw tool-call parameters: the actual command and/or argument payload
+   * the runtime executed, shown verbatim in the trace panel's expandable
+   * "查看参数" box.
    *
-   * Allow-listed argument fields only, home-directory prefixes stripped and
-   * secret shapes masked at the adapter boundary and again by the trace
-   * sanitizer. Present only when the runtime reported usable arguments;
-   * unknown or sensitive keys are never rendered.
+   * Only clipped to a bounded length (marked by the trailing ellipsis); no
+   * secret masking or argument allow-listing happens on this field.
    */
   input?: string
-  /** Bounded, credential-redacted text actually returned by this tool call. */
+  /** The raw text actually returned by this tool call, clipped to a bounded length. */
   output?: string
   outputTruncated?: boolean
+  /**
+   * @deprecated Legacy flag from the credential-redacted era. New trace data
+   * no longer sets it; persisted older entries may still carry it.
+   */
   outputRedacted?: boolean
   /** Only present when the runtime explicitly supplied a process exit code. */
   exitCode?: number
@@ -83,7 +88,9 @@ export interface WorldTraceArtifactRef {
  * Provider- and renderer-neutral read model for meaningful activity in a world.
  *
  * Entries reference canonical facts; they are not a second source of truth.
- * Details are display-safe summaries and must have passed the host sanitizer.
+ * Narrative fields (summary, detail, reasoning) stay host-sanitized; the tool
+ * step's `input`/`output` carry the raw, unmasked call parameters and result
+ * text so the trace panel can show them verbatim.
  */
 export interface WorldTraceEntry {
   id: string

--- a/packages/contracts/tests/tool-trace.test.ts
+++ b/packages/contracts/tests/tool-trace.test.ts
@@ -23,7 +23,7 @@ describe('tool evidence value redaction', () => {
     expect(redactToolTraceText('\u001b[31mfirst\nsecond\u001b[0m')).toBe('first\nsecond')
     const text = redactToolTraceText('password=' + 's'.repeat(500), 80)
     expect(text).not.toContain('ssss')
-    expect(redactToolTraceText('x'.repeat(100_000))).toHaveLength(4_000)
+    expect(redactToolTraceText('x'.repeat(100_000))).toHaveLength(32_000)
   })
   it('suppresses credential container bodies, not source files discussing credentials', () => {
     for (const path of ['.env', '/etc/secrets.json', 'C:\\Users\\alice\\.ssh\\id_rsa', 'HEAD:.env']) expect(isSensitiveToolPath(path)).toBe(true)

--- a/packages/harness-adapter/src/adapter.ts
+++ b/packages/harness-adapter/src/adapter.ts
@@ -852,9 +852,9 @@ export function normalizeHarnessTraceNotification(
       const toolName = stringValue(data.name) ?? 'unknown-tool'
       const callId = stringValue(data.callId) ?? 'unknown-call'
       const metadata: JsonObject = { turn: numberValue(data.turn) ?? 0, step: numberValue(data.step) ?? 0 }
-      // The raw argument blob never travels; only its redacted allow-listed
-      // subject does, so the trace can say what a call operated on.
-      toolSubjects?.start(sourceSessionId, callId, toolName, data.arguments)
+      // The raw parameter text (clipped, never redacted) travels as the
+      // trace's "查看参数" evidence for this call.
+      toolSubjects?.start(sourceSessionId, callId, toolName)
       const summary = summarizeToolCall(data.arguments)
       if (summary !== undefined) {
         metadata.toolSummary = summary.summary

--- a/packages/harness-adapter/src/tool-result-summary.ts
+++ b/packages/harness-adapter/src/tool-result-summary.ts
@@ -1,23 +1,17 @@
-import {
-  redactToolTraceText,
-  isSensitiveToolPath,
-  TOOL_TRACE_OUTPUT_LIMIT,
-  type JsonObject,
-} from '@dsh-cyber/contracts'
-import { toolCallAllowsOutput } from './tool-summary.js'
+import type { JsonObject } from '@dsh-cyber/contracts'
 
-interface ToolSubject { name: string; allowOutput: boolean }
+interface ToolSubject { name: string }
 
-/** One instance per AgentRun. Never retain raw arguments, file bodies or credentials. */
+/**
+ * One instance per AgentRun. Results are only claimed by the session and
+ * call id that started them; that identity guard is not a hiding mechanism.
+ */
 export class ToolTraceSubjects {
   readonly #subjects = new Map<string, ToolSubject>()
 
-  start(sessionId: string, callId: string, name: string, args: unknown): void {
-    this.#subjects.set(JSON.stringify([sessionId, callId]), {
-      name: redactToolTraceText(name, 160),
-      allowOutput: toolCallAllowsOutput(args, name),
-    })
-    // Overload loses optional detail, never isolation or the primary turn.
+  start(sessionId: string, callId: string, name: string): void {
+    this.#subjects.set(JSON.stringify([sessionId, callId]), { name: name.slice(0, 160) })
+    // Overload loses the oldest association, never the primary turn.
     while (this.#subjects.size > 256) this.#subjects.delete(this.#subjects.keys().next().value!)
   }
 
@@ -29,20 +23,27 @@ export class ToolTraceSubjects {
   }
 }
 
-/** Only documented text blocks and explicit scalar results; never stringify arbitrary data. */
+/** Bounded raw result text: the full call output, clipped but never redacted. */
+const SCAN_LIMIT = 32_000
+
+/**
+ * Extract the actual text a tool call returned.
+ *
+ * The trace panel shows this verbatim in the expandable "查看结果" box, so no
+ * secret masking and no per-tool allow-listing happens here. Only a call that
+ * was never started in this session has no text claimed for it.
+ */
 export function summarizeToolResult(data: Record<string, unknown>, subject?: ToolSubject): JsonObject {
   const result: JsonObject = {}
   const message = object(data.message)
   const output = object(data.result)
-  const exitCode = data.exitCode ?? output?.exitCode ?? object(data.meta)?.exitCode
+  const meta = object(data.meta)
+  const exitCode = data.exitCode ?? output?.exitCode ?? meta?.exitCode
   if (typeof exitCode === 'number' && Number.isSafeInteger(exitCode)) result.toolExitCode = exitCode
   if (subject === undefined) return result
-  const meta = object(data.meta)
-  if (!subject.allowOutput || (typeof meta?.path === 'string' && isSensitiveToolPath(meta.path))) {
-    result.toolOutput = '未记录此调用的文本结果（凭据文件、任意脚本或尚未适配的工具）。'
-    result.toolOutputRedacted = true
-    return result
-  }
+  const texts: string[] = []
+  let scanned = 0
+  let truncated = false
   const surface = Array.isArray(message?.content) ? message.content : []
   const callId = object(message?.source)?.callId
   // rc.1 represents tool output as user-message -> tool-result -> text.
@@ -54,13 +55,10 @@ export function summarizeToolResult(data: Record<string, unknown>, subject?: Too
     }
     return block?.type === 'text' ? [block] : []
   })
-  const texts: string[] = []
-  let scanned = 0
-  let truncated = surface.length > 64 || blocks.length > 64
   for (const value of blocks.slice(0, 64)) {
     const block = object(value)
     if (block?.type !== 'text' || typeof block.text !== 'string') continue
-    const remaining = 32_000 - scanned
+    const remaining = SCAN_LIMIT - scanned
     if (remaining <= 0) { truncated = true; break }
     const text = block.text.slice(0, remaining)
     texts.push(text)
@@ -72,42 +70,34 @@ export function summarizeToolResult(data: Record<string, unknown>, subject?: Too
     for (const key of ['stdout', 'stderr', 'output', 'text'] as const) {
       const value = output?.[key] ?? data[key]
       if (typeof value !== 'string' || !value.trim()) continue
-      const remaining = 32_000 - scanned
+      const remaining = SCAN_LIMIT - scanned
       if (remaining <= 0) { truncated = true; break }
       texts.push(`${key}:\n${value.slice(0, remaining)}`)
       scanned += Math.min(value.length, remaining)
       if (value.length > remaining) truncated = true
     }
   }
-  // Native read/write/edit presentation metadata is host-observed, unlike
-  // model-proposed old_string/new_string arguments. Show only actual hunks.
+  // Native write/edit presentation metadata is host-observed, unlike
+  // model-proposed old_string/new_string arguments. Show the actual hunks.
   if (/^(?:write|edit)$/.test(subject.name) && Array.isArray(meta?.diffs)) {
     if (meta.diffs.length > 4) truncated = true
     for (const raw of meta.diffs.slice(0, 4)) {
       const diff = object(raw)
       if (typeof diff?.path !== 'string' || typeof diff.oldText !== 'string' || typeof diff.newText !== 'string') continue
-      if (isSensitiveToolPath(diff.path)) {
-        texts.push('[凭据文件的变更内容已隐藏敏感信息]')
-        result.toolOutputRedacted = true
-        continue
-      }
-      const remaining = Math.max(0, 32_000 - scanned)
+      const remaining = Math.max(0, SCAN_LIMIT - scanned)
       const half = Math.min(4_000, Math.floor(remaining / 2))
       if (half === 0) { truncated = true; break }
       const oldText = diff.oldText.slice(0, half)
       const newText = diff.newText.slice(0, half)
       if (diff.oldText.length > half || diff.newText.length > half) truncated = true
-      texts.push(`[实际变更片段] ${redactToolTraceText(diff.path, 300)}\n--- 修改前\n${oldText}\n+++ 修改后\n${newText}`)
+      texts.push(`[实际变更片段] ${diff.path}\n--- 修改前\n${oldText}\n+++ 修改后\n${newText}`)
       scanned += oldText.length + newText.length + 400
     }
   }
   const original = texts.join('\n').trim()
   if (!original) return result
-  const sanitized = redactToolTraceText(original)
-  if (!sanitized) return result
-  result.toolOutput = sanitized
-  if (truncated || original.length > TOOL_TRACE_OUTPUT_LIMIT) result.toolOutputTruncated = true
-  if (/\[已隐藏(?:敏感信息)?\]/.test(sanitized)) result.toolOutputRedacted = true
+  result.toolOutput = original
+  if (truncated) result.toolOutputTruncated = true
   return result
 }
 

--- a/packages/harness-adapter/src/tool-summary.ts
+++ b/packages/harness-adapter/src/tool-summary.ts
@@ -1,111 +1,21 @@
-import { isSensitiveToolPath, redactToolTraceText, TOOL_TRACE_INPUT_LIMIT } from '@dsh-cyber/contracts'
-
-/** Structured targets for the owner's trace; credential values are never retained. */
+/**
+ * Raw tool-call parameter text for the owner's trace.
+ *
+ * The trace panel shows the tool's actual parameters and result verbatim in
+ * an expandable box: no secret masking, no argument allow-listing, no home
+ * folding. Values are only clipped to a bounded length so a single call
+ * cannot bloat the trace or the persisted message metadata.
+ */
 export interface ToolCallSummary {
-  /** One short line for the list: program name + first argument, or the file. */
+  /** One short display line for the target row (the command, or the compact record). */
   summary: string
-  /** The fuller redacted target for the expanded view. */
+  /** The full raw parameter text for the expandable view. */
   detail: string
 }
 
 const COMMAND_KEYS = ['command', 'cmd', 'script'] as const
-const PATH_KEYS = ['path', 'file_path', 'filepath', 'file', 'filename', 'directory', 'dir', 'target_path', 'target'] as const
-const PATTERN_KEYS = ['pattern', 'glob', 'query', 'search', 'regex'] as const
-const URL_KEYS = ['url', 'uri', 'endpoint'] as const
 const MAX_SUMMARY = 120
-const MAX_DETAIL = TOOL_TRACE_INPUT_LIMIT
-
-const SECRET_PATTERNS: ReadonlyArray<RegExp> = [
-  /\bBearer\s+[A-Za-z0-9._~+/-]+=*/gi,
-  /\bsk-[A-Za-z0-9_-]{8,}\b/g,
-  /\bgh[pousr]_[A-Za-z0-9]{8,}\b/g,
-  /\bxox[baprs]-[A-Za-z0-9-]{8,}\b/g,
-  /\bAKIA[0-9A-Z]{12,}\b/g,
-  /\b(?:api[-_ ]?key|authorization|password|passwd|token|secret|credential)s?\s*[:=]\s*[^\s,;'"]+/gi,
-  /(["']?[A-Za-z0-9_-]*(?:token|secret|password|api_key|apikey|access_key|private_key)[A-Za-z0-9_-]*["']?\s*[:=]\s*)[^\s,;'"]+/gi,
-]
-
-function redact(value: string): string {
-  let out = value
-  for (const pattern of SECRET_PATTERNS) out = out.replace(pattern, '[已隐藏]')
-  return out
-}
-
-function foldHome(value: string): string {
-  return value
-    .replaceAll('\\', '/')
-    .replace(/[A-Za-z]:\/(?:Users|users)\/[^/]+/g, '~')
-    .replace(/\/(?:Users|home)\/[^/]+/g, '~')
-}
-
-// A path/URL segment is kept only when it positively reads as human-authored:
-// short and lowercase, or a small extension-suffixed file name. Credential
-// words, long mixed-case runs, and id-shaped digit mixes (webhook and bot-API
-// secrets live exactly there) are replaced per segment.
-const CREDENTIALISH = /(token|secret|passw|credential|api[_-]?key|access[_-]?key|private[_-]?key|\bauth\b|\bpwd\b|session|\bsid\b|otp|verify|key)/i
-function safeSegment(segment: string): boolean {
-  if (segment.length === 0) return true
-  if (CREDENTIALISH.test(segment)) return false
-  if (segment.length > 24) return false
-  if (/[A-Z]/.test(segment) && /\d/.test(segment)) return false
-  if (segment.length >= 12 && /\d/.test(segment)) return false
-  if (segment.length >= 16 && !/^[a-z0-9][a-z0-9.-]*$/.test(segment)) return false
-  if (segment.length >= 12 && segment.includes('_')) return false
-  return true
-}
-
-function redactPathish(value: string): string {
-  // Long source filenames, UUID artifact manifests and words such as session
-  // or keyboard are legitimate filesystem identifiers. Redact values only.
-  return redactToolTraceText(value, MAX_DETAIL)
-}
-
-function redactUrl(value: string): string {
-  const bare = value.split(/[?#]/)[0] ?? value
-  let url: URL
-  try {
-    url = new URL(bare)
-  } catch {
-    return '[无法解析的地址]'
-  }
-  const segments = url.pathname.split('/').filter((segment) => segment.length > 0)
-  const kept = segments.slice(0, 4).map((segment) => (safeSegment(segment) ? segment : '[已隐藏]'))
-  const suffix = segments.length > 4 ? '/…' : ''
-  return `${url.protocol}//${url.host}/${kept.join('/')}${suffix}`
-}
-
-function take(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
-  for (const key of keys) {
-    const value = record[key]
-    if (typeof value === 'string' && value.trim()) return value.slice(0, 64_000).trim()
-  }
-  return undefined
-}
-
-function firstCommandLine(command: string): string {
-  // Program by default. The first argument survives only when it positively
-  // reads as a subcommand (pure lowercase, git/npm/docker style) or as a path
-  // (then segment-redacted). Anything else — short passwords, opaque ids —
-  // becomes an explicit marker, so unrecognized secrets cannot ride along.
-  const head = command.split(/&&|;|\|\|/)[0]?.trim() ?? command.trim()
-  const tokens = head.split(' ').filter(Boolean)
-  if (tokens.length === 0) return ''
-  const program = (tokens[0] ?? '').split(/[\\/]/).pop() ?? ''
-  const next = tokens[1] ?? ''
-  if (next.length === 0 || next.startsWith('-')) return redact(program)
-  if (/^[a-z][a-z-]{0,15}$/.test(next)) return `${redact(program)} ${next}`
-  if (/[/\\~]|\.[A-Za-z0-9]{1,8}$|^[A-Za-z]:/.test(next)) return `${redact(program)} ${redactPathish(foldHome(next))}`
-  return `${redact(program)} [参数已隐藏]`
-}
-
-function summarizeParts(parts: string[]): { summary: string; detail: string } | undefined {
-  const unique = [...new Set(parts.filter((part) => part.length > 0))]
-  if (unique.length === 0) return undefined
-  return {
-    summary: redactToolTraceText(unique.join(' · '), MAX_SUMMARY),
-    detail: redactToolTraceText(unique.join(' · '), MAX_DETAIL),
-  }
-}
+const MAX_DETAIL = 32_000
 
 function argsRecord(raw: unknown): Record<string, unknown> | undefined {
   if (raw !== null && typeof raw === 'object' && !Array.isArray(raw)) return raw as Record<string, unknown>
@@ -118,68 +28,43 @@ function argsRecord(raw: unknown): Record<string, unknown> | undefined {
   }
 }
 
-export function summarizeToolCall(rawArguments: unknown): ToolCallSummary | undefined {
-  const record = argsRecord(rawArguments)
-  if (record === undefined) return undefined
-  const command = take(record, COMMAND_KEYS)
-  const path = take(record, PATH_KEYS)
-  const pattern = take(record, PATTERN_KEYS)
-  const url = take(record, URL_KEYS)
-  const parts: string[] = []
-  if (command !== undefined) parts.push(firstCommandLine(command))
-  if (path !== undefined) parts.push(redact(redactPathish(foldHome(path))))
-  if (pattern !== undefined) parts.push(redact(pattern.slice(0, 80)))
-  if (url !== undefined) parts.push(redactUrl(url))
-  // The detail line keeps fuller pattern text; commands stay on
-  // firstCommandLine so a pipeline tail cannot smuggle anything through.
-  const detailParts: string[] = []
-  if (command !== undefined) detailParts.push(commandDetail(command))
-  if (pattern !== undefined) detailParts.push(redact(pattern.slice(0, 160)))
-  if (url !== undefined) detailParts.push(redactUrl(url))
-  if (path !== undefined) detailParts.push(redact(redactPathish(foldHome(path))))
-  for (const key of ['offset', 'limit', 'start_line', 'end_line', 'startLine', 'endLine', 'line_start', 'line_end']) {
+function take(record: Record<string, unknown>, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
     const value = record[key]
-    if (typeof value === 'number' && Number.isSafeInteger(value) && value >= 0) detailParts.push(`${key}=${value}`)
+    if (typeof value === 'string' && value.trim()) return value.trim()
   }
-  if (typeof record.characterId === 'string') {
-    parts.push(redactToolTraceText(record.characterId, 160))
-    detailParts.push(redactToolTraceText(record.characterId, 160))
-  }
-  if (parts.length === 0 && detailParts.length > 0) parts.push(...detailParts)
-  const result = summarizeParts(parts)
-  if (result === undefined) return undefined
-  const full = summarizeParts(detailParts)
+  return undefined
+}
+
+function clip(value: string, maximum: number): string {
+  return value.length <= maximum ? value : `${value.slice(0, maximum - 1)}…`
+}
+
+function firstLine(value: string): string {
+  const line = value.split(/\r?\n/)[0] ?? value
+  return line.trim()
+}
+
+/**
+ * Display the direct command parameters of a tool call.
+ *
+ * Command-shaped records show the command string; anything else shows the
+ * exact argument payload (the runtime's own JSON for string payloads, a
+ * pretty-printed record otherwise). Nothing is redacted.
+ */
+export function summarizeToolCall(rawArguments: unknown): ToolCallSummary | undefined {
+  if (rawArguments === undefined) return undefined
+  const record = argsRecord(rawArguments)
+  const detail = typeof rawArguments === 'string'
+    ? rawArguments
+    : JSON.stringify(rawArguments, null, 2)
+  const trimmed = detail.trim()
+  if (!trimmed) return undefined
+  const summarySource = record !== undefined
+    ? (take(record, COMMAND_KEYS) ?? (typeof rawArguments === 'string' ? trimmed : JSON.stringify(record)))
+    : firstLine(trimmed)
   return {
-    summary: result.summary,
-    detail: full === undefined ? result.detail : full.detail,
+    summary: clip(summarySource, MAX_SUMMARY),
+    detail: clip(detail, MAX_DETAIL),
   }
-}
-
-
-function commandDetail(command: string): string {
-  // Show real flags for ordinary development commands. Unknown programs and
-  // inline scripts remain summarized; do not pretend to parse a full shell.
-  const commands = command.split(/&&|\|\||[;\n]/)
-  const known = /^(?:git|pnpm|npm|yarn|bun|node|python3?|pytest|vitest|tsc|cargo|go|make|cmake|rg|grep|find|ls|pwd|cat|head|tail|wc|docker|curl)(?:\s|$)/
-  if (commands.every((part) => known.test(part.trim())) && !/[|`]|\$\(|(?:^|\s)(?:-e|-c|--eval|--command)(?:\s|=)/.test(command)) {
-    return redactToolTraceText(command, MAX_DETAIL)
-  }
-  return firstCommandLine(command) + (commands.length > 1 ? ' …' : '')
-}
-
-export function toolCallAllowsOutput(rawArguments: unknown, toolName: string): boolean {
-  const args = argsRecord(rawArguments)
-  if (args === undefined) return false
-  const path = take(args, PATH_KEYS)
-  if (path !== undefined && isSensitiveToolPath(path)) return false
-  const command = take(args, COMMAND_KEYS)
-  if (command !== undefined) {
-    // Normal development commands may expose bounded, value-redacted output.
-    // Environment dumps, credential containers and inline shell programs do not.
-    if (/[|`]|\$\(|(?:^|\s)(?:-e|-c|--eval|--command)(?:\s|=)/.test(command)) return false
-    if (command.split(/[\s"']+/).some(isSensitiveToolPath)) return false
-    const parts = command.split(/&&|\|\||[;\n]/).map((part) => part.trim())
-    return parts.every((part) => /^(?:git (?:status|diff|log|show|ls-files|rev-parse)|(?:pnpm|npm|yarn|bun) (?:test|build|typecheck|run (?:test|build|typecheck)|exec (?:vitest|tsc|playwright))|(?:vitest|tsc|pytest|ls|pwd|rg|grep|head|tail|cat|wc|find)|cargo (?:test|build|check)|go (?:test|build|vet))(?:\s|$)/.test(part))
-  }
-  return /^(?:read|read_file|readfile|write|write_file|edit|str_replace_editor|apply_patch|grep|glob|search|find|world_directory_(?:list|search|get))$/i.test(toolName)
 }

--- a/packages/harness-adapter/tests/adapter.test.ts
+++ b/packages/harness-adapter/tests/adapter.test.ts
@@ -579,7 +579,7 @@ describe('Harness profile and adapter', () => {
     await adapter.close()
   })
 
-  it('normalizes Harness facts without persisting tool arguments', () => {
+  it('normalizes Harness facts and carries the raw tool arguments into tool.started', () => {
     const events = normalizeHarnessNotification({
       method: 'session.event',
       params: {
@@ -607,11 +607,13 @@ describe('Harness profile and adapter', () => {
         callId: 'call-1',
       }),
     ])
-    expect(JSON.stringify(events)).not.toContain('must-not-leak')
-    expect(JSON.stringify(events)).not.toContain('apiKey')
+    // Raw parameters travel verbatim so the trace panel can expand them.
+    expect(events[0]!.metadata.toolDetail).toBe('{"apiKey":"must-not-leak"}')
+    expect(events[0]!.metadata.toolSummary).toBe('{"apiKey":"must-not-leak"}')
+    expect(JSON.stringify(events)).not.toContain('"arguments"')
   })
 
-  it('carries the redacted call target of an allow-listed argument into tool.started', () => {
+  it('carries the direct command target of an argument into tool.started', () => {
     const events = normalizeHarnessNotification({
       method: 'session.event',
       params: {
@@ -633,9 +635,8 @@ describe('Harness profile and adapter', () => {
     expect(events[0]).toMatchObject({
       kind: 'tool.started',
       toolName: 'bash',
-      metadata: { toolSummary: 'git commit', toolDetail: 'git commit -m msg' },
+      metadata: { toolSummary: 'git commit -m msg', toolDetail: '{"command":"git commit -m msg"}' },
     })
-    // The raw argument key survives only as its redacted subject.
     expect(JSON.stringify(events)).not.toContain('"arguments"')
   })
 

--- a/packages/harness-adapter/tests/tool-summary.test.ts
+++ b/packages/harness-adapter/tests/tool-summary.test.ts
@@ -3,100 +3,70 @@ import { describe, expect, it } from 'vitest'
 import { summarizeToolCall } from '../src/tool-summary.js'
 
 describe('summarizeToolCall', () => {
-  it('summarizes a command by its program and first argument', () => {
+  it('shows the direct command without masking', () => {
     const summary = summarizeToolCall('{"command":"git status --short"}')
-    expect(summary?.summary).toBe('git status')
+    expect(summary?.summary).toBe('git status --short')
+    expect(summary?.detail).toBe('{"command":"git status --short"}')
   })
 
-  it('keeps the concise command title and exposes a safe development chain in detail', () => {
+  it('keeps the full raw command chain in detail', () => {
     const summary = summarizeToolCall('{"command":"npm install && npm test"}')
-    expect(summary?.summary).toBe('npm install')
-    expect(summary?.detail).toBe('npm install && npm test')
+    expect(summary?.summary).toBe('npm install && npm test')
+    expect(summary?.detail).toBe('{"command":"npm install && npm test"}')
   })
 
-  it('folds user home prefixes out of file paths', () => {
+  it('keeps file paths raw, without home folding', () => {
     const windows = summarizeToolCall('{"file_path":"C:\\\\Users\\\\alice\\\\proj\\\\src\\\\main.ts"}')
-    expect(windows?.summary).toBe('~/proj/src/main.ts')
+    expect(windows?.summary).toBe('{"file_path":"C:\\\\Users\\\\alice\\\\proj\\\\src\\\\main.ts"}')
     const posix = summarizeToolCall('{"path":"/home/bob/notes/todo.md"}')
-    expect(posix?.summary).toBe('~/notes/todo.md')
+    expect(posix?.detail).toBe('{"path":"/home/bob/notes/todo.md"}')
   })
 
-  it('shows search patterns', () => {
+  it('shows search patterns and their keys verbatim', () => {
     const summary = summarizeToolCall('{"pattern":"function parseJson","glob":"**/*.ts","path":"src"}')
-    expect(summary?.summary).toContain('function parseJson')
-    expect(summary?.summary).toContain('src')
+    expect(summary?.detail).toBe('{"pattern":"function parseJson","glob":"**/*.ts","path":"src"}')
   })
 
-  it('strips the query string of urls', () => {
+  it('keeps url query strings raw', () => {
     const summary = summarizeToolCall('{"url":"https://example.com/docs?session=abc123"}')
-    expect(summary?.summary).toBe('https://example.com/docs')
+    expect(summary?.detail).toContain('session=abc123')
   })
 
-  it('masks high-entropy first arguments on command lines', () => {
+  it('surfaces first arguments that look like secrets, verbatim', () => {
     const summary = summarizeToolCall('{"command":"auth hx9Kq2Lm4Pq7Rt0WvYzBe3Nn5Ma8Cs1Df"}')
-    expect(summary?.summary).toBe('auth [参数已隐藏]')
-    expect(JSON.stringify(summary)).not.toContain('hx9Kq2Lm')
-  })
-
-  it('hides short positional arguments that are neither subcommands nor paths', () => {
-    const summary = summarizeToolCall('{"command":"auth abc123shortsecret"}')
-    expect(summary?.summary).toBe('auth [参数已隐藏]')
-    expect(JSON.stringify(summary)).not.toContain('abc123shortsecret')
-  })
-
-  it('keeps real subcommands and path-shaped arguments', () => {
-    expect(summarizeToolCall('{"command":"git commit -m msg"}')?.summary).toBe('git commit')
-    expect(summarizeToolCall('{"command":"python scripts/build.py"}')?.summary).toBe('python scripts/build.py')
-    expect(summarizeToolCall('{"command":"docker compose up"}')?.summary).toBe('docker compose')
-  })
-
-  it('masks webhook-shaped URL segments while keeping the safe skeleton', () => {
-    const summary = summarizeToolCall('{"url":"https://hooks.slack.com/services/T02ABCDx/B03EFGH1y/XXXXXXXXXXXXXXXXXXXXxy9"}')
-    expect(summary?.summary).toBe('https://hooks.slack.com/services/[已隐藏]/[已隐藏]/[已隐藏]')
-    expect(JSON.stringify(summary)).not.toContain('XXXXXXXXXXXXXXXXXXXXxy9')
-    const docs = summarizeToolCall('{"url":"https://code.example.com/guide/intro"}')
-    expect(docs?.summary).toBe('https://code.example.com/guide/intro')
-  })
-
-  it('keeps credential container filenames while content policy handles their bodies', () => {
-    const summary = summarizeToolCall('{"file_path":"C:\\\\Users\\\\bob\\\\.config\\\\gh_hosts_token.yml"}')
-    expect(summary?.summary).toBe('~/.config/gh_hosts_token.yml')
-    const safe = summarizeToolCall('{"file_path":"/home/bob/notes/meeting.md"}')
-    expect(safe?.summary).toBe('~/notes/meeting.md')
-  })
-
-  it('applies the detail cap rather than the summary cap to the detail line', () => {
-    const longPath = 'notes/' + 'folder/'.repeat(30) + 'todo.md'
-    const summary = summarizeToolCall(JSON.stringify({ path: longPath }))
-    expect((summary?.detail.length ?? 0)).toBeGreaterThan(120)
-    expect((summary?.detail.length ?? 0)).toBeLessThanOrEqual(480)
-  })
-
-  it('never surfaces tokens that live in the dropped tail of a command', () => {
-    // firstCommandLine keeps program+first argument; the token sits in a later
-    // argument, so it is gone — and the redaction layers guard the rest.
-    const summary = summarizeToolCall('{"command":"curl -H \\"Authorization: Bearer abc.def.ghi\\" https://api.internal/v1"}')
-    expect(summary?.summary).toBe('curl')
-    expect(JSON.stringify(summary)).not.toContain('abc.def.ghi')
+    expect(summary?.summary).toBe('auth hx9Kq2Lm4Pq7Rt0WvYzBe3Nn5Ma8Cs1Df')
+    expect(JSON.stringify(summary)).toContain('hx9Kq2Lm4Pq7Rt0WvYzBe3Nn5Ma8Cs1Df')
   })
 
   it('never renders values of keys outside the allow-list', () => {
-    expect(summarizeToolCall('{"apiKey":"sk-live-abcdef0123456789"}')).toBeUndefined()
-    expect(summarizeToolCall('{"body":"full prompt text"}')).toBeUndefined()
-    expect(summarizeToolCall('{"content":"-----BEGIN PRIVATE KEY-----"}')).toBeUndefined()
+    const summary = summarizeToolCall('{"apiKey":"sk-live-abcdef0123456789"}')
+    expect(summary?.detail).toBe('{"apiKey":"sk-live-abcdef0123456789"}')
+    const body = summarizeToolCall('{"body":"full prompt text"}')
+    expect(body?.detail).toBe('{"body":"full prompt text"}')
   })
 
-  it('rejects non-object and malformed argument payloads', () => {
+  it('accepts structured argument objects directly', () => {
+    const summary = summarizeToolCall({ command: 'docker compose up' })
+    expect(summary?.summary).toBe('docker compose up')
+    expect(summary?.detail).toBe(JSON.stringify({ command: 'docker compose up' }, null, 2))
+  })
+
+  it('shows plain text and array payloads as-is', () => {
+    expect(summarizeToolCall('not json at all')?.detail).toBe('not json at all')
+    expect(summarizeToolCall('["array"]')?.detail).toBe('["array"]')
+  })
+
+  it('returns undefined only for no arguments or blank payloads', () => {
     expect(summarizeToolCall(undefined)).toBeUndefined()
-    expect(summarizeToolCall('not json at all')).toBeUndefined()
-    expect(summarizeToolCall('["array"]')).toBeUndefined()
-    expect(summarizeToolCall({})).toBeUndefined()
+    expect(summarizeToolCall('   ')).toBeUndefined()
+    expect(summarizeToolCall(null)?.detail).toBe('null')
   })
 
   it('caps length so a giant argument cannot bloat the trace', () => {
     const huge = '{"pattern":"' + 'x'.repeat(5_000) + '"}'
     const summary = summarizeToolCall(huge)
     expect(summary).toBeDefined()
-    expect((summary?.detail.length ?? 0)).toBeLessThanOrEqual(480 + 60)
+    expect((summary?.detail.length ?? 0)).toBeLessThanOrEqual(32_000)
+    expect((summary?.summary.length ?? 0)).toBeLessThanOrEqual(120)
   })
 })

--- a/packages/harness-adapter/tests/tool-trace-evidence.test.ts
+++ b/packages/harness-adapter/tests/tool-trace-evidence.test.ts
@@ -14,17 +14,18 @@ function start(subjects: ToolTraceSubjects, args: object, name = 'read', callId 
   return normalizeHarnessTraceNotification(event('tool/call', { name, callId, arguments: JSON.stringify(args) }, sessionId), subjects)
 }
 
-describe('scoped tool evidence from real rc.1 event shapes', () => {
-  it('preserves long code filenames and real read ranges', () => {
+describe('raw tool evidence from real rc.1 event shapes', () => {
+  it('keeps long code filenames and raw read ranges', () => {
     const summary = summarizeToolCall({ file_path: 'packages/server/src/services/character-profile-runtime.ts', offset: 10, limit: 25 })!
-    expect(summary.summary).toContain('character-profile-runtime.ts')
-    expect(summary.detail).toContain('offset=10')
-    expect(summary.detail).toContain('limit=25')
+    expect(summary.detail).toContain('character-profile-runtime.ts')
+    expect(summary.detail).toContain('"offset": 10')
+    expect(summary.detail).toContain('"limit": 25')
   })
-  it('keeps actual nested text results and never raw input bodies', () => {
+  it('keeps actual nested text results and the raw input bodies', () => {
     const subjects = new ToolTraceSubjects()
-    const [call] = start(subjects, { file_path: 'src/token-counter.ts', content: 'DO-NOT-LOG-RAW-INPUT' })
-    expect(JSON.stringify(call)).not.toContain('DO-NOT-LOG-RAW-INPUT')
+    const [call] = start(subjects, { file_path: 'src/token-counter.ts', content: 'RAW-INPUT-BODY' })
+    // Raw parameters now travel verbatim; nothing is dropped for a trace view.
+    expect(JSON.stringify(call)).toContain('RAW-INPUT-BODY')
     const [done] = normalizeHarnessTraceNotification(result('1 export const count = 1\n2 // next'), subjects)
     expect(done?.metadata.toolOutput).toContain('export const count')
     expect(done?.toolName).toBe('read')
@@ -37,28 +38,27 @@ describe('scoped tool evidence from real rc.1 event shapes', () => {
     expect(normalizeHarnessTraceNotification(result('own'), subjects)[0]?.metadata.toolOutput).toBe('own')
     expect(normalizeHarnessTraceNotification(result('late duplicate'), subjects)[0]?.metadata.toolOutput).toBeUndefined()
   })
-  it('keeps secret filenames visible but suppresses credential container contents', () => {
+  it('shows credential container contents verbatim', () => {
     const subjects = new ToolTraceSubjects()
-    expect(start(subjects, { file_path: '.env' })[0]?.metadata.toolSummary).toBe('.env')
+    expect(start(subjects, { file_path: '.env' })[0]?.metadata.toolSummary).toBe('{"file_path":".env"}')
     const value = normalizeHarnessTraceNotification(result('UNLABELED-PRIVATE-VALUE'), subjects)[0]
-    expect(JSON.stringify(value)).not.toContain('UNLABELED-PRIVATE-VALUE')
-    expect(value?.metadata.toolOutputRedacted).toBe(true)
+    expect(value?.metadata.toolOutput).toBe('UNLABELED-PRIVATE-VALUE')
+    expect(value?.metadata.toolOutputRedacted).toBeUndefined()
   })
-  it('redacts values and clips large results with explicit flags', () => {
+  it('clips large results with an explicit truncation flag, without redacting', () => {
     const subjects = new ToolTraceSubjects()
     start(subjects, { file_path: 'src/index.ts' })
     const [done] = normalizeHarnessTraceNotification(result('access_token="opaque private value"\n' + 'x'.repeat(40_000)), subjects)
-    expect(done?.metadata.toolOutput).not.toContain('opaque private')
-    expect((done?.metadata.toolOutput as string).length).toBeLessThanOrEqual(4_000)
+    expect(done?.metadata.toolOutput).toContain('opaque private value')
+    expect((done?.metadata.toolOutput as string).length).toBeLessThanOrEqual(32_000)
     expect(done?.metadata.toolOutputTruncated).toBe(true)
-    expect(done?.metadata.toolOutputRedacted).toBe(true)
   })
-  it('shows real safe developer command output and suppresses arbitrary script dumps', () => {
+  it('shows developer command output and arbitrary script dumps alike', () => {
     const subjects = new ToolTraceSubjects()
     start(subjects, { command: 'pnpm test' }, 'bash')
     expect(normalizeHarnessTraceNotification(result('13 passed'), subjects)[0]?.metadata.toolOutput).toBe('13 passed')
     start(subjects, { command: 'node -e "console.log(process.env)"' }, 'bash')
-    expect(JSON.stringify(normalizeHarnessTraceNotification(result('UNLABELED-SECRET'), subjects))).not.toContain('UNLABELED-SECRET')
+    expect(normalizeHarnessTraceNotification(result('SECRET-DUMP-AS-IS'), subjects)[0]?.metadata.toolOutput).toBe('SECRET-DUMP-AS-IS')
   })
   it('retains explicitly reported exit code without guessing one from success', () => {
     const subjects = new ToolTraceSubjects()
@@ -72,7 +72,7 @@ describe('scoped tool evidence from real rc.1 event shapes', () => {
   })
 })
 
-it('projects native observed diff hunks and suppresses the canonical target of a secret-file alias', () => {
+it('projects native observed diff hunks verbatim', () => {
   const subjects = new ToolTraceSubjects()
   start(subjects, { file_path: 'src/index.ts', old_string: 'PROPOSED-ONLY' }, 'edit')
   const [done] = normalizeHarnessTraceNotification(event('tool/result', { message: { source: { callId: 'c' }, content: [] }, meta: { diffs: [{ path: 'src/index.ts', oldText: 'const n = 1', newText: 'const n = 2' }] } }), subjects)
@@ -80,6 +80,6 @@ it('projects native observed diff hunks and suppresses the canonical target of a
   expect(done?.metadata.toolOutput).toContain('const n = 2')
   expect(done?.metadata.toolOutput).not.toContain('PROPOSED-ONLY')
   start(subjects, { file_path: 'innocent-link' }, 'read')
-  const [denied] = normalizeHarnessTraceNotification(event('tool/result', { message: { source: { callId: 'c' }, content: [{ type: 'text', text: 'PRIVATE-ALIAS-CONTENT' }] }, meta: { path: '/private/.env' } }), subjects)
-  expect(JSON.stringify(denied)).not.toContain('PRIVATE-ALIAS-CONTENT')
+  const [aliased] = normalizeHarnessTraceNotification(event('tool/result', { message: { source: { callId: 'c' }, content: [{ type: 'text', text: 'PRIVATE-ALIAS-CONTENT' }] }, meta: { path: '/private/.env' } }), subjects)
+  expect(aliased?.metadata.toolOutput).toBe('PRIVATE-ALIAS-CONTENT')
 })

--- a/packages/server/src/world-trace/trace-sanitizer.ts
+++ b/packages/server/src/world-trace/trace-sanitizer.ts
@@ -1,4 +1,4 @@
-import { redactToolTraceText, TOOL_TRACE_INPUT_LIMIT } from '@dsh-cyber/contracts'
+import { redactToolTraceText } from '@dsh-cyber/contracts'
 import type { JsonObject, JsonValue, WorldTraceEntry } from '@dsh-cyber/contracts'
 
 const SENSITIVE_KEY = /^(?:authorization|cookie|set-cookie|password|passphrase|secret|api[-_]?key|access[-_]?token|refresh[-_]?token|token|credential)$/i
@@ -26,16 +26,22 @@ export class TraceSanitizer {
     const summary = this.text(entry.summary, 160)
     const detail = entry.detail === undefined ? undefined : this.text(entry.detail, 500)
     const reasoningSummary = entry.reasoningSummary === undefined ? undefined : this.text(entry.reasoningSummary, 1_200)
+    // The tool step's `input`/`output` are the raw, unmasked call parameters
+    // and result the trace panel expands on click; they only ever get clipped
+    // to a bounded length here. `name`/`label`/`description` are narrative
+    // fields (and may interpolate a runtime-supplied tool name), so they stay
+    // on the redaction path.
     const tools = entry.tools?.map((tool) => ({
       ...tool,
       callId: this.text(tool.callId, 160),
       ...(tool.name === undefined ? {} : { name: this.text(tool.name, 160) }),
       label: this.text(tool.label, 200),
       ...(tool.description === undefined ? {} : { description: this.text(tool.description, 300) }),
-      // Second redaction layer for the call target produced at the adapter
-      // boundary; the trace exit must never trust an upstream string.
-      ...(tool.input === undefined ? {} : { input: redactToolTraceText(tool.input, TOOL_TRACE_INPUT_LIMIT) }),
-      ...(tool.output === undefined ? {} : { output: redactToolTraceText(tool.output) }),
+      ...(tool.input === undefined ? {} : { input: clip(tool.input, 32_000) }),
+      ...(tool.output === undefined ? {} : {
+        output: clip(tool.output, 32_000),
+        outputTruncated: tool.outputTruncated || tool.output.length > 32_000,
+      }),
     }))
     // Artifact titles are author-supplied text and reach the trace verbatim, so
     // they pass through the same redaction as every other displayed string.
@@ -84,4 +90,9 @@ export class TraceSanitizer {
     if (value !== null && typeof value === 'object') return this.#record(value)
     return value
   }
+}
+
+/** Plain length clipping without any masking: raw text stays verbatim. */
+function clip(value: string, limit: number): string {
+  return value.length <= limit ? value : `${value.slice(0, limit - 1)}…`
 }

--- a/packages/server/tests/trace-evidence-projection.test.ts
+++ b/packages/server/tests/trace-evidence-projection.test.ts
@@ -13,22 +13,26 @@ function historical() {
   ] as WorkMessage[] } })[0]!
 }
 describe('persistent and live tool evidence projections', () => {
-  it('keeps recorded targets, multiline results and measured elapsed time after a reload', () => {
+  it('keeps recorded targets, raw multiline results and measured elapsed time after a reload', () => {
     const entry = new TraceSanitizer().entry(historical())
     expect(entry.tools?.[0]).toMatchObject({ name: 'read', label: '读取文件', input: 'src/keyboard-shortcuts.ts', durationMs: 1000, outputTruncated: true, exitCode: 2 })
     expect(entry.tools?.[0]?.output).toContain('native result\n')
-    expect(entry.tools?.[0]?.output).not.toContain('opaque-credential')
+    // Raw results are shown verbatim in the trace; no credential masking.
+    expect(entry.tools?.[0]?.output).toContain('opaque-credential')
   })
-  it('projects the same output fields in live events and applies the same exit sanitizer', () => {
+  it('projects the same output fields in live events and applies the same exit clip', () => {
     const entry = new RuntimeEventTraceAdapter().adapt({ kind: 'runtime-event', value: { worldId: 'world', actorId: 'self', sessionId: 'session', agentRunId: 'run', createdAt: run.createdAt, event: { kind: 'tool.completed', source: 'harness', sourceSessionId: 'native', callId: 'c', toolName: 'read', metadata: meta } } })[0]!
     const safe = new TraceSanitizer().entry(entry)
     expect(safe.tools?.[0]?.output).toBe(new TraceSanitizer().entry(historical()).tools?.[0]?.output)
     expect(safe.tools?.[0]?.exitCode).toBe(2)
   })
-  it('never exposes unbounded foreign-adapter output or guessed missing evidence', () => {
+  it('clips unbounded foreign-adapter output without hiding its content', () => {
     const entry = historical()
     entry.tools![0]!.output = 'x'.repeat(1_000_000)
-    expect(new TraceSanitizer().entry(entry).tools?.[0]?.output?.length).toBeLessThanOrEqual(4_000)
+    const clipped = new TraceSanitizer().entry(entry).tools?.[0]?.output
+    expect(clipped?.length).toBeLessThanOrEqual(32_000)
+    expect(clipped).toContain('xx')
+    expect(clipped).not.toContain('已隐藏')
     delete entry.tools![0]!.output
     expect(new TraceSanitizer().entry(entry).tools?.[0]).not.toHaveProperty('output')
   })

--- a/packages/web/src/components/world-trace/WorldTraceToolItem.tsx
+++ b/packages/web/src/components/world-trace/WorldTraceToolItem.tsx
@@ -1,43 +1,63 @@
-import { useEffect, useRef, useState } from 'react'
-import { CheckCircle, CircleNotch, Copy, WarningCircle } from '@phosphor-icons/react'
+import { useState } from 'react'
+import { CheckCircle, CircleNotch, WarningCircle } from '@phosphor-icons/react'
 import type { WorldTraceToolStep } from '@dsh-cyber/contracts'
 import { formatDuration } from '../../i18n/format.js'
 
-/** Render host evidence, not a generated story of what the tool probably did. */
+const PREVIEW_LINES = 5
+
+/**
+ * One tool step in the trace: the raw command and the raw result live together
+ * in a single evidence box. Collapsed it previews the first five lines; when
+ * the content runs longer, clicking the box expands the full text. There is no
+ * copy affordance and no redaction: the owner selects text to take it away.
+ */
 export function WorldTraceToolItem({ tool }: { tool: WorldTraceToolStep }) {
-  const [copyStatus, setCopyStatus] = useState('')
-  const mounted = useRef(true)
-  useEffect(() => { mounted.current = true; return () => { mounted.current = false } }, [])
-  const hasDifferentInput = Boolean(tool.input && tool.input.trim() !== tool.description?.trim())
-  const target = tool.description ?? tool.input
-  const publication = /(?:^|\/)\.dsh\/artifacts\/[^\n]+\.json(?:$|\s| ·)/.test((tool.input ?? target ?? '').replaceAll('\\', '/'))
+  const [expanded, setExpanded] = useState(false)
+  const inputText = (tool.input ?? '').trim()
+  const outputText = tool.output ?? ''
+  const hasInput = inputText !== ''
+  const hasOutput = outputText !== ''
+  const combined = [hasInput ? inputText : '', hasOutput ? outputText : ''].filter(Boolean).join('\n')
+  const lines = combined ? combined.split('\n') : []
+  const clamped = lines.length > PREVIEW_LINES
+  const preview = lines.slice(0, PREVIEW_LINES).join('\n')
+  const publication = /(?:^|\/)\.dsh\/artifacts\/[^\n]+\.json(?:$|\s| ·)/.test(inputText.replaceAll('\\', '/'))
     && /write|create|save/i.test(tool.name ?? '')
   const label = publication ? '写入产物登记清单' : tool.label
   const nonzeroExit = tool.exitCode !== undefined && tool.exitCode !== 0
   const warning = tool.status === 'failed' || nonzeroExit
-  const copy = async (text: string) => {
-    try {
-      if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable')
-      await navigator.clipboard.writeText(text)
-      if (mounted.current) setCopyStatus('已复制')
-    } catch {
-      if (mounted.current) setCopyStatus('复制失败，请选中文本复制')
-    }
-  }
+  const statusText = tool.status === 'running' ? '执行中' : warning ? (nonzeroExit ? '非零退出' : '失败') : '完成'
+  const toggle = () => { if (clamped) setExpanded((value) => !value) }
   return <li className={`world-trace-tool is-${tool.status}${warning ? ' has-warning' : ''}`}>
     {tool.status === 'running' ? <CircleNotch size={14} className="spin" /> : warning ? <WarningCircle size={14} /> : <CheckCircle size={14} weight="fill" />}
     <div className="world-trace-tool__body">
-      <div className="world-trace-tool__heading"><strong>{label}</strong>{tool.name ? <code>{tool.name}</code> : null}</div>
-      {target ? <code className="world-trace-tool__target">{target}</code> : null}
-      {publication ? <small>清单写入与宿主校验、产物登记是不同步骤；登记结果见产出记录。</small> : null}
-      {hasDifferentInput ? <details className="world-trace-tool__evidence"><summary>查看参数</summary><pre>{tool.input}</pre></details> : null}
-      {tool.output !== undefined ? <details className="world-trace-tool__evidence"><summary>查看结果{tool.outputTruncated ? ' · 已截断' : ''}{tool.outputRedacted ? ' · 已脱敏' : ''}</summary><pre>{tool.output}</pre><button type="button" onClick={() => { void copy(tool.output!) }}><Copy size={14} />复制结果</button></details> : null}
-      <div className="world-trace-tool__actions">
-        {tool.input || target ? <button type="button" aria-label={`复制${label}的参数`} onClick={() => { void copy(tool.input ?? target!) }}><Copy size={14} />复制参数</button> : null}
-        {tool.exitCode === undefined ? null : <small>退出码：{tool.exitCode}</small>}
-        <small role="status">{copyStatus}</small>
+      <div className="world-trace-tool__heading">
+        <strong>{label}</strong>
+        {tool.name ? <code>{tool.name}</code> : null}
+        {tool.exitCode !== undefined ? <small>退出码：{tool.exitCode}</small> : null}
       </div>
+      {publication ? <small>清单写入与宿主校验、产物登记是不同步骤；登记结果见产出记录。</small> : null}
+      {!(hasInput || hasOutput) && tool.description ? <small>{tool.description}</small> : null}
+      {hasInput || hasOutput ? <div
+        className={`world-trace-tool__evidence${clamped ? ' is-clickable' : ''}`}
+        role={clamped ? 'button' : undefined}
+        tabIndex={clamped ? 0 : undefined}
+        aria-expanded={clamped ? expanded : undefined}
+        onClick={toggle}
+        onKeyDown={(event) => {
+          if ((event.key === 'Enter' || event.key === ' ') && clamped) {
+            event.preventDefault()
+            toggle()
+          }
+        }}
+      >
+        {expanded ? <>
+          {hasInput ? <div className="world-trace-tool__part"><span>命令</span><pre>{inputText}</pre></div> : null}
+          {hasOutput ? <div className="world-trace-tool__part"><span>结果</span><pre>{outputText}{tool.outputTruncated ? '…' : ''}</pre></div> : null}
+        </> : <pre>{preview}{clamped ? '…' : ''}</pre>}
+        {clamped ? <small className="world-trace-tool__hint">{expanded ? '点击收起' : '点击展开完整内容'}</small> : null}
+      </div> : null}
     </div>
-    <small className="world-trace-tool__status">{tool.status === 'running' ? '执行中' : warning ? (nonzeroExit ? '非零退出' : '失败') : '完成'}{tool.durationMs === undefined ? '' : ` · ${formatDuration(tool.durationMs)}`}</small>
+    <small className="world-trace-tool__status">{statusText}{tool.durationMs === undefined ? '' : ` · ${formatDuration(tool.durationMs)}`}</small>
   </li>
 }

--- a/packages/web/src/components/world-trace/world-trace.css
+++ b/packages/web/src/components/world-trace/world-trace.css
@@ -104,21 +104,23 @@
 .world-trace-turn__body .world-trace-item { padding-bottom: 12px; }
 .world-trace-turn__body .world-trace-item > article { background: var(--surface-1); }
 
-/* Typed tool evidence uses the same tokens as the trace, with no repeated target line. */
+/* One tool step: a compact heading plus a single evidence box holding the
+   raw command and the raw result; the box previews five lines and expands. */
 .world-trace-tools > .world-trace-tool { grid-template-columns: 16px minmax(0, 1fr) auto; align-items: start; }
 .world-trace-tool__body { min-width: 0; display: grid; gap: 6px; }
 .world-trace-tool__heading { display: flex; align-items: baseline; flex-wrap: wrap; gap: 8px; }
 .world-trace-tool__heading strong { font-size: 14px; }
 .world-trace-tool__heading code, .world-trace-tool__status { font-size: 12px; }
-.world-trace-tools code.world-trace-tool__target { display: block; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 13px; line-height: 1.6; color: var(--text); }
-.world-trace-tools .world-trace-tool__evidence { height: auto; min-width: 0; border: 1px solid var(--border); background: var(--surface-0); }
-.world-trace-tools .world-trace-tool__evidence > summary { display: block; min-height: 36px; padding: 8px 10px; list-style: disclosure-closed; color: var(--text); font-size: 13px; cursor: pointer; }
-.world-trace-tools .world-trace-tool__evidence[open] > summary { list-style: disclosure-open; }
-.world-trace-tools .world-trace-tool__evidence pre { margin: 0; padding: 10px; max-height: 360px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 13px; line-height: 1.6; color: var(--text); user-select: text; }
-.world-trace-tool__actions { display: flex; flex-wrap: wrap; align-items: center; gap: 10px; }
-.world-trace-tool__body button { display: inline-flex; align-items: center; gap: 5px; min-height: 36px; padding: 4px 8px; background: var(--surface-1); color: var(--text); border: 1px solid var(--border); font: inherit; font-size: 12px; cursor: pointer; }
-.world-trace-tool__body button:focus-visible, .world-trace-tool__body summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
-.world-trace-tool__body small { font-size: 12px; line-height: 1.5; }
+.world-trace-tool__heading small, .world-trace-tool__body small { font-size: 12px; line-height: 1.5; color: var(--text-muted); }
+.world-trace-tool__evidence { min-width: 0; border: 1px solid var(--border); background: var(--surface-0); }
+.world-trace-tool__evidence.is-clickable { cursor: pointer; }
+.world-trace-tool__evidence.is-clickable:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+.world-trace-tool__evidence > pre { margin: 0; padding: 10px; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 13px; line-height: 1.6; color: var(--text); user-select: text; }
+.world-trace-tool__part { padding: 8px 10px 10px; }
+.world-trace-tool__part + .world-trace-tool__part { border-top: 1px solid var(--border); }
+.world-trace-tool__part > span { display: block; margin-bottom: 4px; font-size: 12px; color: var(--text-muted); }
+.world-trace-tool__part pre { margin: 0; max-height: 480px; overflow: auto; white-space: pre-wrap; overflow-wrap: anywhere; font-size: 13px; line-height: 1.6; color: var(--text); user-select: text; }
+.world-trace-tool__hint { display: block; padding: 6px 10px; border-top: 1px solid var(--border); font-size: 12px; line-height: 1.5; color: var(--text-muted); }
 @container world-trace (max-width: 520px) { .world-trace-tools > .world-trace-tool { grid-template-columns: 16px minmax(0, 1fr); } .world-trace-tool__status { grid-column: 2; } }
 
 .world-trace-tools li.has-warning > svg { color: var(--danger); }

--- a/packages/web/tests/world-trace-tool-evidence.test.tsx
+++ b/packages/web/tests/world-trace-tool-evidence.test.tsx
@@ -6,7 +6,7 @@ import { WorldTraceToolItem } from '../src/components/world-trace/WorldTraceTool
 
 let root: Root | undefined
 let container: HTMLDivElement
-const base: WorldTraceToolStep = { callId: 'c', name: 'read', label: '读取文件', status: 'success', description: 'src/character-profile-runtime.ts', input: 'src/character-profile-runtime.ts', durationMs: 11 }
+const base: WorldTraceToolStep = { callId: 'c', name: 'pwsh', label: '执行本地命令', status: 'success', input: 'Get-ChildItem src', output: 'file-a.ts\nfile-b.ts', durationMs: 11 }
 function mount(patch: Partial<WorldTraceToolStep> = {}) {
   container = document.createElement('div'); document.body.append(container)
   root = createRoot(container)
@@ -16,36 +16,45 @@ function mount(patch: Partial<WorldTraceToolStep> = {}) {
 afterEach(() => { if (root) act(() => root!.unmount()); root = undefined; container?.remove(); vi.restoreAllMocks() })
 
 describe('owner-facing tool evidence', () => {
-  it('shows a path once instead of repeating summary and input', () => {
+  it('keeps the label + tool name heading, and drops the redundant target command line', () => {
     const view = mount()
-    expect(view.textContent!.split(base.input!).length - 1).toBe(1)
-    expect(view.querySelector('details')).toBeNull()
-    expect(view.textContent).not.toContain('匹配')
+    expect(view.textContent).toContain('执行本地命令')
+    expect(view.textContent).toContain('pwsh')
+    expect(view.querySelector('.world-trace-tool__target')).toBeNull()
+    // No copy affordances at all: the owner selects text in the box.
+    expect(view.querySelector('button')).toBeNull()
   })
-  it('expands distinct parameters and actual result, with truthful truncation notices', () => {
-    const view = mount({ input: `${base.input} · offset=20 · limit=5`, output: '20 export const value = 1\n21 // next', outputTruncated: true, outputRedacted: true })
-    const details = [...view.querySelectorAll('details')]
-    expect(details).toHaveLength(2)
-    expect(details[1]?.textContent).toContain('已截断')
-    expect(details[1]?.textContent).toContain('已脱敏')
-    act(() => details[1]!.querySelector('summary')!.click())
-    expect(details[1]!.open).toBe(true)
-    expect(details[1]!.querySelector('pre')!.textContent).toContain('20 export const value')
+  it('shows command and result in one box, collapsed to five lines by default', () => {
+    const view = mount({ output: Array.from({ length: 8 }, (_, index) => `line-${index + 1}`).join('\n') })
+    const box = view.querySelector('.world-trace-tool__evidence')!
+    expect(box).not.toBeNull()
+    // Collapsed: a five-line preview without section labels.
+    expect(box.querySelector('pre')!.textContent).toContain('Get-ChildItem src')
+    expect(box.textContent).toContain('line-4')
+    expect(box.textContent).not.toContain('line-8')
+    expect(box.classList.contains('is-clickable')).toBe(true)
+    act(() => box.querySelector('pre')!.click())
+    // Expanded: the full raw command and the full raw result, labeled.
+    expect(box.textContent).toContain('line-8')
+    expect(box.textContent).toContain('命令')
+    expect(box.textContent).toContain('结果')
+    act(() => box.querySelector('pre')!.click())
+    expect(box.textContent).not.toContain('line-8')
   })
-  it('copies only displayed sanitized result and reports copy failure', async () => {
-    const copy = vi.fn().mockResolvedValue(undefined)
-    vi.spyOn(navigator, 'clipboard', 'get').mockReturnValue({ writeText: copy } as unknown as Clipboard)
-    const view = mount({ output: 'token=[已隐藏敏感信息]' })
-    const button = [...view.querySelectorAll('button')].find((entry) => entry.textContent?.includes('复制结果'))!
-    await act(async () => button.click())
-    expect(copy).toHaveBeenCalledWith('token=[已隐藏敏感信息]')
-    expect(view.querySelector('[role=status]')?.textContent).toBe('已复制')
-    copy.mockRejectedValue(new Error('denied'))
-    await act(async () => button.click())
-    expect(view.querySelector('[role=status]')?.textContent).toContain('复制失败')
+  it('shows short content in full without an expand affordance', () => {
+    const view = mount()
+    const box = view.querySelector('.world-trace-tool__evidence')!
+    expect(box.classList.contains('is-clickable')).toBe(false)
+    expect(box.querySelector('pre')!.textContent).toBe('Get-ChildItem src\nfile-a.ts\nfile-b.ts')
+  })
+  it('renders only the available side when the result is missing', () => {
+    const view = mount({ output: undefined, status: 'running' })
+    const box = view.querySelector('.world-trace-tool__evidence')!
+    expect(box.querySelector('pre')!.textContent).toBe('Get-ChildItem src')
+    expect(box.textContent).not.toContain('结果')
   })
   it('does not equate writing an artifact manifest with publishing an artifact', () => {
-    const view = mount({ name: 'write', label: '写入文件', input: '.dsh/artifacts/run-123.json', description: '.dsh/artifacts/run-123.json' })
+    const view = mount({ name: 'write', label: '写入文件', input: '.dsh/artifacts/run-123.json' })
     expect(view.textContent).toContain('写入产物登记清单')
     expect(view.textContent).toContain('不同步骤')
     expect(view.textContent).not.toContain('登记成功')


### PR DESCRIPTION
## 变更内容
- harness-adapter 将工具调用的原始参数与原始结果作为轨迹证据（32k 截断、不打码），移除允许列表/敏感路径门控与脱敏占位结果
- TraceSanitizer 对工具 input/output 仅截断直通，叙述性字段保持脱敏
- 轨迹工具条目：参数框与结果框合并为一个框——默认展示前 5 行预览，点击展开完整原文；移除复制按钮与冗余的命令行；无证据的旧条目保留 description
- 更新单测与 e2e

## 验证
- tsc -b + Web 构建通过；vitest 全量通过（harness-adapter / server / contracts / web）
- Playwright e2e trace-evidence：原始文本在预览与展开态直接可见，复制按钮为 0，1440/1920/4K 三视口无横向溢出，刷新后持久化证据可展开
