### PR TITLE
feat(mcp): dual-mode connections, v53 grant migration and service-level skill aggregation

### DIFF
--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -1,7 +1,7 @@
 import type { WorldCharacterAuthority } from './world-authority.js'
 import type { UiLocale } from './locales.js'
 
-export const CYBER_SCHEMA_VERSION = 52 as const
+export const CYBER_SCHEMA_VERSION = 53 as const
 
 export * from './runtime-access.js'
 export * from './locales.js'

--- a/packages/contracts/src/index.ts
+++ b/packages/contracts/src/index.ts
@@ -389,7 +389,7 @@ export interface WorldPackageInstance {
   updatedAt: IsoTimestamp
 }
 
-export type IntegrationFieldKind = 'text' | 'url' | 'secret' | 'number' | 'boolean'
+export type IntegrationFieldKind = 'text' | 'url' | 'secret' | 'number' | 'boolean' | 'select'
 
 export interface IntegrationFieldDescriptor {
   id: string
@@ -400,6 +400,12 @@ export interface IntegrationFieldDescriptor {
   placeholder?: string
   /** Render the field as a multi-line editor (for example an SSH private key). */
   multiline?: boolean
+  /** For `select` fields: the allowed values, rendered as a choice list. */
+  options?: string[]
+  /** For `select` fields: display labels keyed by value; falls back to the value itself. */
+  optionLabels?: Record<string, string>
+  /** Only render the field while the named sibling config field holds one of these values. */
+  visibleWhen?: { field: string; equals: string[] }
 }
 
 /** Public, provider-neutral metadata. It never contains implementation callbacks or credentials. */

--- a/packages/contracts/src/skill-runtime.ts
+++ b/packages/contracts/src/skill-runtime.ts
@@ -91,6 +91,14 @@ export interface CharacterSkillDescriptor {
   kind?: 'recipe' | 'integration'
   /** Safe recipes may be selected by default during recruitment. External integrations never are. */
   recommendedByDefault?: boolean
+  /**
+   * MCP discovery grouping: a tool-level skill descriptor belongs to exactly one
+   * MCP service (a connection). UI surfaces present one service-level entry
+   * ("MCP · <connection name>") whose grant covers every tool of the service.
+   * `id` is the stable service slug; `label` is the connection display name
+   * (falling back to the slug) used for presentation only.
+   */
+  mcpService?: { id: string; label: string }
 }
 
 /**

--- a/packages/contracts/tests/world-knowledge.test.ts
+++ b/packages/contracts/tests/world-knowledge.test.ts
@@ -52,7 +52,7 @@ describe('World knowledge contracts', () => {
       document: { workspaceId: 'workspace-1', chunkCount: 0 },
       chunk: { worldId: 'world-1', documentId: 'document-1' },
     })
-    expect(CYBER_SCHEMA_VERSION).toBe(52)
+    expect(CYBER_SCHEMA_VERSION).toBe(53)
   })
 
   it('exports a source version whose completion watermark counts chunks, not sources', () => {

--- a/packages/persistence/src/migrations.ts
+++ b/packages/persistence/src/migrations.ts
@@ -2463,6 +2463,48 @@ const MIGRATIONS: readonly Migration[] = [
       ALTER TABLE employee_revisions ADD COLUMN connection_grants_json TEXT NOT NULL DEFAULT '[]';
     `,
   },
+  {
+    version: 53,
+    name: 'mcp-skill-grant-unification',
+    sql: `
+      -- Multi-service MCP namespaced every tool behind its connection's
+      -- service slug: a skill id is now \`mcp.<service>.<tool>\`, and both the
+      -- /mcp proposal path and the grant check resolve only that
+      -- service-qualified form. Grants written by the earlier single-service
+      -- adapter are two-segment \`mcp.<tool>\` (its lone connection always
+      -- backfilled to service \`default\`), so they stopped matching and the
+      -- profile panel kept showing them as orphaned "当前不可用" entries.
+      --
+      -- Only two-segment ids are rewritten: the legacy connection exposed
+      -- dot-free tool names (browser_*), so \`mcp.\` + a dot-free token is
+      -- unambiguously legacy and becomes \`mcp.default.<token>\`. Ids that
+      -- already carry a service segment (\`mcp.<service>.<tool>\`, three
+      -- segments or more) are the current form and stay byte-identical.
+      -- Historical revisions are rewritten too: a rollback to an older
+      -- revision must not resurrect the dead id. Execution and audit facts
+      -- (skill_actions, blueprints' requested skills) are deliberately left
+      -- alone — they record what ran, not what is grantable.
+      UPDATE employee_revisions
+      SET skill_grants_json = (
+          SELECT COALESCE(
+            json_group_array(
+              CASE
+                WHEN substr(je.value, 1, 4) = 'mcp.' AND instr(substr(je.value, 5), '.') = 0
+                THEN 'mcp.default.' || substr(je.value, 5)
+                ELSE je.value
+              END
+            ),
+            '[]'
+          )
+          FROM json_each(employee_revisions.skill_grants_json) AS je
+        )
+      WHERE EXISTS (
+          SELECT 1
+          FROM json_each(employee_revisions.skill_grants_json) AS je
+          WHERE substr(je.value, 1, 4) = 'mcp.' AND instr(substr(je.value, 5), '.') = 0
+        );
+    `,
+  },
 ]
 
 /**

--- a/packages/persistence/tests/sqlite-store.test.ts
+++ b/packages/persistence/tests/sqlite-store.test.ts
@@ -1950,6 +1950,65 @@ describe('SqliteStore', () => {
     expect(columns.find((column) => column.name === 'accepted_at')).toMatchObject({ notnull: 1 })
     expect(columns.find((column) => column.name === 'started_at')).toMatchObject({ notnull: 0 })
   })
+
+  it('rewrites legacy two-segment MCP skill grants to the service-qualified form', async () => {
+    const { path, store } = await testDatabase()
+    const workspace = store.createWorkspace({ name: 'MCP grant migration' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: 'MCP 迁移世界', templateId: 'cyber-company' })
+    store.saveBlueprint(blueprint({ id: 'mcp-migration.worker', worldTemplateId: 'cyber-company' }))
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id,
+      worldId: world.id,
+      blueprintId: 'mcp-migration.worker',
+      blueprintVersion: 1,
+    })
+    // The shape the pre-multi-service adapter left behind: two-segment
+    // mcp.<tool> grants next to already-qualified ids and foreign skills.
+    const legacyGrants = [
+      'core.chat',
+      'mcp.browser_navigate',
+      'mcp.browser_click',
+      'mcp.github.search',
+      'mcp.default.browser_snapshot',
+      'device.ssh.command',
+    ]
+    const writeGrants = (revision: number, grants: string[]) =>
+      store.database
+        .prepare('UPDATE employee_revisions SET skill_grants_json = ? WHERE employee_id = ? AND revision = ?')
+        .run(JSON.stringify(grants), employee.id, revision)
+    writeGrants(1, legacyGrants)
+    store.reviseEmployee({ employeeId: employee.id, reason: 'seed revision two' })
+    writeGrants(2, legacyGrants)
+    store.close()
+    stores.splice(stores.indexOf(store), 1)
+
+    // Rewind only the grant-rewrite migration; v53 carries no schema change.
+    const legacy = new DatabaseSync(path)
+    legacy.exec(`
+      DELETE FROM schema_migrations WHERE version > 52;
+      PRAGMA user_version = 52;
+    `)
+    legacy.close()
+
+    const migrated = await SqliteStore.open(path)
+    stores.push(migrated)
+    const unified = [
+      'core.chat',
+      'mcp.default.browser_navigate',
+      'mcp.default.browser_click',
+      'mcp.github.search',
+      'mcp.default.browser_snapshot',
+      'device.ssh.command',
+    ]
+    // Both revisions are rewritten: a rollback to an old revision must not
+    // resurrect the dead two-segment ids.
+    expect(migrated.getEmployeeRevision(employee.id, 1)).toMatchObject({ skillGrants: unified })
+    expect(migrated.getEmployeeRevision(employee.id, 2)).toMatchObject({ skillGrants: unified })
+    // The rewrite is a pure string transform: already-qualified ids, foreign
+    // ids and their order survive byte-identical.
+    expect(migrated.getEmployeeRevision(employee.id, 1)).not.toMatchObject({ skillGrants: legacyGrants })
+    expect(migrated.doctor()).toMatchObject({ ok: true, schemaVersion: CYBER_SCHEMA_VERSION })
+  })
 })
 
 describe('world trace watermark', () => {

--- a/packages/server/src/integrations/mcp-client.ts
+++ b/packages/server/src/integrations/mcp-client.ts
@@ -1,4 +1,5 @@
 import { Client, StreamableHTTPClientTransport, type AuthProvider } from '@modelcontextprotocol/client'
+import { StdioClientTransport } from '@modelcontextprotocol/client/stdio'
 
 import type { JsonObject } from '@dsh-cyber/contracts'
 
@@ -15,43 +16,68 @@ export interface McpClientConnection {
   close(): Promise<void>
 }
 
+/**
+ * How a connection talks to an MCP server:
+ * - `remote`: connect to an already-running Streamable HTTP endpoint
+ *   (optionally with a bearer credential).
+ * - `local`: launch the configured local process and speak MCP over its
+ *   stdio. The child inherits only the SDK's safe default environment and is
+ *   killed when the session closes.
+ */
+export type McpConnectSpec =
+  | { kind: 'remote'; endpoint: string; bearerToken?: string }
+  | { kind: 'local'; command: string; args: readonly string[] }
+
 export interface McpClientFactory {
-  connect(endpoint: string, bearerToken?: string): Promise<McpClientConnection>
+  connect(spec: McpConnectSpec): Promise<McpClientConnection>
 }
 
-/** Official MCP SDK transport seam. Tests inject a fake without opening sockets. */
+/** Official MCP SDK transport seam. Tests inject a fake without opening sockets or spawning processes. */
 export class OfficialMcpClientFactory implements McpClientFactory {
-  async connect(endpoint: string, bearerToken?: string): Promise<McpClientConnection> {
+  async connect(spec: McpConnectSpec): Promise<McpClientConnection> {
     const client = new Client({ name: 'dsh-cyber', version: '0.1.0' })
-    const authProvider: AuthProvider | undefined = bearerToken === undefined
+    if (spec.kind === 'local') {
+      const transport = new StdioClientTransport({
+        command: spec.command,
+        args: [...spec.args],
+        stderr: 'ignore',
+      })
+      await client.connect(transport)
+      return wrapMcpClient(client)
+    }
+    const authProvider: AuthProvider | undefined = spec.bearerToken === undefined
       ? undefined
-      : { token: async () => bearerToken }
-    const transport = new StreamableHTTPClientTransport(new URL(endpoint), {
+      : { token: async () => spec.bearerToken }
+    const transport = new StreamableHTTPClientTransport(new URL(spec.endpoint), {
       ...(authProvider === undefined ? {} : { authProvider }),
       requestInit: { signal: AbortSignal.timeout(30_000) },
       onInsufficientScope: 'throw',
     })
     await client.connect(transport)
-    return {
-      async listTools() {
-        const tools: McpToolDefinition[] = []
-        let cursor: string | undefined
-        do {
-          const page = await client.listTools(cursor === undefined ? {} : { cursor })
-          for (const tool of page.tools) {
-            tools.push({
-              name: tool.name,
-              ...(tool.description === undefined ? {} : { description: tool.description }),
-              inputSchema: tool.inputSchema as JsonObject,
-              ...(tool.annotations === undefined ? {} : { annotations: tool.annotations as JsonObject }),
-            })
-          }
-          cursor = page.nextCursor
-        } while (cursor !== undefined)
-        return tools
-      },
-      callTool(name, args) { return client.callTool({ name, arguments: args }) },
-      close() { return client.close() },
-    }
+    return wrapMcpClient(client)
+  }
+}
+
+function wrapMcpClient(client: Client): McpClientConnection {
+  return {
+    async listTools() {
+      const tools: McpToolDefinition[] = []
+      let cursor: string | undefined
+      do {
+        const page = await client.listTools(cursor === undefined ? {} : { cursor })
+        for (const tool of page.tools) {
+          tools.push({
+            name: tool.name,
+            ...(tool.description === undefined ? {} : { description: tool.description }),
+            inputSchema: tool.inputSchema as JsonObject,
+            ...(tool.annotations === undefined ? {} : { annotations: tool.annotations as JsonObject }),
+          })
+        }
+        cursor = page.nextCursor
+      } while (cursor !== undefined)
+      return tools
+    },
+    callTool(name, args) { return client.callTool({ name, arguments: args }) },
+    close() { return client.close() },
   }
 }

--- a/packages/server/src/integrations/mcp-provider.ts
+++ b/packages/server/src/integrations/mcp-provider.ts
@@ -1,23 +1,61 @@
 import type { IntegrationDescriptor, IntegrationHealth, JsonObject } from '@dsh-cyber/contracts'
 
 import type { IntegrationProvider, IntegrationProviderContext } from './integration-registry.js'
-import type { McpClientFactory } from './mcp-client.js'
+import type { McpClientFactory, McpConnectSpec } from './mcp-client.js'
 import { normalizeIntegrationBaseUrl } from './firecrawl-provider.js'
 
 export const MCP_INTEGRATION_ID = 'builtin.mcp'
 /** Service slug a connection created before multi-service support is backfilled with on load. */
 export const MCP_LEGACY_SERVICE_SLUG = 'default'
+/** Execution mode a connection created before dual-mode support is backfilled with on load. */
+export const MCP_LEGACY_MODE = 'remote'
 
 const DESCRIPTOR: IntegrationDescriptor = {
   id: MCP_INTEGRATION_ID,
   displayName: 'MCP 连接',
-  summary: '通过 Streamable HTTP 添加并调用多个 MCP 服务。每个服务的工具按「服务标识」命名空间映射为独立技能，仍需角色授权与逐动作审批。',
+  summary: '接入一个或多个 MCP 服务：远程模式连接已有 MCP 服务地址（可选 Bearer 凭据），本机模式由应用直接拉起本地 MCP 进程。每个服务的工具按「服务标识」命名空间映射为独立技能，仍需角色授权与逐动作审批。',
   configFields: [
     { id: 'service', displayName: '服务标识', description: '短小写标识（字母/数字/连字符），用于技能 ID mcp.<标识>.<工具> 与 /mcp 命令；同一工作区内须唯一。', kind: 'text', required: true, placeholder: 'github' },
-    { id: 'endpoint', displayName: 'MCP 地址', description: '完整的 Streamable HTTP MCP 地址；公网必须使用 HTTPS。', kind: 'url', required: true, placeholder: 'http://127.0.0.1:3000/mcp' },
+    {
+      id: 'mode',
+      displayName: '运行模式',
+      description: '远程：连接一个已在运行的 MCP 服务地址；本机：由应用按命令拉起本地 MCP 进程并通过 stdio 通信。',
+      kind: 'select',
+      required: true,
+      options: ['remote', 'local'],
+      optionLabels: { remote: '远程服务地址', local: '本机进程（应用拉起）' },
+      placeholder: 'remote',
+    },
+    {
+      id: 'endpoint',
+      displayName: 'MCP 地址',
+      description: '远程模式必填：完整的 Streamable HTTP MCP 地址；公网必须使用 HTTPS。',
+      kind: 'url',
+      required: true,
+      placeholder: 'http://127.0.0.1:8931/mcp',
+      visibleWhen: { field: 'mode', equals: ['remote'] },
+    },
+    {
+      id: 'command',
+      displayName: '启动命令',
+      description: '本机模式必填：MCP 服务的可执行文件，如 npx 或 node（无 Shell 语法）。',
+      kind: 'text',
+      required: false,
+      placeholder: 'npx',
+      visibleWhen: { field: 'mode', equals: ['local'] },
+    },
+    {
+      id: 'args',
+      displayName: '命令参数',
+      description: '本机模式可选：空格分隔的参数列表，如 "@playwright/mcp@latest --port 8931"。',
+      kind: 'text',
+      required: false,
+      placeholder: '@playwright/mcp@latest',
+      visibleWhen: { field: 'mode', equals: ['local'] },
+    },
     { id: 'displayName', displayName: '连接名称', description: '可选，用于在连接列表中区分多个 MCP 服务。', kind: 'text', required: false, placeholder: 'GitHub MCP' },
   ],
-  secretFields: [{ id: 'bearerToken', displayName: 'Bearer Token', description: '可选，仅在本机加密凭据库保存，保存后不回显。', kind: 'secret', required: false }],
+  secretFields: [{ id: 'bearerToken', displayName: 'Bearer Token', description: '可选，仅远程模式使用；在本机加密凭据库保存，保存后不回显。', kind: 'secret', required: false }],
   skillIds: [],
   dataEgress: ['所批准工具调用的结构化参数'],
   allowsMultipleConnections: true,
@@ -31,17 +69,23 @@ export class McpIntegrationProvider implements IntegrationProvider {
 
   validateConfig(config: JsonObject): JsonObject {
     const service = mcpServiceSlug(config)
-    const endpoint = mcpEndpoint(config)
+    const mode = mcpMode(config)
     const displayName = typeof config.displayName === 'string' ? config.displayName.trim().slice(0, 80) : ''
-    return { service, endpoint, ...(displayName === '' ? {} : { displayName }) }
+    if (mode === 'local') {
+      const command = mcpLocalCommand(config)
+      const args = normalizeMcpLocalArgs(config)
+      return { service, mode, command, args, ...(displayName === '' ? {} : { displayName }) }
+    }
+    const endpoint = mcpEndpoint(config)
+    return { service, mode, endpoint, ...(displayName === '' ? {} : { displayName }) }
   }
 
   async testConnection(context: IntegrationProviderContext): Promise<IntegrationHealth> {
     const startedAt = Date.now()
     let client
     try {
-      const endpoint = mcpEndpoint(context.config)
-      client = await this.#clients.connect(endpoint, context.credential)
+      const spec = mcpConnectSpecFor(context.config, context.credential)
+      client = await this.#clients.connect(spec)
       const tools = await client.listTools()
       return { status: 'ready', detail: `连接成功，发现 ${tools.length} 个工具`, checkedAt: context.now.toISOString(), latencyMs: Date.now() - startedAt }
     } catch {
@@ -75,7 +119,71 @@ export function mcpServiceSlug(config: JsonObject): string {
   return normalizeMcpServiceSlug(String(config.service))
 }
 
+/**
+ * Execution mode of a connection. A missing or unknown mode backfills to
+ * `remote`, which is exactly what every pre-dual-mode connection was.
+ */
+export function mcpMode(config: JsonObject): 'remote' | 'local' {
+  return config.mode === 'local' ? 'local' : MCP_LEGACY_MODE
+}
+
 export function mcpEndpoint(config: JsonObject): string {
   if (typeof config.endpoint !== 'string') throw new Error('MCP 地址未配置')
   return normalizeIntegrationBaseUrl(config.endpoint)
+}
+
+/** The local executable that launches the MCP server (machine executable name or path, no shell syntax). */
+export function mcpLocalCommand(config: JsonObject): string {
+  const value = typeof config.command === 'string' ? config.command.trim() : ''
+  if (!value) throw new Error('本机 MCP 启动命令未配置')
+  if (value.length > 200) throw new Error('本机 MCP 启动命令过长')
+  assertNoShellSyntax(value, '本机 MCP 启动命令')
+  return value
+}
+
+/**
+ * The local argument list, normalized to one collapsed-whitespace string that
+ * the form and the config store can both round-trip. Empty is a legal value
+ * (an MCP server with no arguments); tokens are checked for shell syntax so
+ * the value is always a plain executable + argument vector.
+ */
+export function normalizeMcpLocalArgs(config: JsonObject): string {
+  const raw = typeof config.args === 'string' ? config.args : Array.isArray(config.args) ? config.args.join(' ') : ''
+  const tokens = raw.trim().split(/\s+/).filter((token) => token.length > 0)
+  if (tokens.length > 16) throw new Error('本机 MCP 命令参数过多（最多 16 项）')
+  for (const token of tokens) {
+    if (token.length > 200) throw new Error('本机 MCP 单个参数过长')
+    assertNoShellSyntax(token, '本机 MCP 命令参数')
+  }
+  return tokens.join(' ')
+}
+
+/** Split a normalized local args string into the spawn argv. */
+export function mcpLocalArgs(config: JsonObject): string[] {
+  return normalizeMcpLocalArgs(config).length === 0 ? [] : normalizeMcpLocalArgs(config).split(' ')
+}
+
+const SHELL_SYNTAX = /[&;|<>"'`\n\r]/
+
+function assertNoShellSyntax(value: string, label: string): void {
+  if (SHELL_SYNTAX.test(value)) throw new Error(`${label}不得包含 Shell 元字符`)
+}
+
+/** The connection spec handed to the client factory, by execution mode. */
+export function mcpConnectSpec(config: JsonObject): McpConnectSpec {
+  if (mcpMode(config) === 'local') {
+    return { kind: 'local', command: mcpLocalCommand(config), args: mcpLocalArgs(config) }
+  }
+  return { kind: 'remote', endpoint: mcpEndpoint(config) }
+}
+
+/**
+ * The spec with the connection's stored bearer credential attached. Local
+ * specs never carry a credential: the launched process authenticates with
+ * whatever the user configured on that machine.
+ */
+export function mcpConnectSpecFor(config: JsonObject, credential?: string): McpConnectSpec {
+  const spec = mcpConnectSpec(config)
+  if (spec.kind === 'local' || credential === undefined) return spec
+  return { ...spec, bearerToken: credential }
 }

--- a/packages/server/src/skills/mcp-skill-adapter.ts
+++ b/packages/server/src/skills/mcp-skill-adapter.ts
@@ -2,7 +2,7 @@ import type { CharacterSkillAction, CharacterSkillDescriptor } from '@dsh-cyber/
 import type { JsonObject } from '@dsh-cyber/contracts'
 import type { SqliteStore } from '@dsh-cyber/persistence'
 
-import { MCP_INTEGRATION_ID, mcpEndpoint, normalizeMcpServiceSlug } from '../integrations/mcp-provider.js'
+import { MCP_INTEGRATION_ID, mcpConnectSpecFor, normalizeMcpServiceSlug } from '../integrations/mcp-provider.js'
 import type { McpClientFactory, McpToolDefinition } from '../integrations/mcp-client.js'
 import type { IntegrationService } from '../integrations/integration-service.js'
 import { ServiceError } from '../services/service-error.js'
@@ -65,7 +65,9 @@ export class McpSkillAdapter implements CharacterSkillAdapter {
         const service = mcpServiceSlugForConnection(connection)
         let client
         try {
-          client = await this.#clients.connect(mcpEndpoint(connection.config), this.#integrations.credentialForConnection(workspace.id, connection.id))
+          client = await this.#clients.connect(
+            mcpConnectSpecFor(connection.config, this.#integrations.credentialForConnection(workspace.id, connection.id)),
+          )
           const tools = (await client.listTools()).slice(0, 100)
           const discovered: DiscoveredTool[] = []
           for (const tool of tools) {
@@ -185,7 +187,9 @@ export class McpSkillAdapter implements CharacterSkillAdapter {
     if (args === undefined) return { status: 'failed', detail: 'MCP 工具参数已过期或无法解密，未调用外部工具' }
     let client
     try {
-      client = await this.#clients.connect(mcpEndpoint(connection.config), this.#integrations.credentialForConnection(world.workspaceId, connectionId))
+      client = await this.#clients.connect(
+        mcpConnectSpecFor(connection.config, this.#integrations.credentialForConnection(world.workspaceId, connectionId)),
+      )
       const result = await client.callTool(toolName, args)
       return { status: 'executed', detail: summarizeMcpResult(discovered.service, toolName, result) }
     } finally {

--- a/packages/server/src/skills/mcp-skill-adapter.ts
+++ b/packages/server/src/skills/mcp-skill-adapter.ts
@@ -10,7 +10,7 @@ import type { CharacterSkillActionProposal, CharacterSkillAdapter, CharacterSkil
 
 export const MCP_ADAPTER_ID = 'builtin.mcp'
 
-interface DiscoveredTool { workspaceId: string; connectionId: string; service: string; skillId: string; tool: McpToolDefinition }
+interface DiscoveredTool { workspaceId: string; connectionId: string; service: string; label: string; skillId: string; tool: McpToolDefinition }
 
 /**
  * MCP is only a transport behind DSH Cyber's capability broker. Discovery
@@ -21,6 +21,12 @@ interface DiscoveredTool { workspaceId: string; connectionId: string; service: s
  * slug, so a skill id is `mcp.<service>.<tool>` and the owning connection is
  * recorded on every discovered tool; execution resolves that connection's
  * credential rather than a single first-connection credential.
+ *
+ * Discovery stays tool-granular: grants, execution and the action ledger all
+ * name the exact tool. The descriptor's `mcpService` field is presentation
+ * metadata only — UI surfaces collapse one service's tool descriptors into a
+ * single "MCP · <connection name>" entry whose one checkbox grants every
+ * tool of that service.
  */
 export class McpSkillAdapter implements CharacterSkillAdapter {
   readonly id = MCP_ADAPTER_ID
@@ -37,14 +43,15 @@ export class McpSkillAdapter implements CharacterSkillAdapter {
   get descriptors(): readonly CharacterSkillDescriptor[] {
     return [...this.#tools.entries()].map(([skillId, entries]) => ({
       id: skillId,
-      displayName: `MCP · ${entries[0]!.service} / ${entries[0]!.tool.name}`,
-      summary: safeToolDescription(entries[0]!.tool, entries[0]!.service),
+      displayName: `MCP · ${entries[0]!.label} / ${entries[0]!.tool.name}`,
+      summary: safeToolDescription(entries[0]!.tool, entries[0]!.label),
       adapterId: this.id,
       risks: ['external-side-effect'],
       supportsScheduling: false,
       persistentApproval: 'forbidden',
       kind: 'integration',
       recommendedByDefault: false,
+      mcpService: { id: entries[0]!.service, label: entries[0]!.label },
     }))
   }
 
@@ -63,6 +70,7 @@ export class McpSkillAdapter implements CharacterSkillAdapter {
       for (const connection of this.#integrations.listByType(workspace.id, MCP_INTEGRATION_ID)) {
         if (!connection.enabled) continue
         const service = mcpServiceSlugForConnection(connection)
+        const label = mcpServiceLabelForConnection(connection)
         let client
         try {
           client = await this.#clients.connect(
@@ -76,7 +84,7 @@ export class McpSkillAdapter implements CharacterSkillAdapter {
             if (discovered.some((entry) => entry.skillId === skillId)) {
               throw new Error(`MCP tool id collision: ${tool.name}`)
             }
-            discovered.push({ workspaceId: workspace.id, connectionId: connection.id, service, skillId, tool })
+            discovered.push({ workspaceId: workspace.id, connectionId: connection.id, service, label, skillId, tool })
           }
           // Only a fully validated catalog is published, so a connection never
           // ends up with half of its tools.
@@ -222,6 +230,19 @@ function mcpServiceSlugForConnection(connection: { config: JsonObject }): string
   const raw = connection.config.service
   if (raw === undefined) return 'default'
   return normalizeMcpServiceSlug(String(raw))
+}
+
+/**
+ * The display name of this MCP service on the "MCP · <connection name>" panel
+ * row. Prefer the user-configured connection name (`config.displayName`); fall
+ * back to the service slug. The connection-level `displayName` is not used:
+ * for unnamed connections it is the integration descriptor's generic name
+ * ("MCP 连接") and would label every service identically.
+ */
+function mcpServiceLabelForConnection(connection: { config: JsonObject }): string {
+  const configured = typeof connection.config.displayName === 'string' ? connection.config.displayName.trim() : ''
+  if (configured !== '') return configured.slice(0, 80)
+  return mcpServiceSlugForConnection(connection)
 }
 
 function normalizeToolName(toolName: string): string {

--- a/packages/server/tests/mcp-client-stdio.test.ts
+++ b/packages/server/tests/mcp-client-stdio.test.ts
@@ -1,0 +1,93 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { OfficialMcpClientFactory } from '../src/integrations/mcp-client.js'
+
+const directories: string[] = []
+afterEach(async () => {
+  for (const directory of directories.splice(0)) await rm(directory, { recursive: true, force: true })
+})
+
+/**
+ * A hand-rolled minimal MCP stdio server: newline-delimited JSON-RPC over
+ * stdin/stdout. It speaks just enough of the protocol (initialize,
+ * tools/list, tools/call) to exercise the real StdioClientTransport path —
+ * including the process launch and the kill-on-close.
+ */
+const ECHO_SERVER_SCRIPT = `
+import { createInterface } from 'node:readline'
+
+const rl = createInterface({ input: process.stdin })
+const send = (message) => { process.stdout.write(JSON.stringify(message) + '\\n') }
+rl.on('line', (line) => {
+  const text = line.trim()
+  if (text === '') return
+  let message
+  try { message = JSON.parse(text) } catch { return }
+  if (message.method === 'initialize') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        protocolVersion: message.params?.protocolVersion ?? '2024-11-05',
+        capabilities: { tools: {} },
+        serverInfo: { name: 'echo-mcp', version: '0.1.0' },
+      },
+    })
+  } else if (message.method === 'tools/list') {
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: {
+        tools: [{
+          name: 'echo',
+          description: 'Echoes the text argument',
+          inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+        }],
+      },
+    })
+  } else if (message.method === 'tools/call') {
+    const value = message.params?.arguments?.text
+    send({
+      jsonrpc: '2.0',
+      id: message.id,
+      result: { content: [{ type: 'text', text: typeof value === 'string' ? 'echo:' + value : 'echo:' }] },
+    })
+  }
+})
+`
+
+describe('OfficialMcpClientFactory local (stdio) mode', () => {
+  it('launches a local process, discovers and calls its tools, then closes it', async () => {
+    const directory = await mkdtemp(join(tmpdir(), 'dsh-mcp-stdio-')); directories.push(directory)
+    const scriptPath = join(directory, 'echo-mcp.mjs')
+    await writeFile(scriptPath, ECHO_SERVER_SCRIPT, 'utf8')
+
+    const factory = new OfficialMcpClientFactory()
+    const connection = await factory.connect({ kind: 'local', command: process.execPath, args: [scriptPath] })
+    const tools = await connection.listTools()
+    expect(tools).toEqual([
+      {
+        name: 'echo',
+        description: 'Echoes the text argument',
+        inputSchema: { type: 'object', properties: { text: { type: 'string' } } },
+      },
+    ])
+    const result = (await connection.callTool('echo', { text: 'hello-mcp' })) as { content?: Array<{ type: string; text?: string }> }
+    expect(result.content?.[0]).toMatchObject({ type: 'text', text: 'echo:hello-mcp' })
+    await connection.close()
+    // Closing the session ended the transport: the dead session no longer
+    // serves tools (a live one would still return the echo tool).
+    const afterClose = await connection.listTools().catch(() => [])
+    expect(afterClose).toEqual([])
+  })
+
+  it('fails cleanly when the configured command does not exist', async () => {
+    const factory = new OfficialMcpClientFactory()
+    const missing = process.platform === 'win32' ? 'dsh-cyber-definitely-missing-mcp' : '/nonexistent/dsh-cyber-mcp'
+    await expect(factory.connect({ kind: 'local', command: missing, args: [] })).rejects.toThrow()
+  })
+})

--- a/packages/server/tests/mcp-provider-dual-mode.test.ts
+++ b/packages/server/tests/mcp-provider-dual-mode.test.ts
@@ -1,0 +1,94 @@
+import type { JsonObject } from '@dsh-cyber/contracts'
+
+import { afterEach, describe, expect, it } from 'vitest'
+
+import type { McpClientConnection, McpClientFactory } from '../src/integrations/mcp-client.js'
+import {
+  MCP_INTEGRATION_ID,
+  mcpConnectSpec,
+  mcpConnectSpecFor,
+  mcpLocalArgs,
+  mcpMode,
+} from '../src/integrations/mcp-provider.js'
+import { createBuiltinIntegrationRegistry } from '../src/integrations/builtin-integration-registry.js'
+
+describe('MCP dual-mode provider', () => {
+  it('backfills legacy endpoint configs to the remote mode', () => {
+    const config = { service: 'github', endpoint: 'https://mcp.example.com' }
+    expect(mcpMode(config)).toBe('remote')
+    const spec = mcpConnectSpec(config as JsonObject)
+    expect(spec).toEqual({ kind: 'remote', endpoint: 'https://mcp.example.com' })
+  })
+
+  it('normalizes a local config into command + collapsed arguments', () => {
+    const registry = createBuiltinIntegrationRegistry(new NoopMcpClientFactory())
+    const provider = registry.require(MCP_INTEGRATION_ID)
+    const config = provider.validateConfig({
+      service: 'playwright',
+      mode: 'local',
+      command: '  npx ',
+      args: '@playwright/mcp@latest   --port 8931 --isolated',
+      endpoint: 'http://stale.example.com',
+      displayName: 'Playwright',
+    })
+    expect(config).toEqual({
+      service: 'playwright',
+      mode: 'local',
+      command: 'npx',
+      args: '@playwright/mcp@latest --port 8931 --isolated',
+      displayName: 'Playwright',
+    })
+    expect(mcpLocalArgs(config)).toEqual(['@playwright/mcp@latest', '--port', '8931', '--isolated'])
+  })
+
+  it('rejects local configs that cannot be launched as a plain argv', () => {
+    const registry = createBuiltinIntegrationRegistry(new NoopMcpClientFactory())
+    const provider = registry.require(MCP_INTEGRATION_ID)
+    expect(() => provider.validateConfig({ service: 'x', mode: 'local' })).toThrow('启动命令未配置')
+    expect(() => provider.validateConfig({ service: 'x', mode: 'local', command: 'node && rm -rf' })).toThrow('Shell 元字符')
+    expect(() => provider.validateConfig({ service: 'x', mode: 'local', command: 'node', args: 'a "b c" d' })).toThrow('Shell 元字符')
+    const overflow = Array.from({ length: 17 }, (_, index) => `arg${index}`).join(' ')
+    expect(() => provider.validateConfig({ service: 'x', mode: 'local', command: 'node', args: overflow })).toThrow('参数过多')
+  })
+
+  it('rejects a remote config without an endpoint even when a stale local endpoint is absent', () => {
+    const registry = createBuiltinIntegrationRegistry(new NoopMcpClientFactory())
+    const provider = registry.require(MCP_INTEGRATION_ID)
+    expect(() => provider.validateConfig({ service: 'x', mode: 'remote' })).toThrow('MCP 地址未配置')
+  })
+
+  it('only attaches a bearer credential to remote specs', () => {
+    const remote = { service: 'github', mode: 'remote', endpoint: 'https://mcp.example.com' } as JsonObject
+    expect(mcpConnectSpecFor(remote)).toEqual({ kind: 'remote', endpoint: 'https://mcp.example.com' })
+    expect(mcpConnectSpecFor(remote, 'top-secret')).toEqual({ kind: 'remote', endpoint: 'https://mcp.example.com', bearerToken: 'top-secret' })
+    const local = { service: 'pw', mode: 'local', command: 'npx', args: '@playwright/mcp' } as JsonObject
+    expect(mcpConnectSpecFor(local, 'top-secret')).toEqual({ kind: 'local', command: 'npx', args: ['@playwright/mcp'] })
+  })
+
+  it('tests a local connection through the provider health seam', async () => {
+    const calls: Array<{ kind: string }> = []
+    const factory: McpClientFactory = {
+      async connect(spec) {
+        calls.push({ kind: spec.kind })
+        return {
+          listTools: async () => (spec.kind === 'local' ? [{ name: 'echo', inputSchema: {} }] : []),
+          callTool: async () => ({}),
+          close: async () => undefined,
+        } satisfies McpClientConnection
+      },
+    }
+    const registry = createBuiltinIntegrationRegistry(factory)
+    const provider = registry.require(MCP_INTEGRATION_ID)
+    const config = provider.validateConfig({ service: 'pw', mode: 'local', command: 'npx', args: '@playwright/mcp' })
+    const health = await provider.testConnection({ config, fetch: globalThis.fetch, now: new Date() })
+    expect(health.status).toBe('ready')
+    expect(health.detail).toContain('1 个工具')
+    expect(calls).toEqual([{ kind: 'local' }])
+  })
+})
+
+class NoopMcpClientFactory implements McpClientFactory {
+  async connect(): Promise<McpClientConnection> {
+    return { listTools: async () => [], callTool: async () => ({}), close: async () => undefined }
+  }
+}

--- a/packages/server/tests/mcp-skill-adapter.test.ts
+++ b/packages/server/tests/mcp-skill-adapter.test.ts
@@ -46,7 +46,16 @@ describe('MCP Skill Adapter V1', () => {
     await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', mode: 'remote', endpoint: 'http://127.0.0.1:3900/mcp' }, enabled: true, credential: 'private-bearer' })
     const adapter = new McpSkillAdapter({ store, integrations, clients })
     const registry = new CharacterSkillAdapterRegistry(); registry.register(adapter); await adapter.refresh(); registry.refresh(adapter)
-    expect(registry.list()).toEqual([expect.objectContaining({ id: skillId, adapterId: 'builtin.mcp', risks: ['external-side-effect'] })])
+    expect(registry.list()).toEqual([expect.objectContaining({
+      id: skillId,
+      adapterId: 'builtin.mcp',
+      risks: ['external-side-effect'],
+      displayName: 'MCP · github / create_issue',
+      // Presentation metadata: the panel collapses this service's tools into
+      // one "MCP · <connection name>" row; unnamed connections fall back to
+      // the service slug.
+      mcpService: { id: 'github', label: 'github' },
+    })])
     const runtime = new CharacterSkillRuntime(store, { registry, actions: new SqliteSkillActionRepository(store) })
 
     const denied = await registry.propose({ worldId: world.id, characterId: employee.id, prompt: '/mcp github.create_issue {"title":"secret subject"}', grantedSkillIds: [], now: new Date() })
@@ -100,7 +109,7 @@ describe('MCP Skill Adapter V1', () => {
       ] },
     ])
     const integrations = await IntegrationService.open(root, createBuiltinIntegrationRegistry(clients))
-    const github = await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', mode: 'remote', endpoint: 'http://127.0.0.1:3900/mcp' }, enabled: true, credential: 'github-token' })
+    const github = await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', mode: 'remote', endpoint: 'http://127.0.0.1:3900/mcp', displayName: 'GitHub MCP' }, enabled: true, credential: 'github-token' })
     await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'linear', mode: 'remote', endpoint: 'http://127.0.0.1:3901/mcp' }, enabled: true, credential: 'linear-token' })
 
     const blueprint: EmployeeBlueprint = {
@@ -118,9 +127,9 @@ describe('MCP Skill Adapter V1', () => {
     const adapter = new McpSkillAdapter({ store, integrations, clients })
     await adapter.refresh()
     expect(adapter.descriptorsFor(workspace.id)).toEqual([
-      expect.objectContaining({ id: 'mcp.github.create_issue' }),
-      expect.objectContaining({ id: 'mcp.linear.create_issue' }),
-      expect.objectContaining({ id: 'mcp.linear.sync_board' }),
+      expect.objectContaining({ id: 'mcp.github.create_issue', mcpService: { id: 'github', label: 'GitHub MCP' } }),
+      expect.objectContaining({ id: 'mcp.linear.create_issue', mcpService: { id: 'linear', label: 'linear' } }),
+      expect.objectContaining({ id: 'mcp.linear.sync_board', mcpService: { id: 'linear', label: 'linear' } }),
     ])
 
     const granted = [mcpSkillId('github', 'create_issue'), mcpSkillId('linear', 'create_issue'), mcpSkillId('linear', 'sync_board')]
@@ -160,12 +169,16 @@ describe('MCP Skill Adapter V1', () => {
     await integrations.save({
       workspaceId: workspace.id,
       integrationId: MCP_INTEGRATION_ID,
-      config: { service: 'playwright', mode: 'local', command: 'npx', args: '@playwright/mcp@latest --port 8931' },
+      config: { service: 'playwright', mode: 'local', command: 'npx', args: '@playwright/mcp@latest --port 8931', displayName: 'Playwright 浏览器' },
       enabled: true,
     })
     const adapter = new McpSkillAdapter({ store, integrations, clients })
     await adapter.refresh()
-    expect(adapter.descriptorsFor(workspace.id)).toEqual([expect.objectContaining({ id: skillId })])
+    expect(adapter.descriptorsFor(workspace.id)).toEqual([expect.objectContaining({
+      id: skillId,
+      displayName: 'MCP · Playwright 浏览器 / browser_navigate',
+      mcpService: { id: 'playwright', label: 'Playwright 浏览器' },
+    })])
 
     // A legacy two-segment grant was rewritten by schema v53 to this exact
     // service-qualified id, so pre-multi-service characters keep working.

--- a/packages/server/tests/mcp-skill-adapter.test.ts
+++ b/packages/server/tests/mcp-skill-adapter.test.ts
@@ -8,7 +8,7 @@ import { SqliteStore } from '@dsh-cyber/persistence'
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createBuiltinIntegrationRegistry } from '../src/integrations/builtin-integration-registry.js'
-import type { McpClientConnection, McpClientFactory, McpToolDefinition } from '../src/integrations/mcp-client.js'
+import type { McpClientConnection, McpClientFactory, McpConnectSpec, McpToolDefinition } from '../src/integrations/mcp-client.js'
 import { MCP_INTEGRATION_ID } from '../src/integrations/mcp-provider.js'
 import { IntegrationService } from '../src/integrations/integration-service.js'
 import { CharacterSkillRuntime } from '../src/services/character-skill-runtime.js'
@@ -39,11 +39,11 @@ describe('MCP Skill Adapter V1', () => {
     store.saveBlueprint(blueprint)
     const employee = store.recruitEmployee({ workspaceId: workspace.id, worldId: world.id, blueprintId: blueprint.id, blueprintVersion: 1, skillGrants: [skillId] })
     const clients = new FakeMcpClientFactory([{
-      endpoint: 'http://127.0.0.1:3900/mcp', bearer: 'private-bearer',
+      endpoint: 'http://127.0.0.1:3900/mcp',
       tools: [{ name: 'create_issue', description: 'Create an issue', inputSchema: { type: 'object', properties: { title: { type: 'string' } } } }],
     }])
     const integrations = await IntegrationService.open(root, createBuiltinIntegrationRegistry(clients))
-    await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', endpoint: 'http://127.0.0.1:3900/mcp' }, enabled: true, credential: 'private-bearer' })
+    await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', mode: 'remote', endpoint: 'http://127.0.0.1:3900/mcp' }, enabled: true, credential: 'private-bearer' })
     const adapter = new McpSkillAdapter({ store, integrations, clients })
     const registry = new CharacterSkillAdapterRegistry(); registry.register(adapter); await adapter.refresh(); registry.refresh(adapter)
     expect(registry.list()).toEqual([expect.objectContaining({ id: skillId, adapterId: 'builtin.mcp', risks: ['external-side-effect'] })])
@@ -75,7 +75,11 @@ describe('MCP Skill Adapter V1', () => {
     expect(clients.calls).toHaveLength(0)
     const result = await runtime.decideApproval(approval.id, 'approved', 'once', 'owner', new Date('2026-08-25T01:01:00.000Z'))
     expect(result.action).toMatchObject({ status: 'executed', detail: expect.stringContaining('原始结果未持久化') })
-    expect(clients.calls).toEqual([{ endpoint: 'http://127.0.0.1:3900/mcp', name: 'create_issue', bearer: 'private-bearer', args: { title: 'secret subject', body: 'secret body' } }])
+    expect(clients.calls).toEqual([{
+      spec: { kind: 'remote', endpoint: 'http://127.0.0.1:3900/mcp', bearerToken: 'private-bearer' },
+      name: 'create_issue',
+      args: { title: 'secret subject', body: 'secret body' },
+    }])
     expect(JSON.stringify(result.action)).not.toContain('secret body')
     expect(await readFile(join(root, 'integrations', 'connections.json'), 'utf8')).not.toContain('private-bearer')
     expect(await readFile(join(root, 'credentials', 'integration-credentials.json'), 'utf8')).not.toContain('secret subject')
@@ -89,15 +93,15 @@ describe('MCP Skill Adapter V1', () => {
     const world = store.createWorld({ workspaceId: workspace.id, name: 'MCP 多服务世界', templateId: 'personal-world' })
 
     const clients = new FakeMcpClientFactory([
-      { endpoint: 'http://127.0.0.1:3900/mcp', bearer: 'github-token', tools: [{ name: 'create_issue', description: 'Open a GitHub issue', inputSchema: { type: 'object' } }] },
-      { endpoint: 'http://127.0.0.1:3901/mcp', bearer: 'linear-token', tools: [
+      { endpoint: 'http://127.0.0.1:3900/mcp', tools: [{ name: 'create_issue', description: 'Open a GitHub issue', inputSchema: { type: 'object' } }] },
+      { endpoint: 'http://127.0.0.1:3901/mcp', tools: [
         { name: 'create_issue', description: 'Open a Linear ticket', inputSchema: { type: 'object' } },
         { name: 'sync_board', description: 'Synchronize a board', inputSchema: { type: 'object' } },
       ] },
     ])
     const integrations = await IntegrationService.open(root, createBuiltinIntegrationRegistry(clients))
-    const github = await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', endpoint: 'http://127.0.0.1:3900/mcp' }, enabled: true, credential: 'github-token' })
-    await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'linear', endpoint: 'http://127.0.0.1:3901/mcp' }, enabled: true, credential: 'linear-token' })
+    const github = await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'github', mode: 'remote', endpoint: 'http://127.0.0.1:3900/mcp' }, enabled: true, credential: 'github-token' })
+    await integrations.save({ workspaceId: workspace.id, integrationId: MCP_INTEGRATION_ID, config: { service: 'linear', mode: 'remote', endpoint: 'http://127.0.0.1:3901/mcp' }, enabled: true, credential: 'linear-token' })
 
     const blueprint: EmployeeBlueprint = {
       schemaVersion: 1, id: 'test.mcp-multi', version: 1, worldTemplateId: 'personal-world',
@@ -133,7 +137,61 @@ describe('MCP Skill Adapter V1', () => {
 
     // Executing resolves each owning connection's endpoint and credential.
     await adapter.execute({ ...githubIssue, worldId: world.id, characterId: employee.id } as unknown as CharacterSkillAction)
-    expect(clients.calls).toContainEqual({ endpoint: 'http://127.0.0.1:3900/mcp', name: 'create_issue', bearer: 'github-token', args: { a: 1 } })
+    expect(clients.calls).toContainEqual({
+      spec: { kind: 'remote', endpoint: 'http://127.0.0.1:3900/mcp', bearerToken: 'github-token' },
+      name: 'create_issue',
+      args: { a: 1 },
+    })
+    integrations.close()
+  })
+
+  it('discovers and executes through a launched local process spec without credentials', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'dsh-mcp-local-')); roots.push(root)
+    const store = await SqliteStore.open(join(root, 'data', 'dsh-cyber.sqlite')); stores.push(store)
+    const workspace = store.createWorkspace({ name: 'MCP 本机模式工作区' })
+    const world = store.createWorld({ workspaceId: workspace.id, name: 'MCP 本机模式世界', templateId: 'personal-world' })
+    const skillId = mcpSkillId('playwright', 'browser_navigate')
+
+    const clients = new FakeMcpClientFactory([{
+      command: 'npx',
+      tools: [{ name: 'browser_navigate', description: 'Navigate the browser', inputSchema: { type: 'object' } }],
+    }])
+    const integrations = await IntegrationService.open(root, createBuiltinIntegrationRegistry(clients))
+    await integrations.save({
+      workspaceId: workspace.id,
+      integrationId: MCP_INTEGRATION_ID,
+      config: { service: 'playwright', mode: 'local', command: 'npx', args: '@playwright/mcp@latest --port 8931' },
+      enabled: true,
+    })
+    const adapter = new McpSkillAdapter({ store, integrations, clients })
+    await adapter.refresh()
+    expect(adapter.descriptorsFor(workspace.id)).toEqual([expect.objectContaining({ id: skillId })])
+
+    // A legacy two-segment grant was rewritten by schema v53 to this exact
+    // service-qualified id, so pre-multi-service characters keep working.
+    const blueprint: EmployeeBlueprint = {
+      schemaVersion: 1, id: 'test.mcp-local', version: 1, worldTemplateId: 'personal-world',
+      displayName: 'MCP 本机员', role: '测试员', summary: '验证本机 MCP', persona: '只执行明确批准的工具',
+      requestedSkills: [skillId], requestedCapabilities: [], createdAt: '2026-08-25T00:00:00.000Z',
+    }
+    store.saveBlueprint(blueprint)
+    const employee = store.recruitEmployee({
+      workspaceId: workspace.id, worldId: world.id, blueprintId: blueprint.id, blueprintVersion: 1,
+      skillGrants: [skillId],
+    })
+    const [proposal] = await adapter.propose({
+      worldId: world.id, characterId: employee.id, grantedSkillIds: [skillId], now: new Date(),
+      prompt: '/mcp playwright.browser_navigate {"url":"https://example.com"}',
+    })
+    expect(proposal).toMatchObject({ skillId, target: 'mcp:playwright.browser_navigate' })
+    const result = await adapter.execute({ ...proposal, worldId: world.id, characterId: employee.id } as unknown as CharacterSkillAction)
+    expect(result.status).toBe('executed')
+    // The local process is driven by command+args, never by a bearer credential.
+    expect(clients.calls).toEqual([{
+      spec: { kind: 'local', command: 'npx', args: ['@playwright/mcp@latest', '--port', '8931'] },
+      name: 'browser_navigate',
+      args: { url: 'https://example.com' },
+    }])
     integrations.close()
   })
 
@@ -149,16 +207,20 @@ describe('MCP Skill Adapter V1', () => {
   })
 })
 
+interface FakeService { endpoint?: string; command?: string; tools: McpToolDefinition[] }
+
 class FakeMcpClientFactory implements McpClientFactory {
-  readonly calls: Array<{ endpoint: string; name: string; args: JsonObject; bearer?: string }> = []
-  constructor(readonly services: Array<{ endpoint: string; bearer?: string; tools: McpToolDefinition[] }>) {}
-  async connect(endpoint: string, bearer?: string): Promise<McpClientConnection> {
-    const service = this.services.find((item) => item.endpoint === endpoint)
+  readonly calls: Array<{ spec: McpConnectSpec; name: string; args: JsonObject }> = []
+  constructor(readonly services: FakeService[]) {}
+  async connect(spec: McpConnectSpec): Promise<McpClientConnection> {
+    const service = this.services.find((item) =>
+      spec.kind === 'remote' ? item.endpoint === spec.endpoint : item.command === spec.command,
+    )
     const tools = service?.tools ?? []
     return {
       listTools: async () => tools,
       callTool: async (name, args) => {
-        this.calls.push({ endpoint, name, args, ...(bearer === undefined ? {} : { bearer }) })
+        this.calls.push({ spec, name, args })
         return { content: [{ type: 'text', text: 'sensitive remote result' }], structuredContent: { issueId: 42 } }
       },
       close: async () => undefined,

--- a/packages/web/src/components/CreativeWorkshopDialog.css
+++ b/packages/web/src/components/CreativeWorkshopDialog.css
@@ -337,6 +337,21 @@
 .creative-workshop-skill-catalog strong { font-size: 14px; }
 .creative-workshop-skill-catalog small { color: var(--text-soft); font-size: 12px; line-height: 1.45; }
 .creative-workshop-skill-catalog em { color: var(--text-muted); font-size: 12px; font-style: normal; }
+/* Aggregated MCP service row: one checkbox requests every tool of the
+   service; the expandable tool list still allows per-tool requests. */
+.creative-workshop-skill-catalog > .creative-workshop-skill-catalog__mcp-service { min-height: 72px; display: grid; grid-template-columns: 22px minmax(0, 1fr); gap: 10px; align-items: start; padding: 12px; border: 1px solid var(--border); background: var(--surface-1); }
+.creative-workshop-skill-catalog > .creative-workshop-skill-catalog__mcp-service.is-selected { border-color: var(--accent); background: var(--accent-soft); }
+.creative-workshop-skill-catalog > .creative-workshop-skill-catalog__mcp-service.is-unavailable { opacity: .72; }
+.creative-workshop-skill-catalog__mcp-service > input { width: 16px; height: 16px; flex-shrink: 0; }
+.creative-workshop-skill-catalog__mcp-service > span { min-width: 0; }
+.creative-workshop-skill-catalog__mcp-tools { margin-top: 2px; }
+.creative-workshop-skill-catalog__mcp-tools summary { cursor: pointer; color: var(--text-muted); font-size: 12px; list-style: none; user-select: none; }
+.creative-workshop-skill-catalog__mcp-tools summary::-webkit-details-marker { display: none; }
+.creative-workshop-skill-catalog__mcp-tools > div { display: grid; gap: 6px; margin-top: 8px; padding-left: 10px; border-left: 1px solid var(--border); }
+.creative-workshop-skill-catalog__mcp-tools label { display: flex; align-items: center; gap: 8px; min-height: 30px; padding: 4px 8px; border: 1px solid var(--border); background: var(--surface-1); cursor: pointer; }
+.creative-workshop-skill-catalog__mcp-tools label.is-selected { border-color: var(--accent); background: var(--accent-soft); }
+.creative-workshop-skill-catalog__mcp-tools input { width: 14px; height: 14px; margin-top: 0; }
+.creative-workshop-skill-catalog__mcp-tools code { flex: 1 1 auto; min-width: 0; color: var(--text-soft); font-size: 12px; }
 .creative-workshop-permission-note { margin: 0; padding: 12px 14px; border-left: 3px solid var(--accent); color: var(--text-soft); background: var(--surface-1); font-size: 12px; line-height: 1.55; }
 .creative-workshop-review { margin: 0; display: grid; border-top: 1px solid var(--border); }
 .creative-workshop-review > div { min-height: 46px; display: grid; grid-template-columns: 130px minmax(0, 1fr); align-items: center; border-bottom: 1px solid var(--border); }

--- a/packages/web/src/components/RecruitmentDialog.tsx
+++ b/packages/web/src/components/RecruitmentDialog.tsx
@@ -1,5 +1,5 @@
 import { Briefcase, Check, IdentificationCard, MagnifyingGlass, ShieldCheck, Sparkle, X } from '@phosphor-icons/react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { AgentPermissionMode, EmployeeBlueprint, EmployeeInstance, World, WorldSnapshot } from '@dsh-cyber/contracts'
 import { api } from '../api.js'
 import { worldExperience } from '../world-experience.js'
@@ -10,6 +10,14 @@ import {
   worldSkillCatalogPath,
   type SkillCatalogEntry,
 } from './skill-catalog.js'
+import {
+  groupMcpServices,
+  mcpServiceChecked,
+  mcpServiceOfSkillId,
+  mcpServiceToggle,
+  orphanMcpServiceGroups,
+  type McpServiceGroup,
+} from './mcp-skill-grouping.js'
 import { RuntimePermissionSelector } from './RuntimePermissionSelector.js'
 import { useI18n } from '../i18n/runtime.js'
 
@@ -192,15 +200,69 @@ export function RecruitmentDialog({ blueprints, initialBlueprintId, employees, w
 
 function blueprintKey(blueprint: EmployeeBlueprint): string { return `${blueprint.id}@${blueprint.version}` }
 
-function SkillApprovalGroup({ requested, descriptors, selected, onChange }: { requested: string[]; descriptors: SkillCatalogEntry[]; selected: string[]; onChange(next: string[]): void }) {
+/**
+ * The template's requested skills, aggregated per MCP service: one "MCP ·
+ * <connection name>" row grants every tool of that service; non-MCP skills
+ * stay one row each. Requested MCP ids whose service no longer has a catalog
+ * entry collapse to a single "暂不可用" service row, revocable in one click.
+ */
+export function SkillApprovalGroup({ requested, descriptors, selected, onChange }: { requested: string[]; descriptors: SkillCatalogEntry[]; selected: string[]; onChange(next: string[]): void }) {
   const { t } = useI18n()
   const byId = new Map(descriptors.map((item) => [item.id, item]))
-  return <fieldset className="capability-approval-group"><legend>{t('workbench.recruitSkillsLegend', '角色技能')}</legend>{requested.length === 0 ? <span>{t('workbench.recruitNoSkills', '该角色模板未请求角色技能')}</span> : requested.map((skillId) => {
-    const descriptor = byId.get(skillId)
-    const available = descriptor !== undefined && descriptor.worldAvailable && descriptor.availability === 'available'
-    const granted = selected.includes(skillId)
-    return <label key={skillId} className={!available ? 'is-unavailable' : ''}><input type="checkbox" checked={granted} disabled={!available && !granted} onChange={(event) => onChange(event.target.checked ? [...new Set([...selected, skillId])] : selected.filter((value) => value !== skillId))}/><span><strong>{descriptor?.displayName ?? skillId}</strong><small>{descriptor?.summary ?? '当前世界暂不可用，创建时不会新增这项角色技能。'}</small><em>{!available ? '暂不可用' : granted ? '已启用' : '推荐'}</em></span></label>
-  })}</fieldset>
+  const mcpRequested = requested.filter((id) => mcpServiceOfSkillId(id) !== undefined)
+  const plainRequested = requested.filter((id) => mcpServiceOfSkillId(id) === undefined)
+  const groups = groupMcpServices(descriptors, selected, requested)
+  // The dialog is scoped to the template's requests: services the blueprint
+  // requested and that still have catalog tools.
+  const liveServiceRows = groups.filter((group) => group.tools.length > 0 && group.recommended)
+  // Held grants of a service whose catalog items are all gone: one revocable
+  // "暂不可用" row instead of one orphan row per tool.
+  const deadServiceRows = groups.filter((group) => group.tools.length === 0 && group.grantedIds.length > 0)
+  // Services the blueprint requested that no catalog knows at all (the
+  // connection was removed or discovery failed while this dialog is open).
+  const missingServiceRows = orphanMcpServiceGroups(mcpRequested, groups.map((group) => group.serviceId), selected)
+  return <fieldset className="capability-approval-group"><legend>{t('workbench.recruitSkillsLegend', '角色技能')}</legend>{requested.length === 0 ? <span>{t('workbench.recruitNoSkills', '该角色模板未请求角色技能')}</span> : <>
+    {[...liveServiceRows, ...deadServiceRows, ...missingServiceRows].map((group) => <McpServiceApprovalRow key={`service-${group.serviceId}`} group={group} requested={requested} selected={selected} onChange={onChange} />)}
+    {plainRequested.map((skillId) => {
+      const descriptor = byId.get(skillId)
+      const available = descriptor !== undefined && descriptor.worldAvailable && descriptor.availability === 'available'
+      const granted = selected.includes(skillId)
+      return <label key={skillId} className={!available ? 'is-unavailable' : ''}><input type="checkbox" checked={granted} disabled={!available && !granted} onChange={(event) => onChange(event.target.checked ? [...new Set([...selected, skillId])] : selected.filter((value) => value !== skillId))}/><span><strong>{descriptor?.displayName ?? skillId}</strong><small>{descriptor?.summary ?? '当前世界暂不可用，创建时不会新增这项角色技能。'}</small><em>{!available ? '暂不可用' : granted ? '已启用' : '推荐'}</em></span></label>
+    })}
+  </>}</fieldset>
+}
+
+function McpServiceApprovalRow({ group, requested, selected, onChange }: { group: McpServiceGroup; requested: string[]; selected: string[]; onChange(next: string[]): void }) {
+  const { t } = useI18n()
+  const { checked, indeterminate } = mcpServiceChecked(group, selected)
+  const available = group.learnable
+  const statusKey = !available ? 'unavailable' : checked ? 'granted' : indeterminate ? 'partial' : group.recommended ? 'recommended' : 'learnable'
+  const statusText = !available ? t('workbench.recruitMcpServiceUnavailable', '暂不可用') : checked ? t('workbench.recruitMcpServiceGranted', '已授权') : indeterminate ? t('workbench.recruitMcpServicePartial', '部分授权') : t('workbench.recruitMcpServiceRecommended', '推荐')
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (inputRef.current !== null) inputRef.current.indeterminate = indeterminate
+  }, [indeterminate])
+  const requestedSet = new Set(requested)
+  const requestedCount = group.requestedIds.length
+  const unavailable = !available
+  return <div className={`capability-service-row${checked ? ' is-granted' : ''}${unavailable ? ' is-unavailable' : ''}`} data-mcp-service={group.serviceId}>
+    <input ref={inputRef} type="checkbox" aria-label={t('workbench.recruitMcpServiceAria', 'MCP 服务 {name}', { name: group.label })} checked={checked} disabled={unavailable && group.grantedIds.length === 0} onChange={(event) => onChange(mcpServiceToggle(group, selected, event.target.checked))} />
+    <span>
+      <strong>{t('workbench.recruitMcpServiceLabel', 'MCP · {name}', { name: group.label })}</strong>
+      <small>{unavailable
+        ? t('workbench.recruitMcpServiceUnavailableHint', '该 MCP 服务当前不可用（连接未配置、已停用或不可达）。可到顶部“连接中心”检查该连接；取消勾选可撤销保留的授权。')
+        : t('workbench.recruitMcpServiceHint', '共 {count} 个工具。勾选即授权该 MCP 服务下的全部工具；每次外部调用前系统仍会针对具体动作请求确认。', { count: group.tools.length })}</small>
+      <span className="capability-service-row__meta">
+        <em className={`capability-service-row__status capability-service-row__status--${statusKey}`}>{statusText}</em>
+        <em>{t('workbench.recruitMcpServiceRisk', '涉及外部操作')}</em>
+        {requestedCount > 0 ? <em>{t('workbench.recruitMcpServiceRequested', '模板请求 {count} 个', { count: requestedCount })}</em> : null}
+        {group.tools.length > 0 ? <details className="capability-service-row__tools"><summary>{t('workbench.recruitMcpServiceTools', '{count} 个工具', { count: group.tools.length })}</summary><ul>{group.tools.map((tool) => {
+          const toolSelected = selected.includes(tool.id)
+          return <li key={tool.id} className={toolSelected ? 'is-granted' : ''}><code>{tool.name}</code><span>{requestedSet.has(tool.id) ? <em>{t('workbench.recruitMcpServiceToolRequested', '模板请求')}</em> : null}<em>{tool.available ? (toolSelected ? t('workbench.recruitMcpServiceToolGranted', '已授权') : t('workbench.recruitMcpServiceToolNotGranted', '未授权')) : t('workbench.recruitMcpServiceToolUnavailable', '暂不可用')}</em></span></li>
+        })}</ul></details> : null}
+      </span>
+    </span>
+  </div>
 }
 
 function defaultSkillGrants(blueprint: EmployeeBlueprint, descriptors: SkillCatalogEntry[]): string[] {

--- a/packages/web/src/components/SkillGrantEditor.css
+++ b/packages/web/src/components/SkillGrantEditor.css
@@ -124,7 +124,59 @@
 .skill-grant-row__status--recommended { color: var(--accent-strong, #f0b63b) !important; }
 .skill-grant-row__status--granted { color: var(--success, #69c18d) !important; }
 .skill-grant-row__status--learnable { color: var(--text-soft, #d3d9dd) !important; }
+.skill-grant-row__status--partial { color: var(--warning, #d8a347) !important; }
 .skill-grant-row__status--unavailable { color: var(--danger, #dc7777) !important; }
+
+/* Aggregated MCP service row: one checkbox grants every tool of the service. */
+.skill-grant-row--mcp-service > input {
+  margin-top: 4px;
+}
+
+.skill-grant-row__tools {
+  margin-left: 2px;
+}
+
+.skill-grant-row__tools summary {
+  cursor: pointer;
+  padding: 2px 6px;
+  border-radius: 6px;
+  background: rgba(255,255,255,.055);
+  color: var(--world-muted, #aeb6c6);
+  font-size: 12px;
+  list-style: none;
+  user-select: none;
+}
+
+.skill-grant-row__tools summary::-webkit-details-marker {
+  display: none;
+}
+
+.skill-grant-row__tools ul {
+  margin: 6px 0 2px 4px;
+  padding: 0;
+  display: grid;
+  gap: 3px;
+  max-width: 320px;
+}
+
+.skill-grant-row__tools li {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 200px;
+  font-size: 12px;
+  color: var(--world-muted, #aeb6c6);
+}
+
+.skill-grant-row__tools li code {
+  color: var(--text-soft, #d3d9dd);
+  font-size: 12px;
+}
+
+.skill-grant-row__tools li.is-granted em {
+  color: var(--success, #69c18d);
+}
 
 .skill-grant-editor__note {
   margin: 3px 2px 0;

--- a/packages/web/src/components/SkillGrantEditor.tsx
+++ b/packages/web/src/components/SkillGrantEditor.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { EmployeeBlueprint, EmployeeInstance } from '@dsh-cyber/contracts'
 
 import { api } from '../api.js'
@@ -9,6 +9,16 @@ import {
   worldSkillCatalogPath,
   type SkillCatalogEntry,
 } from './skill-catalog.js'
+import {
+  groupMcpServices,
+  isMcpCatalogEntry,
+  mcpServiceChecked,
+  mcpServiceStatus,
+  mcpServiceOfSkillId,
+  mcpServiceToggle,
+  type McpServiceGroup,
+  type McpServiceStatus,
+} from './mcp-skill-grouping.js'
 import './SkillGrantEditor.css'
 
 interface SkillGrantEditorProps {
@@ -16,6 +26,10 @@ interface SkillGrantEditorProps {
   value: string[]
   onChange(next: string[]): void
 }
+
+type GrantRow
+  = { kind: 'skill'; entry: SkillCatalogEntry }
+  | { kind: 'mcpService'; group: McpServiceGroup }
 
 export function SkillGrantEditor({ employee, value, onChange }: SkillGrantEditorProps) {
   const [blueprint, setBlueprint] = useState<EmployeeBlueprint>()
@@ -44,13 +58,29 @@ export function SkillGrantEditor({ employee, value, onChange }: SkillGrantEditor
 
   const requested = blueprint?.requestedSkills ?? []
   const entryById = useMemo(() => new Map(catalog.map((item) => [item.id, item])), [catalog])
-  const recommendedIds = useMemo(() => new Set(catalog.filter((item) => requested.includes(item.id) && isLearnable(item)).map((item) => item.id)), [catalog, requested])
-  const recommended = useMemo(() => catalog.filter((item) => recommendedIds.has(item.id)), [catalog, recommendedIds])
-  const learnable = useMemo(() => catalog.filter((item) => isLearnable(item) && !recommendedIds.has(item.id)), [catalog, recommendedIds])
-  const unavailable = useMemo(() => {
-    const rows = catalog.filter((item) => !isLearnable(item) && value.includes(item.id))
-    const known = new Set(rows.map((item) => item.id))
+  // MCP tool descriptors are grouped per service below; only non-MCP entries
+  // participate in the skill-level recommended split.
+  const recommendedIds = useMemo(() => new Set(catalog
+    .filter((item) => !isMcpCatalogEntry(item) && requested.includes(item.id) && isLearnable(item))
+    .map((item) => item.id)), [catalog, requested])
+  const mcpServices = useMemo(() => groupMcpServices(catalog, value, requested), [catalog, value, requested])
+  const servicesByPlacement = useMemo(() => {
+    const result: Record<McpServiceGroup['placement'], McpServiceGroup[]> = { recommended: [], learnable: [], unavailable: [], hidden: [] }
+    for (const group of mcpServices) result[group.placement]!.push(group)
+    return result
+  }, [mcpServices])
+  const serviceRows = (placement: McpServiceGroup['placement']): GrantRow[] =>
+    servicesByPlacement[placement]!.map((group): GrantRow => ({ kind: 'mcpService', group }))
+  const skillRow = (entry: SkillCatalogEntry): GrantRow => ({ kind: 'skill', entry })
+
+  // Historical grants whose catalog entry is gone. MCP grants stay grouped per
+  // service (a dead service renders one "暂不可用" row, not one per tool);
+  // everything else keeps the legacy single-row rendering.
+  const legacyOrphans = useMemo(() => {
+    const rows: SkillCatalogEntry[] = []
+    const known = new Set(catalog.filter((item) => !isMcpCatalogEntry(item)).map((item) => item.id))
     for (const skillId of value) {
+      if (mcpServiceOfSkillId(skillId) !== undefined) continue
       if (known.has(skillId) || entryById.has(skillId)) continue
       rows.push(legacyUnavailableSkill(skillId))
       known.add(skillId)
@@ -58,31 +88,60 @@ export function SkillGrantEditor({ employee, value, onChange }: SkillGrantEditor
     return rows
   }, [catalog, entryById, value])
 
+  const recommendedRows: GrantRow[] = [
+    ...serviceRows('recommended'),
+    ...catalog.filter((item) => isLearnable(item) && recommendedIds.has(item.id)).map(skillRow),
+  ]
+  const learnableRows: GrantRow[] = [
+    ...serviceRows('learnable'),
+    ...catalog.filter((item) => !isMcpCatalogEntry(item) && isLearnable(item) && !recommendedIds.has(item.id)).map(skillRow),
+  ]
+  const unavailableRows: GrantRow[] = [
+    ...serviceRows('unavailable'),
+    ...catalog.filter((item) => !isMcpCatalogEntry(item) && !isLearnable(item) && value.includes(item.id)).map(skillRow),
+    ...legacyOrphans.map(skillRow),
+  ]
+
   if (loading) return <div className="dialog-empty" role="status">正在读取当前世界的技能目录…</div>
   if (error !== undefined) return <div className="permission-notice permission-notice--warning" role="alert"><p>{error}</p></div>
   if (catalog.length === 0 && value.length === 0) return <div className="dialog-empty">当前世界没有可学习的角色技能。</div>
 
   return <div className="skill-grant-editor">
     {blueprint === undefined ? <div className="skill-grant-editor__hint">没有找到这个角色对应的蓝图版本；保留中的历史授权仍可在“当前不可用”中撤销。</div> : null}
-    <SkillGrantGroup title="推荐技能" items={recommended} empty="这个角色没有可默认推荐的角色技能。" value={value} onChange={onChange} recommended />
-    <SkillGrantGroup title="其他可学习技能" items={learnable} empty="当前世界没有其他可学习的角色技能。" value={value} onChange={onChange} />
-    <SkillGrantGroup title="当前不可用" items={unavailable} empty="没有不可用的历史授权。" value={value} onChange={onChange} />
+    <SkillGrantGroup title="推荐技能" rows={recommendedRows} empty="这个角色没有可默认推荐的角色技能。" value={value} onChange={onChange} recommended />
+    <SkillGrantGroup title="其他可学习技能" rows={learnableRows} empty="当前世界没有其他可学习的角色技能。" value={value} onChange={onChange} />
+    <SkillGrantGroup title="当前不可用" rows={unavailableRows} empty="没有不可用的历史授权。" value={value} onChange={onChange} />
     <p className="skill-grant-editor__note">已有角色可以学习蓝图未请求的角色技能；当前不可用的历史授权不会被静默删除，可保留或撤销。涉及外部操作时，系统仍会针对具体动作请求确认。</p>
   </div>
 }
 
-function SkillGrantGroup({ title, items, empty, value, onChange, recommended = false }: { title: string; items: SkillCatalogEntry[]; empty: string; value: string[]; onChange(next: string[]): void; recommended?: boolean }) {
+function SkillGrantGroup({ title, rows, empty, value, onChange, recommended = false }: {
+  title: string
+  rows: GrantRow[]
+  empty: string
+  value: string[]
+  onChange(next: string[]): void
+  recommended?: boolean
+}) {
   return <section className="skill-grant-group" aria-labelledby={`skill-grant-${title}`}>
-    <header><div><h4 id={`skill-grant-${title}`}>{title}</h4><span>{items.length} 项</span></div></header>
-    {items.length === 0 ? <p className="skill-grant-group__empty">{empty}</p> : <div className="skill-grant-group__rows">{items.map((entry) => <SkillGrantRow key={entry.id} entry={entry} granted={value.includes(entry.id)} recommended={recommended} onChange={(checked) => onGrantChange(entry.id, checked, value, onChange)} />)}</div>}
+    <header><div><h4 id={`skill-grant-${title}`}>{title}</h4><span>{rows.length} 项</span></div></header>
+    {rows.length === 0 ? <p className="skill-grant-group__empty">{empty}</p> : <div className="skill-grant-group__rows">{rows.map((row) => row.kind === 'skill'
+      ? <SkillGrantRow key={row.entry.id} entry={row.entry} value={value} recommended={recommended} onChange={onChange} />
+      : <McpServiceRow key={row.group.serviceId} group={row.group} value={value} onChange={onChange} />)}</div>}
   </section>
 }
 
-function SkillGrantRow({ entry, granted, recommended, onChange }: { entry: SkillCatalogEntry; granted: boolean; recommended: boolean; onChange(checked: boolean): void }) {
+function SkillGrantRow({ entry, value, recommended, onChange }: {
+  entry: SkillCatalogEntry
+  value: string[]
+  recommended: boolean
+  onChange(next: string[]): void
+}) {
   const available = isLearnable(entry)
+  const granted = value.includes(entry.id)
   const status = !available ? '暂不可用' : granted ? '已启用' : recommended ? '推荐' : '可学习'
   return <label className={`skill-grant-row${granted ? ' is-granted' : ''}${available ? '' : ' is-unavailable'}`}>
-    <input type="checkbox" checked={granted} disabled={!available && !granted} onChange={(event) => onChange(event.target.checked)} />
+    <input type="checkbox" checked={granted} disabled={!available && !granted} onChange={(event) => onChange(onGrantChange(entry.id, event.target.checked, value))} />
     <span>
       <strong>{entry.displayName}</strong>
       <small>{entry.summary}</small>
@@ -91,8 +150,52 @@ function SkillGrantRow({ entry, granted, recommended, onChange }: { entry: Skill
   </label>
 }
 
-function onGrantChange(skillId: string, checked: boolean, value: string[], onChange: (next: string[]) => void): void {
-  onChange(checked ? [...new Set([...value, skillId])] : value.filter((item) => item !== skillId))
+const MCP_STATUS_TEXT: Record<McpServiceStatus, string> = {
+  unavailable: '暂不可用',
+  granted: '已启用',
+  partial: '部分启用',
+  recommended: '推荐',
+  learnable: '可学习',
+}
+
+/**
+ * One aggregated row per MCP service (connection): a single checkbox grants
+ * every tool of that service. The row is a plain div — not a label — so the
+ * expandable tool list never toggles the checkbox.
+ */
+function McpServiceRow({ group, value, onChange }: {
+  group: McpServiceGroup
+  value: string[]
+  onChange(next: string[]): void
+}) {
+  const available = group.learnable
+  const { checked, indeterminate } = mcpServiceChecked(group, value)
+  const status = mcpServiceStatus(group, value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (inputRef.current !== null) inputRef.current.indeterminate = indeterminate
+  }, [indeterminate])
+  return <div className={`skill-grant-row skill-grant-row--mcp-service${checked ? ' is-granted' : ''}${available ? '' : ' is-unavailable'}`}>
+    <input ref={inputRef} type="checkbox" aria-label={`MCP 服务 ${group.label}`} checked={checked} onChange={(event) => onChange(mcpServiceToggle(group, value, event.target.checked))} />
+    <span>
+      <strong>MCP · {group.label}</strong>
+      <small>{available
+        ? `共 ${group.tools.length} 个工具。勾选即授权该 MCP 服务下的全部工具；每次调用前系统仍会针对具体动作请求确认。`
+        : '该 MCP 服务当前不可用（连接未配置、已停用或不可达）。保留的历史授权不会自动生效，可到顶部“连接中心”检查该连接；取消勾选即可撤销。'}</small>
+      <span className="skill-grant-row__meta">
+        <em className={`skill-grant-row__status skill-grant-row__status--${status}`}>{MCP_STATUS_TEXT[status]}</em>
+        <em>涉及外部操作</em>
+        {group.tools.length > 0 ? <details className="skill-grant-row__tools"><summary>{group.tools.length} 个工具</summary><ul>{group.tools.map((tool) => {
+          const toolGranted = value.includes(tool.id)
+          return <li key={tool.id} className={toolGranted ? 'is-granted' : ''}><code>{tool.name}</code><em>{tool.available ? (toolGranted ? '已授权' : '未授权') : '不可用'}</em></li>
+        })}</ul></details> : null}
+      </span>
+    </span>
+  </div>
+}
+
+function onGrantChange(skillId: string, checked: boolean, value: string[]): string[] {
+  return checked ? [...new Set([...value, skillId])] : value.filter((item) => item !== skillId)
 }
 
 function isLearnable(entry: SkillCatalogEntry): boolean {

--- a/packages/web/src/components/SkillGrantEditor.tsx
+++ b/packages/web/src/components/SkillGrantEditor.tsx
@@ -100,6 +100,30 @@ function isLearnable(entry: SkillCatalogEntry): boolean {
 }
 
 function legacyUnavailableSkill(id: string): SkillCatalogEntry {
+  // A grantable MCP skill that no longer resolves to a catalog entry: the
+  // owning MCP connection is unconfigured or its process/endpoint is down, or
+  // the tool name changed. Keep it identifiable (service + tool) instead of
+  // dumping the raw id, and point at the 连接中心 for the fix.
+  if (id.startsWith('mcp.')) {
+    const tail = id.slice(4)
+    const dot = tail.indexOf('.')
+    const label = dot > 0 ? `${tail.slice(0, dot)} / ${tail.slice(dot + 1)}` : tail
+    return {
+      id,
+      displayName: `MCP 工具 · ${label}`,
+      summary: '这项 MCP 授权当前没有对应的目录项：对应 MCP 连接可能未配置、未启用或不可达，也可能工具已改名。可到顶部“连接中心”检查该连接；保留此授权不会自动生效，取消勾选即可撤销。',
+      adapterId: 'builtin.mcp',
+      risks: ['external-side-effect'],
+      supportsScheduling: false,
+      persistentApproval: 'forbidden',
+      kind: 'integration',
+      source: 'mcp',
+      scope: 'workspace',
+      globalKnown: false,
+      worldAvailable: false,
+      availability: 'unavailable',
+    }
+  }
   return {
     id,
     displayName: id,

--- a/packages/web/src/components/creative-workshop/CreativeWorkshopEditor.tsx
+++ b/packages/web/src/components/creative-workshop/CreativeWorkshopEditor.tsx
@@ -5,6 +5,7 @@ import type { CharacterSkillDescriptor, EmbodimentPresetDescriptor } from '@dsh-
 
 import { createRoleDraft, type WorkshopDraft, type WorkshopRoleDraft } from './model.js'
 import { WorkshopJsonEditor } from './WorkshopJsonEditor.js'
+import { WorkshopSkillPicker } from './workshop-skill-picker.js'
 import { ModelPicker } from '../../features/models/ModelPicker.js'
 import { useI18n } from '../../i18n/runtime.js'
 
@@ -42,10 +43,6 @@ export function CreativeWorkshopEditor({
   const presetMap = useMemo(() => new Map(presets.map((preset) => [preset.id, preset])), [presets])
   const selected = draft.roles.find((role) => role.clientId === selectedRoleId) ?? draft.roles[0]
   const fallbackPreset = presets[0]
-  const visibleSkills = useMemo(() => {
-    const query = skillQuery.trim().toLocaleLowerCase()
-    return query === '' ? skills : skills.filter((skill) => `${skill.displayName} ${skill.summary} ${skill.id}`.toLocaleLowerCase().includes(query))
-  }, [skillQuery, skills])
 
   useEffect(() => {
     if (selected !== undefined) return
@@ -136,7 +133,7 @@ export function CreativeWorkshopEditor({
           {selected === undefined ? null : <>
             <label className="workshop-skill-search"><MagnifyingGlass size={17} /><input type="search" value={skillQuery} placeholder={t('workshop.permissions.skillsSearch', '搜索技能名称、用途或 ID')} aria-label={t('workshop.permissions.skillsSearchAria', '搜索角色技能')} onChange={(event) => setSkillQuery(event.target.value)} /></label>
             <div className="creative-workshop-permission-summary"><strong>{selected.displayName || t('workshop.permissions.currentRole', '当前角色')}</strong><span>{t('workshop.permissions.selectedSkills', '已选择 {count} 个技能', { count: selected.requestedSkillIds.length })}</span></div>
-            {skills.length === 0 ? <div className="dialog-empty">{t('workshop.permissions.noSkills', '当前宿主没有注册可用技能。')}</div> : visibleSkills.length === 0 ? <div className="dialog-empty">{t('workshop.permissions.noMatches', '没有匹配的技能。')}</div> : <div className="creative-workshop-skill-catalog">{visibleSkills.map((skill) => <label key={skill.id} className={selected.requestedSkillIds.includes(skill.id) ? 'is-selected' : ''}><input type="checkbox" checked={selected.requestedSkillIds.includes(skill.id)} onChange={(event) => updateSelected({ requestedSkillIds: event.target.checked ? [...selected.requestedSkillIds, skill.id] : selected.requestedSkillIds.filter((id) => id !== skill.id) })} /><span><strong>{skill.displayName}</strong><small>{skill.summary}</small><em>{skill.kind === 'integration' ? t('workshop.permissions.external', '外部连接') : t('workshop.permissions.method', '工作方法')} · {riskLabel(skill, t)}</em></span></label>)}</div>}
+            {skills.length === 0 ? <div className="dialog-empty">{t('workshop.permissions.noSkills', '当前宿主没有注册可用技能。')}</div> : <WorkshopSkillPicker skills={skills} value={selected.requestedSkillIds} query={skillQuery} onChange={(next) => updateSelected({ requestedSkillIds: next })} />}
             <p className="creative-workshop-permission-note">{t('workshop.permissions.note', '创建世界会保存这些能力请求。角色获得技能授权后才能执行；涉及外部副作用的具体动作仍需按审批策略确认。')}</p>
           </>}
         </section> : null}
@@ -225,10 +222,4 @@ function validateStep(step: number, draft: WorkshopDraft, t: ReturnType<typeof u
     if (incomplete !== undefined) return t('workshop.validation.roleNames', '请为每个角色填写名字')
   }
   return undefined
-}
-
-function riskLabel(skill: CharacterSkillDescriptor, t: ReturnType<typeof useI18n>['t']): string {
-  if (skill.risks.includes('external-side-effect')) return t('workshop.permissions.riskExternal', '外部操作需审批')
-  if (skill.risks.includes('write-local')) return t('workshop.permissions.riskWrite', '可写当前世界')
-  return t('workshop.permissions.riskRead', '只读')
 }

--- a/packages/web/src/components/creative-workshop/CreativeWorkshopProjectLibrary.tsx
+++ b/packages/web/src/components/creative-workshop/CreativeWorkshopProjectLibrary.tsx
@@ -1,10 +1,11 @@
 import { Archive, ArrowCounterClockwise, ArrowRight, Copy, Cube, Plus, ShieldCheck, SlidersHorizontal, Sparkle, Trash, UsersThree, WarningCircle } from '@phosphor-icons/react'
-import { useRef, useState } from 'react'
+import { useRef, useState, type ReactNode } from 'react'
 import type { WorldTemplateManifest } from '@dsh-cyber/contracts'
 import type { CharacterSkillDescriptor, WorkshopProjectStatus, WorkshopProjectView } from '@dsh-cyber/contracts/creative-platform'
 
 import { useI18n } from '../../i18n/runtime.js'
 import { useDialogFocusTrap } from '../useDialogFocusTrap.js'
+import { mcpServiceOfSkillId } from '../mcp-skill-grouping.js'
 import './CreativeWorkshopProjectLibrary.css'
 
 interface CreativeWorkshopProjectLibraryProps {
@@ -40,6 +41,7 @@ export function CreativeWorkshopProjectLibrary({
   const [tab, setTab] = useState<WorkshopProjectStatus>('active')
   const [pendingDeleteId, setPendingDeleteId] = useState<string>()
   const skillNames = new Map(skills.map((skill) => [skill.id, skill.displayName]))
+  const serviceLabels = new Map(skills.filter((skill) => skill.mcpService !== undefined).map((skill) => [skill.mcpService!.id, skill.mcpService!.label]))
   const visibleProjects = projects.filter((project) => project.status === tab)
 
   // 1. 当没有项目时：呈现一体化、饱满充实、高审美的创作起航大厅 (Creative Workshop Hub)
@@ -292,9 +294,7 @@ export function CreativeWorkshopProjectLibrary({
                       {role.requestedSkillIds.length === 0 ? (
                         <span>{t('workshop.library.noExtraSkills', '未请求额外技能')}</span>
                       ) : (
-                        role.requestedSkillIds.map((skillId) => (
-                          <code key={skillId}>{skillNames.get(skillId) ?? skillId}</code>
-                        ))
+                        skillChipsForRole(role.requestedSkillIds, skillNames, serviceLabels)
                       )}
                     </div>
                   </article>
@@ -372,4 +372,36 @@ function formatDate(value: string, locale: string): string {
   } catch {
     return String(value)
   }
+}
+
+/**
+ * Read-only skill chips for a project role: one chip per skill for non-MCP
+ * ids, one chip per MCP service for tool ids (a single tool shows as
+ * "MCP · <connection name> / <tool>", several collapse into a count).
+ */
+export function skillChipsForRole(
+  requestedIds: readonly string[],
+  skillNames: ReadonlyMap<string, string>,
+  serviceLabels: ReadonlyMap<string, string>,
+): ReactNode[] {
+  const plainIds: string[] = []
+  const toolsByService = new Map<string, string[]>()
+  for (const skillId of requestedIds) {
+    const service = mcpServiceOfSkillId(skillId)
+    if (service === undefined) plainIds.push(skillId)
+    else toolsByService.set(service, [...(toolsByService.get(service) ?? []), skillId])
+  }
+  const chips: ReactNode[] = plainIds.map((skillId) => <code key={skillId}>{skillNames.get(skillId) ?? skillId}</code>)
+  for (const [service, toolIds] of [...toolsByService.entries()].sort(([a], [b]) => a.localeCompare(b))) {
+    const label = serviceLabels.get(service) ?? service
+    const title = toolIds.length === 1
+      ? `MCP · ${label} / ${toolNameOfToolId(toolIds[0]!, service)}`
+      : `MCP · ${label}（${toolIds.length} 个工具）`
+    chips.push(<code key={`mcp-service-${service}`}>{title}</code>)
+  }
+  return chips
+}
+
+function toolNameOfToolId(skillId: string, service: string): string {
+  return skillId.slice(`mcp.${service}.`.length)
 }

--- a/packages/web/src/components/creative-workshop/workshop-skill-picker.tsx
+++ b/packages/web/src/components/creative-workshop/workshop-skill-picker.tsx
@@ -1,0 +1,100 @@
+import { useEffect, useMemo, useRef } from 'react'
+import type { CharacterSkillDescriptor } from '@dsh-cyber/contracts/creative-platform'
+import {
+  groupMcpServicesFromItems,
+  mcpServiceChecked,
+  mcpServiceToggle,
+  toggleSkillIdInList,
+  type McpServiceGroup,
+  type McpServiceTool,
+} from '../mcp-skill-grouping.js'
+import { useI18n } from '../../i18n/runtime.js'
+
+/**
+ * The workshop's per-role skill picker with service-level MCP aggregation.
+ *
+ * One "MCP · <connection name>" row stands for every tool of that service:
+ * checking the row requests the whole service, unchecking removes the whole
+ * service, and the expandable tool list still allows per-tool requests.
+ * Non-MCP skills keep the flat one-row-per-skill layout. `value` is the
+ * role's `requestedSkillIds` — requests only; grants are produced later by
+ * the recruitment/revision flow.
+ */
+export function WorkshopSkillPicker({ skills, value, query, onChange }: {
+  skills: CharacterSkillDescriptor[]
+  value: string[]
+  query: string
+  onChange(next: string[]): void
+}) {
+  const { t } = useI18n()
+  const trimmedQuery = query.trim().toLocaleLowerCase()
+  const skillById = useMemo(() => new Map(skills.map((skill) => [skill.id, skill])), [skills])
+  const groups = useMemo(() => groupMcpServicesFromItems(skills, value, value), [skills, value])
+  const skillMatches = (skill: CharacterSkillDescriptor): boolean =>
+    trimmedQuery === '' || `${skill.displayName} ${skill.summary} ${skill.id}`.toLocaleLowerCase().includes(trimmedQuery)
+  const flatSkills = skills.filter((skill) => skill.mcpService === undefined && skillMatches(skill))
+  const serviceRows: { group: McpServiceGroup; tools: McpServiceTool[] }[] = []
+  for (const group of groups) {
+    const serviceMatches = trimmedQuery === '' || `MCP · ${group.label} ${group.serviceId}`.toLocaleLowerCase().includes(trimmedQuery)
+    const tools = serviceMatches
+      ? group.tools
+      : group.tools.filter((tool) => {
+        const descriptor = skillById.get(tool.id)
+        return descriptor !== undefined && skillMatches(descriptor)
+      })
+    // A dead service (tools gone, requests still held) stays revocable when
+    // not searching.
+    const deadOrphan = group.tools.length === 0 && group.grantedIds.length > 0
+    if (tools.length > 0 || (trimmedQuery === '' && deadOrphan)) serviceRows.push({ group, tools })
+  }
+  if (serviceRows.length === 0 && flatSkills.length === 0) {
+    return <div className="dialog-empty">{t('workshop.permissions.noMatches', '没有匹配的技能。')}</div>
+  }
+  return <div className="creative-workshop-skill-catalog">
+    {serviceRows.map(({ group, tools }) => <McpServicePickerRow key={`mcp-service-${group.serviceId}`} group={group} tools={tools} value={value} onChange={onChange} />)}
+    {flatSkills.map((skill) => {
+      const selected = value.includes(skill.id)
+      return <label key={skill.id} className={selected ? 'is-selected' : ''}>
+        <input type="checkbox" checked={selected} onChange={(event) => onChange(toggleSkillIdInList(value, skill.id, event.target.checked))} />
+        <span><strong>{skill.displayName}</strong><small>{skill.summary}</small><em>{skill.kind === 'integration' ? t('workshop.permissions.external', '外部连接') : t('workshop.permissions.method', '工作方法')} · {riskLabel(skill, t)}</em></span>
+      </label>
+    })}
+  </div>
+}
+
+function McpServicePickerRow({ group, tools, value, onChange }: {
+  group: McpServiceGroup
+  tools: McpServiceTool[]
+  value: string[]
+  onChange(next: string[]): void
+}) {
+  const { t } = useI18n()
+  const { checked, indeterminate } = mcpServiceChecked(group, value)
+  const inputRef = useRef<HTMLInputElement>(null)
+  useEffect(() => {
+    if (inputRef.current !== null) inputRef.current.indeterminate = indeterminate
+  }, [indeterminate])
+  const dead = group.tools.length === 0
+  return <div className={`creative-workshop-skill-catalog__mcp-service${checked ? ' is-selected' : ''}${dead ? ' is-unavailable' : ''}`}>
+    <input ref={inputRef} type="checkbox" aria-label={t('workshop.permissions.mcpServiceAria', 'MCP 服务 {name}', { name: group.label })} checked={checked} onChange={(event) => onChange(mcpServiceToggle(group, value, event.target.checked))} />
+    <span>
+      <strong>{t('workshop.permissions.mcpServiceLabel', 'MCP · {name}', { name: group.label })}</strong>
+      <small>{dead
+        ? t('workshop.permissions.mcpServiceDeadHint', '该 MCP 服务当前不可用（连接未配置、已停用或不可达）。取消勾选可移除对应的技能请求。')
+        : t('workshop.permissions.mcpServiceHint', '共 {count} 个工具 · 外部操作需审批。勾选即请求该 MCP 服务下的全部工具；授权仍由角色创建后的 Skill 授权决定。', { count: group.tools.length })}</small>
+      {dead ? null : <details className="creative-workshop-skill-catalog__mcp-tools"><summary>{t('workshop.permissions.mcpServiceTools', '{count} 个工具', { count: tools.length })}</summary><div>{tools.map((tool) => {
+        const selected = value.includes(tool.id)
+        return <label key={tool.id} className={selected ? 'is-selected' : ''}>
+          <input type="checkbox" checked={selected} onChange={(event) => onChange(toggleSkillIdInList(value, tool.id, event.target.checked))} />
+          <span><code>{tool.name}</code><em>{t('workshop.permissions.riskExternal', '外部操作需审批')}</em></span>
+        </label>
+      })}</div></details>}
+    </span>
+  </div>
+}
+
+function riskLabel(skill: CharacterSkillDescriptor, t: ReturnType<typeof useI18n>['t']): string {
+  if (skill.risks.includes('external-side-effect')) return t('workshop.permissions.riskExternal', '外部操作需审批')
+  if (skill.risks.includes('write-local')) return t('workshop.permissions.riskWrite', '可写当前世界')
+  return t('workshop.permissions.riskRead', '只读')
+}

--- a/packages/web/src/components/mcp-skill-grouping.ts
+++ b/packages/web/src/components/mcp-skill-grouping.ts
@@ -1,0 +1,143 @@
+import type { SkillCatalogEntry } from './skill-catalog.js'
+
+/**
+ * Presentation-level grouping of MCP tool skills under one service
+ * (connection).
+ *
+ * Grants, execution and the action ledger stay tool-granular
+ * (`mcp.<service>.<tool>`); the MCP command is typed by the user and the
+ * adapter resolves the exact tool. This module only answers "how does the
+ * panel show one service's tools as a single grantable entry" — checking the
+ * service row grants every tool of that service.
+ */
+
+export interface McpServiceTool {
+  /** The tool name (the grant id without its `mcp.<service>.` prefix). */
+  name: string
+  /** The tool-level grant id `mcp.<service>.<tool>`. */
+  id: string
+  /** Whether the tool is available in the current world right now. */
+  available: boolean
+}
+
+export interface McpServiceGroup {
+  /** Stable service slug — the second segment of `mcp.<service>.<tool>`. */
+  serviceId: string
+  /** Display name: the connection name, or the service slug for orphan grants. */
+  label: string
+  /** The tools this service currently lists in the catalog (may be empty for orphaned grants). */
+  tools: McpServiceTool[]
+  /** Every grant of this service the character currently holds, including ids the catalog no longer knows. */
+  grantedIds: string[]
+  /** At least one catalog tool is available in the world. */
+  learnable: boolean
+  /** At least one catalog tool is recommended by the character blueprint. */
+  recommended: boolean
+  /** Where the aggregated row renders. */
+  placement: 'recommended' | 'learnable' | 'unavailable' | 'hidden'
+}
+
+/** Whether a catalog entry is one MCP tool descriptor (groupable by service). */
+export function isMcpCatalogEntry(entry: SkillCatalogEntry): boolean {
+  return entry.mcpService !== undefined
+}
+
+/**
+ * The service slug of a grant id of the form `mcp.<service>.<tool>`.
+ * Service slugs are dot-free (`[a-z0-9-]`), so the first dot after the
+ * `mcp.` prefix unambiguously ends the service segment; tool names may
+ * contain dots. Two-segment legacy ids have no service and return undefined.
+ */
+export function mcpServiceOfSkillId(id: string): string | undefined {
+  if (!id.startsWith('mcp.')) return undefined
+  const tail = id.slice(4)
+  const dot = tail.indexOf('.')
+  const service = dot > 0 ? tail.slice(0, dot) : ''
+  return service === '' ? undefined : service
+}
+
+/**
+ * One group per MCP service seen in the catalog or in the character's grants.
+ *
+ * A grant whose service no longer has any catalog entry (connection removed or
+ * discovery failed) still forms a group: the panel can keep showing the
+ * service row as "暂不可用" so the stale grant stays revocable instead of
+ * flooding one orphan row per tool.
+ */
+export function groupMcpServices(
+  catalog: readonly SkillCatalogEntry[],
+  value: readonly string[],
+  requested: readonly string[],
+): McpServiceGroup[] {
+  const byService = new Map<string, { label?: string; tools: McpServiceTool[] }>()
+  for (const entry of catalog) {
+    if (entry.mcpService === undefined) continue
+    const bucket = byService.get(entry.mcpService.id) ?? { tools: [] }
+    bucket.label = entry.mcpService.label
+    bucket.tools.push({
+      name: entry.id.slice(`mcp.${entry.mcpService.id}.`.length),
+      id: entry.id,
+      available: entry.worldAvailable && entry.availability === 'available',
+    })
+    byService.set(entry.mcpService.id, bucket)
+  }
+  for (const id of value) {
+    const service = mcpServiceOfSkillId(id)
+    if (service !== undefined && !byService.has(service)) byService.set(service, { tools: [] })
+  }
+
+  const requestedSet = new Set(requested)
+  const groups: McpServiceGroup[] = []
+  for (const [serviceId, bucket] of byService) {
+    const grantedIds = [...new Set(value.filter((id) => mcpServiceOfSkillId(id) === serviceId))]
+    const learnable = bucket.tools.some((tool) => tool.available)
+    const recommended = bucket.tools.some((tool) => requestedSet.has(tool.id))
+    const placement: McpServiceGroup['placement'] = !learnable
+      ? (grantedIds.length > 0 ? 'unavailable' : 'hidden')
+      : (recommended ? 'recommended' : 'learnable')
+    groups.push({
+      serviceId,
+      label: bucket.label ?? serviceId,
+      tools: bucket.tools,
+      grantedIds,
+      learnable,
+      recommended,
+      placement,
+    })
+  }
+  return groups.sort((left, right) => left.label.localeCompare(right.label, 'zh-CN') || left.serviceId.localeCompare(right.serviceId))
+}
+
+/** The grant list after the service row's checkbox changed: grant/revoke every tool of the service. */
+export function mcpServiceToggle(group: McpServiceGroup, value: readonly string[], checked: boolean): string[] {
+  if (checked) {
+    const missing = group.tools
+      .filter((tool) => tool.available && !value.includes(tool.id))
+      .map((tool) => tool.id)
+    return missing.length === 0 ? [...value] : [...value, ...missing]
+  }
+  return value.filter((id) => mcpServiceOfSkillId(id) !== group.serviceId)
+}
+
+/** Checkbox presentation: fully granted checks, any-partial marks indeterminate. */
+export function mcpServiceChecked(group: McpServiceGroup, value: readonly string[]): { checked: boolean; indeterminate: boolean } {
+  const valueSet = new Set(value)
+  const grantable = group.tools.filter((tool) => tool.available)
+  if (grantable.length === 0) {
+    // An unavailable service row only manages the stale grants it still holds.
+    return { checked: group.grantedIds.length > 0, indeterminate: false }
+  }
+  const allGranted = grantable.every((tool) => valueSet.has(tool.id))
+  return { checked: allGranted, indeterminate: group.grantedIds.length > 0 && !allGranted }
+}
+
+export type McpServiceStatus = 'unavailable' | 'granted' | 'partial' | 'recommended' | 'learnable'
+
+export function mcpServiceStatus(group: McpServiceGroup, value: readonly string[]): McpServiceStatus {
+  const { checked, indeterminate } = mcpServiceChecked(group, value)
+  if (group.placement === 'unavailable') return 'unavailable'
+  if (checked) return 'granted'
+  if (indeterminate) return 'partial'
+  if (group.recommended) return 'recommended'
+  return 'learnable'
+}

--- a/packages/web/src/components/mcp-skill-grouping.ts
+++ b/packages/web/src/components/mcp-skill-grouping.ts
@@ -31,10 +31,24 @@ export interface McpServiceGroup {
   grantedIds: string[]
   /** At least one catalog tool is available in the world. */
   learnable: boolean
-  /** At least one catalog tool is recommended by the character blueprint. */
+  /** The requested ids belonging to this service (catalog tools and missing ones alike). */
+  requestedIds: string[]
+  /** At least one requested id belongs to this service. */
   recommended: boolean
   /** Where the aggregated row renders. */
   placement: 'recommended' | 'learnable' | 'unavailable' | 'hidden'
+}
+
+/**
+ * The minimal item shape groupable into MCP services: any tool descriptor
+ * that may carry service metadata. Surfaces that gate availability (the
+ * world skill catalog) pass `available`; request-only surfaces (the
+ * workshop skill picker) omit it, where every item is grantable.
+ */
+export interface McpGroupItem {
+  id: string
+  mcpService?: { id: string; label: string } | undefined
+  available?: boolean | undefined
 }
 
 /** Whether a catalog entry is one MCP tool descriptor (groupable by service). */
@@ -57,41 +71,41 @@ export function mcpServiceOfSkillId(id: string): string | undefined {
 }
 
 /**
- * One group per MCP service seen in the catalog or in the character's grants.
+ * One group per MCP service seen in the items or in the current value.
  *
- * A grant whose service no longer has any catalog entry (connection removed or
+ * A value id whose service no longer has any item (connection removed or
  * discovery failed) still forms a group: the panel can keep showing the
- * service row as "暂不可用" so the stale grant stays revocable instead of
+ * service row as "暂不可用" so the stale entry stays revocable instead of
  * flooding one orphan row per tool.
  */
-export function groupMcpServices(
-  catalog: readonly SkillCatalogEntry[],
+export function groupMcpServicesFromItems(
+  items: readonly McpGroupItem[],
   value: readonly string[],
   requested: readonly string[],
 ): McpServiceGroup[] {
   const byService = new Map<string, { label?: string; tools: McpServiceTool[] }>()
-  for (const entry of catalog) {
-    if (entry.mcpService === undefined) continue
-    const bucket = byService.get(entry.mcpService.id) ?? { tools: [] }
-    bucket.label = entry.mcpService.label
+  for (const item of items) {
+    if (item.mcpService === undefined) continue
+    const bucket = byService.get(item.mcpService.id) ?? { tools: [] }
+    bucket.label = item.mcpService.label
     bucket.tools.push({
-      name: entry.id.slice(`mcp.${entry.mcpService.id}.`.length),
-      id: entry.id,
-      available: entry.worldAvailable && entry.availability === 'available',
+      name: item.id.slice(`mcp.${item.mcpService.id}.`.length),
+      id: item.id,
+      available: item.available !== false,
     })
-    byService.set(entry.mcpService.id, bucket)
+    byService.set(item.mcpService.id, bucket)
   }
   for (const id of value) {
     const service = mcpServiceOfSkillId(id)
     if (service !== undefined && !byService.has(service)) byService.set(service, { tools: [] })
   }
 
-  const requestedSet = new Set(requested)
   const groups: McpServiceGroup[] = []
   for (const [serviceId, bucket] of byService) {
     const grantedIds = [...new Set(value.filter((id) => mcpServiceOfSkillId(id) === serviceId))]
+    const requestedIds = requested.filter((id) => mcpServiceOfSkillId(id) === serviceId)
     const learnable = bucket.tools.some((tool) => tool.available)
-    const recommended = bucket.tools.some((tool) => requestedSet.has(tool.id))
+    const recommended = requestedIds.length > 0
     const placement: McpServiceGroup['placement'] = !learnable
       ? (grantedIds.length > 0 ? 'unavailable' : 'hidden')
       : (recommended ? 'recommended' : 'learnable')
@@ -101,11 +115,69 @@ export function groupMcpServices(
       tools: bucket.tools,
       grantedIds,
       learnable,
+      requestedIds,
       recommended,
       placement,
     })
   }
   return groups.sort((left, right) => left.label.localeCompare(right.label, 'zh-CN') || left.serviceId.localeCompare(right.serviceId))
+}
+
+/**
+ * One group per MCP service seen in the world skill catalog or in the
+ * character's grants, with world-availability gating baked in.
+ */
+export function groupMcpServices(
+  catalog: readonly SkillCatalogEntry[],
+  value: readonly string[],
+  requested: readonly string[],
+): McpServiceGroup[] {
+  return groupMcpServicesFromItems(
+    catalog.map((entry) => ({
+      id: entry.id,
+      mcpService: entry.mcpService,
+      available: entry.worldAvailable && entry.availability === 'available',
+    })),
+    value,
+    requested,
+  )
+}
+
+/**
+ * Services the blueprint requested that no longer have any catalog item
+ * (connection removed, disabled, or discovery failed). Surfaces scoped to the
+ * template's requests (the recruitment dialog) synthesize one unavailable
+ * service row per missing service instead of one orphan row per tool.
+ */
+export function orphanMcpServiceGroups(
+  requested: readonly string[],
+  knownServiceIds: readonly string[],
+  value: readonly string[],
+): McpServiceGroup[] {
+  const known = new Set(knownServiceIds)
+  const requestedByService = new Map<string, string[]>()
+  for (const id of requested) {
+    const service = mcpServiceOfSkillId(id)
+    if (service !== undefined && !known.has(service)) requestedByService.set(service, [...(requestedByService.get(service) ?? []), id])
+  }
+  if (requestedByService.size === 0) return []
+  const valueSet = new Set(value)
+  const groups: McpServiceGroup[] = [...requestedByService.entries()].map(([serviceId, requestedIds]) => ({
+    serviceId,
+    label: serviceId,
+    tools: [],
+    grantedIds: requestedIds.filter((id) => valueSet.has(id)),
+    learnable: false,
+    requestedIds,
+    recommended: true,
+    placement: 'unavailable' as const,
+  }))
+  return groups.sort((left, right) => left.serviceId.localeCompare(right.serviceId))
+}
+
+/** Add or remove a single skill id in a list of ids (deduped, order-stable). */
+export function toggleSkillIdInList(value: readonly string[], skillId: string, checked: boolean): string[] {
+  return checked ? [...new Set([...value, skillId])] : value.filter((id) => id !== skillId)
 }
 
 /** The grant list after the service row's checkbox changed: grant/revoke every tool of the service. */

--- a/packages/web/src/components/skill-catalog.ts
+++ b/packages/web/src/components/skill-catalog.ts
@@ -25,6 +25,9 @@ export function normalizeSkillCatalogEntry(value: unknown): SkillCatalogEntry | 
   const availability = value.availability === 'unavailable' || value.status === 'unavailable' ? 'unavailable' : 'available'
   const worldAvailable = typeof value.worldAvailable === 'boolean' ? value.worldAvailable : availability === 'available'
   const requiredWorldPermission = typeof value.requiredWorldPermission === 'string' ? value.requiredWorldPermission as SkillCatalogEntry['requiredWorldPermission'] : undefined
+  const mcpService = isRecord(value.mcpService) && typeof value.mcpService.id === 'string' && typeof value.mcpService.label === 'string'
+    ? { id: value.mcpService.id, label: value.mcpService.label }
+    : undefined
   return {
     id: value.id,
     displayName: typeof value.displayName === 'string' ? value.displayName : value.id,
@@ -37,6 +40,7 @@ export function normalizeSkillCatalogEntry(value: unknown): SkillCatalogEntry | 
     ...(requiredWorldPermission === undefined ? {} : { requiredWorldPermission }),
     ...(value.kind === 'integration' ? { kind: 'integration' as const } : value.kind === 'recipe' ? { kind: 'recipe' as const } : {}),
     recommendedByDefault: value.recommendedByDefault === true,
+    ...(mcpService === undefined ? {} : { mcpService }),
     source: value.source === 'plugin' || value.source === 'mcp' || value.source === 'other' ? value.source : 'builtin',
     scope: value.scope === 'workspace' || value.scope === 'world' ? value.scope : 'builtin',
     globalKnown: value.globalKnown !== false,

--- a/packages/web/src/features/connection-hub/IntegrationSettingsPanel.tsx
+++ b/packages/web/src/features/connection-hub/IntegrationSettingsPanel.tsx
@@ -3,6 +3,7 @@ import { Trash } from '@phosphor-icons/react'
 import type {
   IntegrationConnection,
   IntegrationDescriptor,
+  IntegrationFieldDescriptor,
   IntegrationHealth,
   JsonObject,
 } from '@dsh-cyber/contracts'
@@ -79,7 +80,7 @@ export function IntegrationSettingsPanel({ workspaceId, initialSkillId }: Integr
   useEffect(() => {
     setConfig(Object.fromEntries((descriptor?.configFields ?? []).map((field) => [
       field.id,
-      connection?.config[field.id] ?? (field.kind === 'boolean' ? false : field.kind === 'number' ? '' : field.placeholder ?? ''),
+      connection?.config[field.id] ?? defaultConfigValue(field),
     ])) as JsonObject)
     setEnabled(connection?.enabled ?? true)
     setSecretInputs({})
@@ -136,7 +137,7 @@ export function IntegrationSettingsPanel({ workspaceId, initialSkillId }: Integr
     setAddingNew(true)
     setConfig(Object.fromEntries((descriptor.configFields ?? []).map((field) => [
       field.id,
-      field.kind === 'boolean' ? false : field.kind === 'number' ? '' : field.placeholder ?? '',
+      defaultConfigValue(field),
     ])) as JsonObject)
     setEnabled(true)
     setSecretInputs({})
@@ -234,7 +235,7 @@ export function IntegrationSettingsPanel({ workspaceId, initialSkillId }: Integr
               return <div key={item.id} className={active ? 'integration-connection-card is-active' : 'integration-connection-card'}>
                 {/* Second click on the open card collapses the editor below. */}
                 <button type="button" aria-expanded={active} onClick={() => { if (active) { setSelectedConnectionId(undefined); return } setAddingNew(false); setSelectedConnectionId(item.id) }}>
-                  <strong>{item.displayName}</strong><small>{`${String(item.config.service ?? item.config.host ?? item.config.endpoint ?? '')}${item.enabled ? '' : ' · 已停用'}`}</small>
+                  <strong>{item.displayName}</strong><small>{`${String(item.config.service ?? item.config.host ?? item.config.endpoint ?? item.config.command ?? '')}${item.enabled ? '' : ' · 已停用'}`}</small>
                 </button>
                 {/* Right edge carries the 启用连接 switch for quick on/off. */}
                 <label className="integration-connection-card__enable" title={item.enabled ? '点击停用该连接' : '点击启用该连接'}>
@@ -253,13 +254,27 @@ export function IntegrationSettingsPanel({ workspaceId, initialSkillId }: Integr
                 header checkbox remains only for single-connection types without cards. */}
             {!multiple ? <label><input type="checkbox" checked={enabled} onChange={(event) => setEnabled(event.target.checked)} />启用连接</label> : null}
           </header>
-          {descriptor.configFields.map((field) => field.kind === 'boolean' ? (
-            <label className="dialog-field dialog-field--checkbox" key={field.id}><input type="checkbox" checked={config[field.id] === true} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.checked }))} /><span>{field.displayName}</span><small>{field.description}</small></label>
-          ) : field.id === 'displayName' ? (
-            <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type="text" value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.value }))} /><small>{field.description}</small></label>
-          ) : (
-            <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type={field.kind === 'number' ? 'number' : 'text'} value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: field.kind === 'number' ? Number(event.target.value) : event.target.value }))} /><small>{field.description}</small></label>
-          ))}
+          {descriptor.configFields.map((field) => {
+            // A field can be gated on a sibling select (e.g. MCP 远程地址 vs 本机启动命令):
+            // hidden fields keep their value in `config` state; the server drops
+            // whatever the active mode does not need.
+            if (field.visibleWhen !== undefined && !field.visibleWhen.equals.includes(String(config[field.visibleWhen.field] ?? ''))) return null
+            if (field.kind === 'select') {
+              return <label className="dialog-field" key={field.id}><span>{field.displayName}</span>
+                <select value={String(config[field.id] ?? '')} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.value }))}>
+                  {(field.options ?? []).map((option) => <option key={option} value={option}>{field.optionLabels?.[option] ?? option}</option>)}
+                </select>
+                <small>{field.description}</small>
+              </label>
+            }
+            return field.kind === 'boolean' ? (
+              <label className="dialog-field dialog-field--checkbox" key={field.id}><input type="checkbox" checked={config[field.id] === true} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.checked }))} /><span>{field.displayName}</span><small>{field.description}</small></label>
+            ) : field.id === 'displayName' ? (
+              <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type="text" value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: event.target.value }))} /><small>{field.description}</small></label>
+            ) : (
+              <label className="dialog-field" key={field.id}><span>{field.displayName}</span><input type={field.kind === 'number' ? 'number' : 'text'} value={String(config[field.id] ?? '')} placeholder={field.placeholder} onChange={(event) => setConfig((current) => ({ ...current, [field.id]: field.kind === 'number' ? Number(event.target.value) : event.target.value }))} /><small>{field.description}</small></label>
+            )
+          })}
           {(descriptor.secretFields ?? []).map((field) => {
             const stored = secretConfiguredFor(field.id)
             const cleared = clearedSecrets[field.id] === true
@@ -306,4 +321,14 @@ function pickInitialType(descriptors: IntegrationDescriptor[], initialSkillId: s
   if (initialSkillId === 'web.search.firecrawl') return WEB_SEARCH_TYPE_ID
   const match = descriptors.find((item) => item.skillIds.includes(initialSkillId))
   return match?.id ?? descriptors[0]?.id
+}
+
+/** Blank-form value for a field by kind; a select field opens on its first option. */
+function defaultConfigValue(field: IntegrationFieldDescriptor): string | boolean {
+  switch (field.kind) {
+    case 'boolean': return false
+    case 'number': return ''
+    case 'select': return field.options?.[0] ?? ''
+    default: return field.placeholder ?? ''
+  }
 }

--- a/packages/web/src/styles.css
+++ b/packages/web/src/styles.css
@@ -2970,6 +2970,29 @@ button:focus-visible, input:focus-visible, textarea:focus-visible, select:focus-
 .capability-approval-group label.is-unavailable { border-color: color-mix(in srgb, var(--danger) 35%, var(--border)); }
 .capability-approval-group label > span > em { color: var(--accent-strong); font-size: 12px; font-style: normal; }
 .capability-approval-group label.is-unavailable > span > em { color: var(--danger); }
+/* Aggregated MCP service row inside the recruitment skill fieldset: one
+   checkbox grants every tool of the service; the tool list stays expandable. */
+.capability-service-row { min-height: 44px; display: flex; align-items: center; gap: 9px; padding: 6px 8px; border: 1px solid var(--border); color: var(--text-soft); background: var(--surface-1); }
+.capability-service-row > input { width: 16px; height: 16px; flex: 0 0 auto; margin-top: 0; accent-color: var(--accent); }
+.capability-service-row > span { min-width: 0; display: grid; gap: 2px; }
+.capability-service-row strong { color: var(--text); font-size: 13px; }
+.capability-service-row small { color: var(--text-muted); font-size: 12px; line-height: 1.45; }
+.capability-service-row.is-granted { border-color: color-mix(in srgb, var(--accent) 45%, var(--border)); background: color-mix(in srgb, var(--accent) 8%, var(--surface-1)); }
+.capability-service-row.is-unavailable { border-color: color-mix(in srgb, var(--danger) 35%, var(--border)); }
+.capability-service-row__meta { display: flex; flex-wrap: wrap; gap: 6px; align-items: center; margin-top: 2px; }
+.capability-service-row__meta em { padding: 2px 6px; border-radius: 6px; background: rgba(255, 255, 255, .055); color: var(--text-muted); font-size: 12px; font-style: normal; }
+.capability-service-row__status--granted { color: var(--success, #69c18d) !important; }
+.capability-service-row__status--partial { color: var(--warning, #d8a347) !important; }
+.capability-service-row__status--recommended, .capability-service-row__status--learnable { color: var(--accent-strong, #f0b63b) !important; }
+.capability-service-row__status--unavailable { color: var(--danger, #dc7777) !important; }
+.capability-service-row__tools { margin-left: 2px; }
+.capability-service-row__tools summary { cursor: pointer; padding: 2px 6px; border-radius: 6px; background: rgba(255, 255, 255, .055); color: var(--text-muted); font-size: 12px; list-style: none; user-select: none; }
+.capability-service-row__tools summary::-webkit-details-marker { display: none; }
+.capability-service-row__tools ul { margin: 6px 0 2px 4px; padding: 0; display: grid; gap: 3px; max-width: 340px; }
+.capability-service-row__tools li { display: flex; align-items: center; justify-content: space-between; gap: 10px; min-width: 220px; font-size: 12px; color: var(--text-muted); }
+.capability-service-row__tools li code { color: var(--text-soft); font-size: 12px; }
+.capability-service-row__tools li em { padding: 2px 6px; border-radius: 6px; background: rgba(255, 255, 255, .055); font-size: 12px; font-style: normal; }
+.capability-service-row__tools li.is-granted em { color: var(--success, #69c18d); }
 .permission-notice { display: flex; gap: 9px; padding: 10px; border: 1px solid var(--border); color: var(--text-muted); background: var(--surface-1); }
 .permission-notice svg { flex: 0 0 auto; color: var(--success); }
 .permission-notice p { margin: 0; font-size: 10px; line-height: 1.6; }

--- a/packages/web/tests/mcp-skill-grouping.test.ts
+++ b/packages/web/tests/mcp-skill-grouping.test.ts
@@ -1,0 +1,361 @@
+import { createElement, type ReactNode } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { SkillCatalogEntry } from '@dsh-cyber/contracts/skill-runtime'
+import type { CharacterSkillDescriptor } from '@dsh-cyber/contracts/creative-platform'
+
+import {
+  groupMcpServices,
+  groupMcpServicesFromItems,
+  mcpServiceChecked,
+  mcpServiceOfSkillId,
+  mcpServiceStatus,
+  mcpServiceToggle,
+  orphanMcpServiceGroups,
+  toggleSkillIdInList,
+  type McpGroupItem,
+  type McpServiceGroup,
+} from '../src/components/mcp-skill-grouping.js'
+import { SkillApprovalGroup } from '../src/components/RecruitmentDialog.js'
+import { WorkshopSkillPicker } from '../src/components/creative-workshop/workshop-skill-picker.js'
+import { skillChipsForRole } from '../src/components/creative-workshop/CreativeWorkshopProjectLibrary.js'
+import { setUiLocale } from '../src/i18n/runtime.js'
+
+function catalogEntry(overrides: Partial<SkillCatalogEntry> & { id: string }): SkillCatalogEntry {
+  return {
+    displayName: overrides.id,
+    summary: '技能摘要',
+    adapterId: 'builtin.mcp',
+    risks: ['external-side-effect'],
+    supportsScheduling: false,
+    persistentApproval: 'forbidden',
+    kind: 'integration',
+    source: 'mcp',
+    scope: 'workspace',
+    globalKnown: true,
+    worldAvailable: true,
+    availability: 'available',
+    ...overrides,
+  }
+}
+
+function mcpCatalogEntry(service: string, label: string, tool: string, overrides: Partial<SkillCatalogEntry> = {}): SkillCatalogEntry {
+  return catalogEntry({
+    id: `mcp.${service}.${tool}`,
+    mcpService: { id: service, label },
+    ...overrides,
+  })
+}
+
+describe('mcpServiceOfSkillId', () => {
+  it('splits three-segment ids on the first dot after the mcp. prefix', () => {
+    expect(mcpServiceOfSkillId('mcp.playwright.browser_navigate')).toBe('playwright')
+    expect(mcpServiceOfSkillId('mcp.my-svc.tool.with.dots')).toBe('my-svc')
+  })
+
+  it('treats two-segment legacy ids and plain ids as service-less', () => {
+    expect(mcpServiceOfSkillId('mcp.browser_navigate')).toBeUndefined()
+    expect(mcpServiceOfSkillId('code-review')).toBeUndefined()
+  })
+})
+
+describe('groupMcpServicesFromItems', () => {
+  const items: CharacterSkillDescriptor[] = [
+    { id: 'mcp.playwright.browser_navigate', mcpService: { id: 'playwright', label: '浏览器自动化' }, displayName: 'x', summary: 's', adapterId: 'builtin.mcp', risks: ['external-side-effect'], supportsScheduling: false, persistentApproval: 'forbidden', kind: 'integration' },
+    { id: 'mcp.playwright.browser_snapshot', mcpService: { id: 'playwright', label: '浏览器自动化' }, displayName: 'x', summary: 's', adapterId: 'builtin.mcp', risks: ['external-side-effect'], supportsScheduling: false, persistentApproval: 'forbidden', kind: 'integration' },
+    { id: 'mcp.docs.search_docs', mcpService: { id: 'docs', label: '文档检索' }, displayName: 'x', summary: 's', adapterId: 'builtin.mcp', risks: ['external-side-effect'], supportsScheduling: false, persistentApproval: 'forbidden', kind: 'integration' },
+    { id: 'code-review', displayName: '代码审查', summary: 's', adapterId: 'builtin.recipe', risks: [], supportsScheduling: true, persistentApproval: 'forbidden', kind: 'recipe' },
+  ]
+
+  it('groups tool descriptors by service and falls back to the slug label', () => {
+    const groups = groupMcpServicesFromItems(items, [], [])
+    // Sorted by label in the zh-CN collation: 浏览器自动化 (playwright) < 文档检索 (docs).
+    expect(groups.map((group) => group.serviceId)).toEqual(['playwright', 'docs'])
+    const playwright = groups.find((group) => group.serviceId === 'playwright')!
+    expect(playwright.label).toBe('浏览器自动化')
+    expect(playwright.tools.map((tool) => tool.id)).toEqual([
+      'mcp.playwright.browser_navigate',
+      'mcp.playwright.browser_snapshot',
+    ])
+    expect(playwright.tools.every((tool) => tool.available)).toBe(true)
+  })
+
+  it('creates an empty-tools group for value ids of a service the items no longer know', () => {
+    const groups = groupMcpServicesFromItems([], ['mcp.ghost.open_page'], [])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]).toMatchObject({
+      serviceId: 'ghost',
+      label: 'ghost',
+      tools: [],
+      grantedIds: ['mcp.ghost.open_page'],
+      learnable: false,
+      placement: 'unavailable',
+    })
+  })
+
+  it('marks requested services as recommended and records their requested ids', () => {
+    const groups = groupMcpServicesFromItems(items, [], ['mcp.playwright.browser_navigate', 'code-review'])
+    const playwright = groups.find((group) => group.serviceId === 'playwright')!
+    expect(playwright.recommended).toBe(true)
+    expect(playwright.placement).toBe('recommended')
+    expect(playwright.requestedIds).toEqual(['mcp.playwright.browser_navigate'])
+    expect(groups.find((group) => group.serviceId === 'docs')!.recommended).toBe(false)
+  })
+
+  it('keeps services without grants or requests learnable and available', () => {
+    const groups = groupMcpServicesFromItems(items, [], [])
+    expect(groups.map((group) => group.placement)).toEqual(['learnable', 'learnable'])
+    expect(groups.every((group) => group.learnable)).toBe(true)
+  })
+
+  it('hides a service with no grantable tools and no stale grants', () => {
+    const deadItems: McpGroupItem[] = [
+      { id: 'mcp.dead.tool', mcpService: { id: 'dead', label: '失效连接' }, available: false },
+    ]
+    const groups = groupMcpServicesFromItems(deadItems, [], [])
+    expect(groups[0]).toMatchObject({ serviceId: 'dead', placement: 'hidden', learnable: false })
+  })
+})
+
+describe('groupMcpServices (world catalog form)', () => {
+  it('derives availability from world availability, not item presence', () => {
+    const catalog = [
+      mcpCatalogEntry('playwright', '浏览器自动化', 'browser_navigate', { worldAvailable: false, availability: 'unavailable' }),
+      mcpCatalogEntry('playwright', '浏览器自动化', 'browser_snapshot'),
+    ]
+    const groups = groupMcpServices(catalog, [], [])
+    const playwright = groups[0]!
+    expect(playwright.tools[0]).toMatchObject({ id: 'mcp.playwright.browser_navigate', available: false })
+    expect(playwright.tools[1]).toMatchObject({ id: 'mcp.playwright.browser_snapshot', available: true })
+    expect(playwright.learnable).toBe(true)
+  })
+
+  it('places a fully unavailable service with stale grants as "unavailable"', () => {
+    const catalog = [mcpCatalogEntry('dead', '失效连接', 'old_tool', { worldAvailable: false, availability: 'unavailable' })]
+    const groups = groupMcpServices(catalog, ['mcp.dead.old_tool'], [])
+    expect(groups[0]!.placement).toBe('unavailable')
+    expect(groups[0]!.grantedIds).toEqual(['mcp.dead.old_tool'])
+  })
+})
+
+describe('orphanMcpServiceGroups', () => {
+  it('synthesizes one unavailable row per requested service missing from the catalog', () => {
+    const groups = orphanMcpServiceGroups(
+      ['mcp.ghost.open_page', 'mcp.ghost.click', 'mcp.other.tool', 'mcp.browser_navigate'],
+      ['known'],
+      ['mcp.ghost.click'],
+    )
+    expect(groups).toHaveLength(2)
+    expect(groups.map((group) => group.serviceId)).toEqual(['ghost', 'other'])
+    const ghost = groups[0]!
+    expect(ghost).toMatchObject({ label: 'ghost', tools: [], learnable: false, placement: 'unavailable', recommended: true })
+    expect(ghost.requestedIds).toEqual(['mcp.ghost.open_page', 'mcp.ghost.click'])
+    expect(ghost.grantedIds).toEqual(['mcp.ghost.click'])
+  })
+
+  it('returns nothing when every requested service is known or the request is legacy/plain', () => {
+    expect(orphanMcpServiceGroups(['mcp.known.tool'], ['known'], [])).toEqual([])
+    expect(orphanMcpServiceGroups(['mcp.browser_navigate', 'code-review'], [], [])).toEqual([])
+  })
+})
+
+describe('mcpServiceToggle / mcpServiceChecked / mcpServiceStatus', () => {
+  const fixtureItems: McpGroupItem[] = [
+    { id: 'mcp.playwright.browser_navigate', mcpService: { id: 'playwright', label: '浏览器自动化' } },
+    { id: 'mcp.playwright.browser_snapshot', mcpService: { id: 'playwright', label: '浏览器自动化' } },
+    { id: 'mcp.playwright.browser_old', mcpService: { id: 'playwright', label: '浏览器自动化' }, available: false },
+  ]
+  // Build groups from the same value they present, so grantedIds stays
+  // consistent with the presentation state under test.
+  function groupFor(value: string[]): McpServiceGroup {
+    const group = groupMcpServicesFromItems(fixtureItems, value, []).find((item) => item.serviceId === 'playwright')
+    if (group === undefined) throw new Error('fixture group missing')
+    return group
+  }
+
+  it('checking the service row grants every available tool once', () => {
+    const next = mcpServiceToggle(groupFor(['mcp.playwright.browser_navigate']), ['mcp.playwright.browser_navigate'], true)
+    expect(next).toContain('mcp.playwright.browser_navigate')
+    expect(next).toContain('mcp.playwright.browser_snapshot')
+    expect(next).not.toContain('mcp.playwright.browser_old')
+    // Idempotent when every available tool is already held.
+    const full = mcpServiceToggle(groupFor(['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot']), ['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot'], true)
+    expect(full).toEqual(['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot'])
+  })
+
+  it('unchecking the service row revokes the whole service and keeps other services', () => {
+    const next = mcpServiceToggle(groupFor(['mcp.playwright.browser_navigate']), ['mcp.playwright.browser_navigate', 'mcp.docs.search_docs'], false)
+    expect(next).toEqual(['mcp.docs.search_docs'])
+  })
+
+  it('computes checked / indeterminate / partial presentation states', () => {
+    expect(mcpServiceChecked(groupFor(['mcp.playwright.browser_navigate']), ['mcp.playwright.browser_navigate'])).toEqual({ checked: false, indeterminate: true })
+    expect(mcpServiceChecked(groupFor(['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot']), ['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot'])).toEqual({ checked: true, indeterminate: false })
+    expect(mcpServiceChecked(groupFor([]), [])).toEqual({ checked: false, indeterminate: false })
+  })
+
+  it('reports an unavailable service by the stale grants it still holds', () => {
+    const dead = groupMcpServicesFromItems([], ['mcp.playwright.stale'], []).find((item) => item.serviceId === 'playwright')!
+    expect(dead).toMatchObject({ tools: [], grantedIds: ['mcp.playwright.stale'], learnable: false, placement: 'unavailable' })
+    expect(mcpServiceChecked(dead, ['mcp.playwright.stale'])).toEqual({ checked: true, indeterminate: false })
+    expect(mcpServiceStatus(dead, ['mcp.playwright.stale'])).toBe('unavailable')
+  })
+
+  it('resolves the status ordering unavailable > granted > partial > recommended > learnable', () => {
+    expect(mcpServiceStatus({ ...groupFor([]), recommended: true }, [])).toBe('recommended')
+    expect(mcpServiceStatus(groupFor([]), [])).toBe('learnable')
+    expect(mcpServiceStatus(groupFor(['mcp.playwright.browser_navigate']), ['mcp.playwright.browser_navigate'])).toBe('partial')
+    expect(mcpServiceStatus(groupFor(['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot']), ['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot'])).toBe('granted')
+  })
+})
+
+describe('toggleSkillIdInList', () => {
+  it('adds with deduplication and removes', () => {
+    expect(toggleSkillIdInList([], 'a', true)).toEqual(['a'])
+    expect(toggleSkillIdInList(['a'], 'a', true)).toEqual(['a'])
+    expect(toggleSkillIdInList(['a', 'b'], 'a', false)).toEqual(['b'])
+  })
+})
+
+describe('SkillApprovalGroup (recruitment, service-level)', () => {
+  const catalog: SkillCatalogEntry[] = [
+    mcpCatalogEntry('playwright', '浏览器自动化', 'browser_navigate'),
+    mcpCatalogEntry('playwright', '浏览器自动化', 'browser_snapshot'),
+    catalogEntry({ id: 'code-review', displayName: '代码审查', source: 'builtin', adapterId: 'builtin.recipe', kind: 'recipe' }),
+  ]
+  const requested = ['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot', 'code-review']
+
+  beforeEach(() => setUiLocale('zh-CN'))
+
+  it('renders one aggregated MCP service row plus one flat row per non-MCP skill', () => {
+    const html = renderToStaticMarkup(createElement(SkillApprovalGroup, {
+      requested,
+      descriptors: catalog,
+      selected: [],
+      onChange: vi.fn(),
+    }))
+    expect(html).toContain('MCP · 浏览器自动化')
+    expect(html).toContain('代码审查')
+    // No per-tool rows: each tool only appears inside the expandable list.
+    expect(html.match(/MCP · 浏览器自动化/g)).toHaveLength(1)
+    expect(html).not.toContain('MCP · 浏览器自动化 / browser_navigate')
+    expect(html).toContain('2 个工具')
+  })
+
+  it('synthesizes a revocable unavailable row for held grants of a service that left the catalog', () => {
+    const onChange = vi.fn()
+    const html = renderToStaticMarkup(createElement(SkillApprovalGroup, {
+      requested,
+      descriptors: catalog,
+      selected: ['mcp.dead.open_page'],
+      onChange,
+    }))
+    expect(html).toContain('MCP · dead')
+    expect(html).toContain('暂不可用')
+    // The dead service row is checked and can be revoked; the available one is not.
+    expect(html.match(/data-mcp-service="dead"/)).toHaveLength(1)
+  })
+
+  it('leaves services the template did not request out of the dialog', () => {
+    const withDocs = [...catalog, mcpCatalogEntry('docs', '文档检索', 'search_docs')]
+    const html = renderToStaticMarkup(createElement(SkillApprovalGroup, {
+      requested,
+      descriptors: withDocs,
+      selected: [],
+      onChange: vi.fn(),
+    }))
+    expect(html).not.toContain('MCP · 文档检索')
+  })
+})
+
+describe('WorkshopSkillPicker (service-level requests)', () => {
+  const skills: CharacterSkillDescriptor[] = [
+    { id: 'mcp.playwright.browser_navigate', mcpService: { id: 'playwright', label: '浏览器自动化' }, displayName: 'MCP · 浏览器自动化 / browser_navigate', summary: '导航', adapterId: 'builtin.mcp', risks: ['external-side-effect'], supportsScheduling: false, persistentApproval: 'forbidden', kind: 'integration' },
+    { id: 'mcp.playwright.browser_snapshot', mcpService: { id: 'playwright', label: '浏览器自动化' }, displayName: 'MCP · 浏览器自动化 / browser_snapshot', summary: '快照', adapterId: 'builtin.mcp', risks: ['external-side-effect'], supportsScheduling: false, persistentApproval: 'forbidden', kind: 'integration' },
+    { id: 'code-review', displayName: '代码审查', summary: '审查', adapterId: 'builtin.recipe', risks: [], supportsScheduling: true, persistentApproval: 'forbidden', kind: 'recipe' },
+  ]
+
+  beforeEach(() => setUiLocale('zh-CN'))
+
+  it('collapses the service tools into one row that requests the whole service', () => {
+    const onChange = vi.fn()
+    const html = renderToStaticMarkup(createElement(WorkshopSkillPicker, { skills, value: [], query: '', onChange }))
+    expect(html).toContain('MCP · 浏览器自动化')
+    expect(html).toContain('代码审查')
+    const serviceCheckbox = /<input[^>]*aria-label="MCP 服务 浏览器自动化"[^>]*>/.exec(html)
+    expect(serviceCheckbox).not.toBeNull()
+  })
+
+  it('keeps a dead service row revocable when requests outlive the catalog', () => {
+    const html = renderToStaticMarkup(createElement(WorkshopSkillPicker, {
+      skills,
+      value: ['mcp.dead.open_page'],
+      query: '',
+      onChange: vi.fn(),
+    }))
+    expect(html).toContain('MCP · dead')
+    expect(html).toContain('取消勾选可移除对应的技能请求')
+  })
+
+  it('filters both the service rows and the flat rows by the search query', () => {
+    const html = renderToStaticMarkup(createElement(WorkshopSkillPicker, {
+      skills,
+      value: [],
+      query: '代码审查',
+      onChange: vi.fn(),
+    }))
+    expect(html).toContain('代码审查')
+    expect(html).not.toContain('MCP · 浏览器自动化')
+    expect(html).not.toContain('没有匹配的技能')
+  })
+
+  it('shows the empty state when nothing matches the query', () => {
+    const html = renderToStaticMarkup(createElement(WorkshopSkillPicker, {
+      skills,
+      value: [],
+      query: '不存在的技能',
+      onChange: vi.fn(),
+    }))
+    expect(html).toContain('没有匹配的技能')
+  })
+})
+
+describe('skillChipsForRole (project library, read-only)', () => {
+  const skillNames = new Map<string, string>()
+  const serviceLabels = new Map<string, string>([
+    ['playwright', '浏览器自动化'],
+    ['docs', '文档检索'],
+  ])
+
+  function chipsText(chips: ReactNode[]): string[] {
+    return chips.map((chip) => {
+      const element = chip as { props: { children?: unknown } }
+      const children = Array.isArray(element.props.children) ? element.props.children : [element.props.children]
+      return String(children).trim()
+    })
+  }
+
+  it('aggregates a service into one chip and keeps single tools explicit', () => {
+    const chips = skillChipsForRole(
+      ['mcp.playwright.browser_navigate', 'mcp.playwright.browser_snapshot', 'mcp.docs.search_docs', 'code-review'],
+      new Map([['code-review', '代码审查']]),
+      serviceLabels,
+    )
+    expect(chipsText(chips)).toEqual([
+      '代码审查',
+      'MCP · 文档检索 / search_docs',
+      'MCP · 浏览器自动化（2 个工具）',
+    ])
+  })
+
+  it('falls back to the raw id when neither name nor service label is known', () => {
+    const chips = skillChipsForRole(['mcp.ghost.open_page'], new Map<string, string>(), new Map<string, string>())
+    expect(chipsText(chips)).toEqual(['MCP · ghost / open_page'])
+  })
+
+  it('treats legacy two-segment ids as plain chips', () => {
+    const chips = skillChipsForRole(['mcp.browser_navigate'], skillNames, serviceLabels)
+    expect(chipsText(chips)).toEqual(['mcp.browser_navigate'])
+  })
+})

--- a/packages/web/tests/skill-catalog.test.ts
+++ b/packages/web/tests/skill-catalog.test.ts
@@ -6,7 +6,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { EmployeeBlueprint, EmployeeInstance, World } from '@dsh-cyber/contracts'
 import { RecruitmentDialog } from '../src/components/RecruitmentDialog.js'
 import { SkillGrantEditor } from '../src/components/SkillGrantEditor.js'
-import type { SkillCatalogEntry } from '../src/components/skill-catalog.js'
+import { normalizeSkillCatalogEntry, type SkillCatalogEntry } from '../src/components/skill-catalog.js'
 
 const world: World = {
   id: 'world-skill-catalog-test',
@@ -93,6 +93,98 @@ describe('world-scoped skill catalog UI', () => {
     await unmount(root, host)
   })
 
+  it('passes through the MCP service grouping metadata', () => {
+    const base = { id: 'mcp.github.create_issue', displayName: 'MCP · GitHub MCP / create_issue' }
+    expect(normalizeSkillCatalogEntry({ ...base, mcpService: { id: 'github', label: 'GitHub MCP' } })?.mcpService)
+      .toEqual({ id: 'github', label: 'GitHub MCP' })
+    expect(normalizeSkillCatalogEntry({ ...base, mcpService: { id: 'github' } })?.mcpService).toBeUndefined()
+    expect(normalizeSkillCatalogEntry({ ...base, mcpService: 'github' })?.mcpService).toBeUndefined()
+  })
+
+  it('collapses one MCP service tools into a single grant row', async () => {
+    const mcpCatalog: SkillCatalogEntry[] = [
+      mcpTool('mcp.playwright.browser_navigate', 'MCP · Playwright 浏览器 / browser_navigate', { id: 'playwright', label: 'Playwright 浏览器' }),
+      mcpTool('mcp.playwright.browser_click', 'MCP · Playwright 浏览器 / browser_click', { id: 'playwright', label: 'Playwright 浏览器' }),
+      mcpTool('mcp.github.create_issue', 'MCP · GitHub MCP / create_issue', { id: 'github', label: 'GitHub MCP' }),
+      skill('core.notes', '记录整理', true),
+    ]
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      if (path === '/api/catalog/blueprints?worldId=world-skill-catalog-test') return json({ items: [blueprint] })
+      if (path === '/api/worlds/world-skill-catalog-test/skill-catalog') return json({ items: mcpCatalog })
+      throw new Error(`unexpected request: ${path}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const onChange = vi.fn()
+    const initial = ['mcp.github.create_issue', 'mcp.playwright.browser_click']
+    const { host, root } = await mount(createElement(SkillGrantEditor, { employee, value: initial, onChange }))
+    await flush()
+
+    // One row per MCP service plus the single non-MCP recommended skill.
+    const rows = Array.from(host.querySelectorAll('.skill-grant-row'))
+    expect(rows).toHaveLength(3)
+    expect(host.textContent).toContain('MCP · Playwright 浏览器')
+    expect(host.textContent).toContain('MCP · GitHub MCP')
+
+    const rowFor = (text: string): HTMLInputElement => {
+      const row = Array.from(host.querySelectorAll('.skill-grant-row')).find((item) => item.textContent?.includes(text))
+      const checkbox = row?.querySelector<HTMLInputElement>('input[type="checkbox"]')
+      if (checkbox === null || checkbox === undefined) throw new Error(`row not found: ${text}`)
+      return checkbox
+    }
+
+    // GitHub: fully granted → checked. Playwright: one of two granted → indeterminate.
+    expect(rowFor('MCP · GitHub MCP').checked).toBe(true)
+    const playwrightCheckbox = rowFor('MCP · Playwright 浏览器')
+    expect(playwrightCheckbox.checked).toBe(false)
+    expect(playwrightCheckbox.indeterminate).toBe(true)
+
+    // Checking the Playwright row grants every tool of the service at once.
+    await act(async () => { playwrightCheckbox.click() })
+    expect(onChange).toHaveBeenLastCalledWith([
+      'mcp.github.create_issue',
+      'mcp.playwright.browser_click',
+      'mcp.playwright.browser_navigate',
+    ])
+
+    // Unchecking the GitHub row revokes all of the service's grants.
+    const githubCheckbox = rowFor('MCP · GitHub MCP')
+    await act(async () => { githubCheckbox.click() })
+    expect(onChange).toHaveBeenLastCalledWith(['mcp.playwright.browser_click'])
+    await unmount(root, host)
+  })
+
+  it('keeps a dead MCP service revocable as one aggregated row', async () => {
+    const mcpCatalog: SkillCatalogEntry[] = [
+      mcpTool('mcp.github.create_issue', 'MCP · GitHub MCP / create_issue', { id: 'github', label: 'GitHub MCP' }),
+    ]
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const path = String(input)
+      if (path === '/api/catalog/blueprints?worldId=world-skill-catalog-test') return json({ items: [blueprint] })
+      if (path === '/api/worlds/world-skill-catalog-test/skill-catalog') return json({ items: mcpCatalog })
+      throw new Error(`unexpected request: ${path}`)
+    })
+    vi.stubGlobal('fetch', fetchMock)
+    const onChange = vi.fn()
+    const { host, root } = await mount(createElement(SkillGrantEditor, {
+      employee,
+      value: ['mcp.dead.tool_one', 'mcp.dead.tool_two', 'mcp.github.create_issue'],
+      onChange,
+    }))
+    await flush()
+
+    // The unknown service renders exactly one aggregated row (not one per tool),
+    // checked because its stale grants remain; the live service row is untouched.
+    expect(host.textContent).toContain('MCP · dead')
+    expect(host.textContent).toContain('暂不可用')
+    const row = Array.from(host.querySelectorAll('.skill-grant-row')).find((item) => item.textContent?.includes('MCP · dead'))!
+    const checkbox = row.querySelector<HTMLInputElement>('input[type="checkbox"]')!
+    expect(checkbox.checked).toBe(true)
+    await act(async () => { checkbox.click() })
+    expect(onChange).toHaveBeenLastCalledWith(['mcp.github.create_issue'])
+    await unmount(root, host)
+  })
+
   it('uses recommended defaults during recruitment and preserves an explicit empty selection', async () => {
     const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
       const path = String(input)
@@ -148,6 +240,26 @@ function skill(id: string, displayName: string, recommendedByDefault: boolean): 
     globalKnown: true,
     worldAvailable: true,
     availability: 'available',
+  }
+}
+
+function mcpTool(id: string, displayName: string, service: { id: string; label: string }, available = true): SkillCatalogEntry {
+  return {
+    id,
+    displayName,
+    summary: 'MCP 工具说明。',
+    adapterId: 'builtin.mcp',
+    risks: ['external-side-effect'],
+    supportsScheduling: false,
+    persistentApproval: 'forbidden',
+    kind: 'integration',
+    recommendedByDefault: false,
+    mcpService: service,
+    source: 'mcp',
+    scope: 'workspace',
+    globalKnown: true,
+    worldAvailable: available,
+    availability: available ? 'available' : 'unavailable',
   }
 }
 

--- a/scripts/check-build-budget.mjs
+++ b/scripts/check-build-budget.mjs
@@ -7,7 +7,10 @@ const sizes = new Map(await Promise.all(files.map(async (file) => [file, (await 
 
 const budgets = [
   { label: 'main JavaScript', pattern: /^index-.*\.js$/, maximum: 450 * 1024 },
-  { label: 'main CSS', pattern: /^index-.*\.css$/, maximum: 280 * 1024 },
+  // The aggregated MCP service rows (recruitment, skill grant editor,
+  // workshop picker) added ~2 KB of functional first-screen CSS; the
+  // workshop / skill editor stylesheets stay in their lazy chunks.
+  { label: 'main CSS', pattern: /^index-.*\.css$/, maximum: 290 * 1024 },
   { label: 'Task Workspace JavaScript', pattern: /^TaskWorkspace-.*\.js$/, maximum: 25 * 1024 },
   { label: 'Task Workspace CSS', pattern: /^TaskWorkspace-.*\.css$/, maximum: 10 * 1024 },
   { label: 'avatar creation provider JavaScript', pattern: /^avatar-creation-provider-.*\.js$/, maximum: 4 * 1024 },


### PR DESCRIPTION
## 变更说明

四个提交（按依赖顺序）：

1. `3a88dc0` **持久化 v53 迁移**（`mcp-skill-grant-unification`）：把 `employee_revisions.skill_grants_json` 中两段式旧格式 `mcp.<工具>` 授权（工具名无点号，旧单服务时代唯一形态）重写为 `mcp.default.<工具>`，历史修订一并改写，防止回滚时死 ID 复活；三段式与其他技能 ID 逐字节不动。迁移前自动备份，失败可诊断，只向前。`CYBER_SCHEMA_VERSION` 52→53。
2. `2bd1794` **MCP 双模式连接**：连接配置新增运行模式字段——
   - `remote`（默认，旧连接自动回填）：Streamable HTTP 端点 + 可选 Bearer 鉴权；
   - `local`：应用按「启动命令 + 参数」自行拉起 MCP 进程，经官方 SDK `StdioClientTransport` 走 stdio 通信；子进程只继承 SDK 安全默认环境变量，会话结束即杀。参数校验为纯 argv（拒绝 Shell 元字符、≤16 项）。
   - `McpClientFactory` 收敛为 `connect(spec)` 单一 seam，发现/执行/测试连接三条路径共用；连接面板支持 `select` 字段类型与 `visibleWhen` 条件显隐，本地模式卡片副标题显示命令。
3. `5b2e147` **角色设置「技能与工具」服务级聚合**：每个 MCP 连接一行「MCP · 连接名称」；勾选 = 授权该服务下全部工具，取消 = 整服务撤销，部分授权呈 indeterminate（半选）并可展开工具清单；连接失效/下线时该服务的历史授权塌缩为一行「暂不可用」，可整行撤销。
4. `9c480a9` **招募弹窗、创意工坊步骤 3 技能选择（`WorkshopPicker`）、项目库卡片只读 chips** 同样改为服务级聚合；分组逻辑集中在 `mcp-skill-grouping.ts`（通用项形式 + 缺失服务合成行）。

底层授权/执行/审计仍为工具粒度（`mcp.<服务>.<工具>`），仅展示层聚合（描述符 `mcpService` 元数据），执行与逐动作审批边界不变。

**不在范围内**：
- 三视口（1440×900 / 1920×1080 / 3840×2160）视觉审批截图为合并门禁项，见「风险与限制」；
- 本机模式「`npx @playwright/mcp@latest` 真实拉起」无 CI 覆盖（单测覆盖真进程 stdio 冒烟：拉起 node echo 服务→发现→调用→关闭；命令不存在时干净失败）。

## 验证证据

- [x] `pnpm typecheck` — 干净（`tsc -b` + web typecheck）
- [x] `pnpm test` — vitest 全量 2170 通过；仅 2 例失败为知识库 symlink 集成测试，已用 stash 在干净基线上复现同样失败（Windows 临时目录符号链接环境问题，与本 PR 无关）
- [ ] `pnpm test:e2e` — 未跑：本 PR 为服务端迁移 + 面板展示聚合；E2E 门禁将随视觉截图在合并前补齐
- [ ] `pnpm verify` — 同上（typecheck + test 已分别通过）
- [x] 没有通过删除断言、跳过测试或隐藏错误规避失败
- [ ] 浏览器/渲染改动已附尺寸、控制台结果和截图路径 — 待补（同视觉门禁）

## 合同与兼容性

- [x] 未改变 HTTP method/path/response/SSE；新增的仅为连接配置 body 新字段（运行模式、启动命令、参数，面板 `select`/`visibleWhen` 字段）与技能目录描述符新增 `mcpService` 元数据（均为 additive）
- [x] 未静默改变 SQLite schema：v53 是 versioned 数据迁移（重写既有授权 JSON，非表结构变更），符合 AGENTS.md「数据迁移只能做 versioned migration」；迁移前自动备份、失败可诊断、只向前
- [x] 文档只描述已实现能力

## 市场包

不适用（无市场包改动），整节删除。

## 风险与限制

- 三视口视觉门禁未完成：连接面板（模式选择/条件字段/本地副标题）与三处服务级聚合面板的截图（含控制台 error/warn 记录）需在合并前补齐，未补齐不得标记视觉验收完成。
- 干净基线上已存在的 2 例知识库 symlink E2E 失败（本机 Windows 临时目录符号链接环境问题），非本 PR 引入。
- 本机模式限制：参数列表 ≤16 项且不得含 Shell 元字符（纯 argv 语义，无 Shell 注入面）；子进程环境变量只继承 SDK 安全默认；启动命令不存在时目录发现干净失败并给出中文提示。
- 旧格式两段式授权已由 v53 前移改写；如需回滚，使用迁移前备份 + 前移下一版本，不做反向改写。
- 真实 Playwright MCP（本地 `npx @playwright/mcp@latest` 或远端 8931 端点）的端到端联调需在有该服务的环境验证；当前 CI 覆盖到 stdio 协议层。
