### PR TITLE
chore(search): clarify Firecrawl provider description

### DIFF
--- a/catalog/web-search-providers.json
+++ b/catalog/web-search-providers.json
@@ -17,7 +17,7 @@
     {
       "id": "firecrawl",
       "name": "Firecrawl",
-      "description": "网页搜索与抓取服务。接管原「Firecrawl」连接：密钥只保存在本机加密凭据库，搜索由宿主进程执行，worker 不接触密钥。",
+      "description": "「Firecrawl」联网搜索：密钥只保存在本机加密凭据库，搜索由宿主进程执行，worker 不接触密钥。",
       "endpoint": "https://api.firecrawl.dev",
       "obtain": {
         "text": "前往 Firecrawl 控制台注册并创建 API Key",


### PR DESCRIPTION
收尾仓库遗留分支 `vlfiny-patch-1`。该分支相对已合入的 #211 只有一处 `catalog/web-search-providers.json` 文案调整：将 Firecrawl 描述明确为“联网搜索”，不改变 provider id、endpoint、backend、integrationId、凭据处理或运行时行为。合并后可删除该遗留分支。