### PR TITLE
fix(work-system): use the 20s default model-call budget for task-intent classification

### DIFF
--- a/packages/server/src/composition/compose-work-system.ts
+++ b/packages/server/src/composition/compose-work-system.ts
@@ -55,7 +55,9 @@ export function composeWorkSystem(options: {
     runtime: options.worldRuntime,
     classifier: options.intentClassifier ?? new ModelConversationTaskIntentClassifier({
       store: options.store,
-      call: new ModelJsonCall({ credentials: options.credentials, timeoutMs: 8_000, maxOutputTokens: 512, jsonResponseMode: 'prompt-only' }),
+      // 20s（ModelJsonCall 的默认预算）：远端思考型模型的非流式小调用常态 8s 内
+      // 回不完，8s 硬截止会把可判定消息误报为 model_call_timeout。
+      call: new ModelJsonCall({ credentials: options.credentials, timeoutMs: 20_000, maxOutputTokens: 512, jsonResponseMode: 'prompt-only' }),
     }),
   })
   return { work, taskIntent }


### PR DESCRIPTION
## 背景

任务意图判定（ConversationTaskIntentService）在每条用户消息入站时并行发起一次小而不流式的 JSON 模型调用，原 wiring 写死 `timeoutMs: 8_000`。当判定模型是远端思考型模型（当前工作区默认 agnes-3.0-flash，apihub 基础往返 ~1.2s）时，8s 硬截止经常在长回合占满供应商队列的时段被击穿，轨迹里留下 `model_call_timeout` 的“任务意图判定失败，未生成任务”卡片。近 7 天 20 条失败全部是该码，且与长回合时段聚集。

## 改动

- `packages/server/src/composition/compose-work-system.ts`：`timeoutMs: 8_000 → 20_000`（与 ModelJsonCall 的默认预算一致），调用本身仍然有界（512 输出 token、非流式）。

## 验证

- `tsc -b` 全仓类型检查通过
- `conversation-task-intent` + `conversation-task-from-chat` 共 12 个测试通过
- 纯服务端改动，无视觉门禁