### PR TITLE
chore(search): clarify Firecrawl provider description

### DIFF
--- a/catalog/web-search-providers.json
+++ b/catalog/web-search-providers.json
@@ -17,7 +17,7 @@
     {
       "id": "firecrawl",
       "name": "Firecrawl",
-      "description": "网页搜索与抓取服务。接管原「Firecrawl」连接：密钥只保存在本机加密凭据库，搜索由宿主进程执行，worker 不接触密钥。",
+      "description": "「Firecrawl」联网搜索：密钥只保存在本机加密凭据库，搜索由宿主进程执行，worker 不接触密钥。",
       "endpoint": "https://api.firecrawl.dev",
       "obtain": {
         "text": "前往 Firecrawl 控制台注册并创建 API Key",


### PR DESCRIPTION
从最新 `main` 重放 `vlfiny-patch-1` 唯一尚未合入的一行 Firecrawl 文案调整，避免旧分支落后主线导致分支保护拒绝合并。仅修改说明文字，不改变 provider 配置、凭据、运行时或 API。